### PR TITLE
Import Article file As TypeScript

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -7,7 +7,7 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import fetch from 'node-fetch';
 
-import Article from './dist/components/news/Article';
+import Article from './src/components/news/Article';
 
 import { getConfigValue } from './src/utils/ssmConfig';
 


### PR DESCRIPTION
## Why are you doing this?

The Article can be imported directly as a TypeScript file from the `server.ts` file, as TypeScript will compile it for us, and we aren't using Babel on the server at the moment.

FYI @alexduf 

## Changes

- Imported Article from `src` rather than `dist`.