### PR TITLE
have a max media query

### DIFF
--- a/src/components/shared/HeaderImage.tsx
+++ b/src/components/shared/HeaderImage.tsx
@@ -38,7 +38,9 @@ const HeaderImage = ({ assets }: HeaderImageProps) => {
             <picture>
                 {
                     assets.map(({ file, typeData }, index) => {
-                        return <source srcSet={file} media={`(max-width: ${typeData.width}px)`} key={index}/>
+                        return index + 1 === assets.length
+                            ? <source srcSet={file} media={`(max-width: ${typeData.width}px), (min-width: ${typeData.width}px)`} key={index}/>
+                            : <source srcSet={file} media={`(max-width: ${typeData.width}px)`} key={index}/>
                     })
                 }
                 <img src={file} alt={altText}/>


### PR DESCRIPTION
## Why are you doing this?
On a screen size greater than the max image size it defaults to the base image.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/65063063-5dd2ae00-d975-11e9-8cb9-67662104e8de.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/65063079-65925280-d975-11e9-9bdd-44594304f9b5.png" width="300px" /> |
