### PR TITLE
Bump TypeScript 3.5.3 -> 3.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6241,9 +6241,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "ts-node-dev": "^1.0.0-pre.40",
-    "typescript": "^3.5.3"
+    "typescript": "^3.6.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",


### PR DESCRIPTION
## Why are you doing this?

Keep TypeScript up-to-date.

*Thanks to @AWare*

## Changes

- TypeScript 3.5.3 -> 3.6.3
