### PR TITLE
Add fromTryCatch to Result

### DIFF
--- a/src/types/Result.ts
+++ b/src/types/Result.ts
@@ -55,7 +55,7 @@ class Err<E, B> implements ResultInterface<E, B> {
 
 type Result<E, A> = Ok<E, A> | Err<E, A>;
 
-function fromTryCatch<A, E>(f: () => A, error: E): Result<E, A> {
+function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
     try {
         return new Ok(f());
     } catch (_) {
@@ -70,5 +70,5 @@ export {
     Result,
     Ok,
     Err,
-    fromTryCatch,
+    fromUnsafe,
 };


### PR DESCRIPTION
## Why are you doing this?

Added a new function to generate `Result` types from a JS `try...catch`, as recommended by @davidfurey. This will be useful to reduce code duplication in #19.

### Alternative Implementation

Does anyone prefer this? An optional error argument, falling back to the default JS error?

```ts
function fromTryCatch<A, E>(f: () => A, error: Option<E>): Result<E, A> {
    try {
        return new Ok(f());
    } catch (fallbackError) {
        return new Err(error.withDefault(fallbackError));
    }
}
```

## Changes

- New `fromTryCatch` function for `Result`.