### PR TITLE
Remove old scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 - Working on node v10.16.3 (nvm use 10.16.3)
 - You will need `mobile` Janus credentials to run this project
 1. npm i
-2. npm run compileClient (watches for changes)
-3. npm run dev (compiles and runs server)
-4. http://localhost:3040
+2. npm run build:server (watches for changes)
+3. http://localhost:3040
 
 ### Architecture decisions
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
     "ios >= 11"
   ],
   "scripts": {
-    "dev": "ts-node-dev --respawn ./server.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
-    "compileClient": "./node_modules/.bin/babel ./src/ --extensions '.tsx','.ts' --watch --out-dir dist",
     "build:server": "webpack --config config/webpack.config.js --config-name server",
     "build:client": "webpack --config config/webpack.config.js --config-name client"
   },


### PR DESCRIPTION
## Why are you doing this?
These scripts have been replaced by `build:server` so remove them and update the readme.