### PR TITLE
Cleaner Imports With Webpack

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -1,3 +1,0 @@
-import Article from './src/components/news/Article';
-
-console.log(Article);

--- a/config/tsconfig.client.json
+++ b/config/tsconfig.client.json
@@ -5,6 +5,6 @@
         "target": "esnext"
     },
     "files": [
-        "../client.ts"
+        "../src/client.ts"
     ]
 }

--- a/config/tsconfig.server.json
+++ b/config/tsconfig.server.json
@@ -5,6 +5,6 @@
         "target": "es2018"
     },
     "files": [
-        "../server.ts"
+        "../src/server.ts"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
-    "build:server": "webpack --config config/webpack.config.js --config-name server",
-    "build:client": "webpack --config config/webpack.config.js --config-name client"
+    "build:server": "webpack --config webpack.config.js --config-name server",
+    "build:client": "webpack --config webpack.config.js --config-name client"
   },
   "author": "",
   "license": "ISC",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,3 @@
+import Article from 'components/news/Article';
+
+console.log(Article);

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,15 +6,15 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import fetch from 'node-fetch';
 
-import Article, { ArticleProps } from './src/components/news/Article';
-import LiveblogArticle from './src/components/liveblog/LiveblogArticle';
+import Article, { ArticleProps } from 'components/news/Article';
+import LiveblogArticle from 'components/liveblog/LiveblogArticle';
 
-import { getPillarStyles } from './src/styles';
+import { getPillarStyles } from 'styles';
 
-import { getConfigValue } from './src/utils/ssmConfig';
-import { isFeature, parseCapi } from './src/utils/capi';
-import { fromUnsafe, Result, Ok, Err } from './src/types/Result';
-import { Tag } from './src/types/Capi';
+import { getConfigValue } from 'utils/ssmConfig';
+import { isFeature, parseCapi } from 'utils/capi';
+import { fromUnsafe, Result, Ok, Err } from 'types/Result';
+import { Tag } from 'types/Capi';
 
 const app = express();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         // Allows discovery of node_modules packages
         "moduleResolution": "node",
         "noUnusedLocals": true,
-        "noUnusedParameters": true
+        "noUnusedParameters": true,
+        "baseUrl": "src"
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,11 @@
+// ----- Imports ----- //
+
 const { fork } = require('child_process');
 const webpack = require('webpack');
+const path = require('path');
+
+
+// ----- Plugins ----- //
 
 class LaunchServerPlugin {
     apply(compiler) {
@@ -17,10 +23,24 @@ class LaunchServerPlugin {
     }
 }
 
+
+// ----- Shared Config ----- //
+
+const resolve = {
+    extensions: ['.ts', '.tsx', '.js'],
+    modules: [
+        path.resolve(__dirname, 'src'),
+        'node_modules',
+    ],
+};
+
+
+// ----- Configs ----- //
+
 const serverConfig = {
     name: 'server',
     mode: 'development',
-    entry: './server.ts',
+    entry: 'server.ts',
     target: 'node',
     node: {
         __dirname: false,
@@ -28,9 +48,7 @@ const serverConfig = {
     output: {
         filename: 'server.js',
     },
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js'],
-    },
+    resolve,
     watch: true,
     watchOptions: {
         ignored: /node_modules/,
@@ -69,14 +87,12 @@ const serverConfig = {
 const clientConfig = {
     name: 'client',
     mode: 'development',
-    entry: './client.ts',
+    entry: 'client.ts',
     target: 'web',
     output: {
         filename: 'client.js',
     },
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js'],
-    },
+    resolve,
     module: {
         rules: [
             {


### PR DESCRIPTION
## Why are you doing this?

We would like to use absolute paths for imports.

## Changes

- Moved `server.ts` and `client.ts` to `src`
- Moved webpack config to root
- Updated tsconfig with new paths and resolution path
- Made `server.ts` and `client.ts` use absolute paths
