### PR TITLE
Separate Watch and Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
+    "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "build:server": "webpack --config webpack.config.js --config-name server",
     "build:client": "webpack --config webpack.config.js --config-name client"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,7 @@ const resolve = {
 
 // ----- Configs ----- //
 
-const serverConfig = {
+const serverConfig = env => ({
     name: 'server',
     mode: 'development',
     entry: 'server.ts',
@@ -49,17 +49,17 @@ const serverConfig = {
         filename: 'server.js',
     },
     resolve,
-    watch: true,
+    watch: env && env.watch,
     watchOptions: {
         ignored: /node_modules/,
     },
     plugins: [
         // Reloads the server on change.
-        new LaunchServerPlugin(),
+        (env && env.watch) ? new LaunchServerPlugin() : null,
         // Does not try to require the 'canvas' package,
         // an optional dependency of jsdom that we aren't using.
         new webpack.IgnorePlugin(/^canvas$/),
-    ],
+    ].filter(p => p !== null),
     module: {
         rules: [
             {
@@ -82,7 +82,7 @@ const serverConfig = {
             },
         ]
     }
-};
+});
 
 const clientConfig = {
     name: 'client',


### PR DESCRIPTION
## Why are you doing this?

We'd like to be able to build our server without launching webpack's watch mode or the node server that's used for local development. This will be useful for running builds in CI.

## Changes

- Created a new task specifically for watching in local development.
- Updated the webpack config to use a `watch` environment variable, which turns on watch mode.
