### PR TITLE
Add Compile Check To PR CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,4 @@
-name: Node CI - Lint
+name: Validate
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  build:
+  validate:
 
     runs-on: ubuntu-latest
 
@@ -20,7 +20,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install and lint
-      run: |
-        npm install
-        npm run lint
+    - name: install
+      run: npm install
+    - name: compile server
+      run: npm run build:server
+    - name: lint
+      run: npm run lint


### PR DESCRIPTION
## Why are you doing this?

To include a TypeScript compilation in the PR checks.

FYI @davidfurey @alexduf 

## Changes

- Updated workflow name to 'Validate'
- Added the `build:server` script to the list of steps
