### PR TITLE
Remove extra bracket

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -14,8 +14,7 @@ export const sidePadding = css`
     ${wide} {
         padding-left: 0;
         padding-right: 0;
-    }
-}`;
+    }`;
 
 export type PillarId = 'pillar/news'|'pillar/opinion'|'pillar/sport'|'pillar/arts'|'pillar/lifestyle';
 


### PR DESCRIPTION
## Why are you doing this?
Bracket causes following css to be unused.

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/67481171-69db1b00-f659-11e9-8607-3819159c9768.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/67481193-73648300-f659-11e9-95ab-9b05865edb5d.png" width="300px" /> |
