### PR TITLE
Only images should be full width

### DIFF
--- a/src/components/news/ArticleBody.tsx
+++ b/src/components/news/ArticleBody.tsx
@@ -21,7 +21,7 @@ const ArticleBodyStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
     }
 
     ${until.wide} {
-        figure {
+        figure:not(.interactive) {
             margin-left: ${basePx(-1)};
             margin-right: ${basePx(-1)};
         }


### PR DESCRIPTION
## Why are you doing this?
Things didn't look right after a resolved merge conflict. We want figure images to be full width but not interactives.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/67575841-52716000-f735-11e9-8778-e6b1ed29f278.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/67575870-5e5d2200-f735-11e9-8347-d349cadb2f05.png" width="300px" /> |
