### PR TITLE
Consolidate Option Types

### DIFF
--- a/src/utils/option.ts
+++ b/src/utils/option.ts
@@ -1,1 +1,0 @@
-export type Option<A> = A | null;


### PR DESCRIPTION
## Why are you doing this?

We currently have two implementations of `Option`, one in `utils/option` and one in `types/Option`. This PR consolidates on the latter.

## Changes

- Update `ssmConfig` to use new `Option` type.
- Removed `utils/option.ts`.
