### PR TITLE
Bump TypeScript To Version 3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8780,9 +8780,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
     },
     "uglify-js": {
       "version": "3.6.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node-fetch": "^2.6.0",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",


### PR DESCRIPTION
## Why are you doing this?

TypeScript 3.7 is out; the release notes are [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html).

FYI @SiAdcock @gtrufitt @jonathonherbert @RichieAHB @twrichards @AWare 

## Changes

- Bump TypeScript to 3.7.2.
