### PR TITLE
VSCode Problem Matcher Config

### DIFF
--- a/config/tsconfig.vscode.json
+++ b/config/tsconfig.vscode.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.server.json",
+    "compilerOptions": {
+        "noEmit": true
+    }
+}


### PR DESCRIPTION
## Why are you doing this?

I was struggling with the fact that, as far as I can tell, the VSCode TS language service only reports problems in files that you have open. This means that if you make a change in one file, and it breaks functionality in others that aren't open, the "Problems" view won't show these automatically.

This is probably not an issue if you're using a simple TS compilation with "watch", as VSCode can parse the output produced by that. However, because we're using `webpack` and `ts-loader`, I don't think VSCode is able to parse the output with its default [problem matchers](https://code.visualstudio.com/docs/editor/tasks).

My solution is to create a simple `tsconfig` that does everything the TS config for the server does, but doesn't emit anything to the file system (and doesn't use webpack). This can be used as a Task with the `tsc` problem matcher to populate the problem view.

I'm going to use this locally, but I thought I'd open a speculative PR to see if anyone else might find this useful. This may not be the best way of doing things (maybe EditorConfig could help here?), and I'd be keen to hear any suggestions.

FYI @davidfurey @SiAdcock @gtrufitt 

## Changes

- Added VSCode-specific config file.
