### PR TITLE
New ESLint Rules

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -18,7 +18,10 @@ module.exports =  {
         'max-len': [
             "error",
             { code: 100, ignoreStrings: true, ignoreTemplateLiterals: true },
-        ]
+        ],
+        '@typescript-eslint/explicit-function-return-type': 2,
+        'eqeqeq': 2,
+        'prefer-const': 2,
     },
     settings:  {
         react:  {


### PR DESCRIPTION
## Why are you doing this?

To allow the linter to do more work for us, as suggested by @RichieAHB in #79.

Astonishingly, adding these rules didn't cause any new linter errors. Either we're very tidy 🤔, or something isn't working...

## Changes

- [Require return types](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md) on functions
- [Require use of '===' and '!=='](https://eslint.org/docs/rules/eqeqeq) instead of '==' and '!='
- [Prefer 'const'](https://eslint.org/docs/rules/prefer-const) over 'let'
