### PR TITLE
Used Firefox Accessibility Inspector To Improve Articles

### DIFF
--- a/src/components/shared/HeaderImage.tsx
+++ b/src/components/shared/HeaderImage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 
-import HeaderImageCaption from './HeaderImageCaption';
+import HeaderImageCaption, { captionId } from './HeaderImageCaption';
 import { BlockElement } from 'types/capi-thrift-models';
 import { imageElement } from 'components/blocks/image';
 import { from } from '@guardian/src-foundations/mq';
@@ -41,7 +41,7 @@ const HeaderImage = ({ className, image, imageSalt }: HeaderImageProps): JSX.Ele
         // This is not an iterator, ESLint is confused
         // eslint-disable-next-line react/jsx-key
         <div css={[className, headerImageStyles]}>
-            <figure>
+            <figure aria-labelledby={captionId}>
                 { imageElement(imageTypeData.alt, assets, imageSalt) }
                 <HeaderImageCaption caption={imageTypeData.caption} credit={imageTypeData.credit}/>
             </figure>

--- a/src/components/shared/HeaderImageCaption.tsx
+++ b/src/components/shared/HeaderImageCaption.tsx
@@ -4,13 +4,11 @@ import { basePx, textSans, icons, wideContentWidth } from 'styles';
 import { palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 
-const HeaderImageCaptionStyles = css`
-    input[type=checkbox] {
-        display: none;
-    }
+const captionId = 'header-image-caption';
 
-    label {
-        line-height: 30px;
+const HeaderImageCaptionStyles = css`
+	summary {
+		line-height: 30px;
         text-align: center;
         background-color: ${palette.yellow.main};
         color: ${palette.neutral[7]};
@@ -22,26 +20,26 @@ const HeaderImageCaptionStyles = css`
         right: ${basePx(1)};
         border-radius: 100%;
         z-index: 2;
-        font-size: 2.8rem;
+		font-size: 2.8rem;
+		
+		span {
+			font-size: 0;
+		}
 
 		&::before {
 			${icons}
 			content: "\\e044";
 			font-size: 16px;
+			position: absolute;
+			right: ${basePx(1)};
+		}
+
+		&::-webkit-details-marker {
+			display: none;
 		}
 	}
 
-	label::selection,
-	input[type=checkbox]:checked ~ div span::selection {
-		background-color: transparent;
-	}
-
-	input[type=checkbox] ~ div {
-		display: none
-	}
-
-	input[type=checkbox]:checked ~ div {
-		display: block;
+	details[open] {
 		min-height: 44px;
 		max-height: 999px;
 		background-color: rgba(0, 0, 0, 0.8);
@@ -71,15 +69,16 @@ interface HeaderImageCaptionProps {
 }
 
 const HeaderImageCaption = ({ caption, credit }: HeaderImageCaptionProps): JSX.Element => (
-	<div css={HeaderImageCaptionStyles}>
-		<label htmlFor="captionToggle"></label>
-		<input type="checkbox" id="captionToggle"/>
-		<div>
-			<span>{caption}</span>
-			<span>&nbsp;</span>
-			<span>{credit}</span>
-		</div>
-	</div>
+	<figcaption css={HeaderImageCaptionStyles}>
+		<details>
+			<summary><span>Click to see figure caption</span></summary>
+			<span id={captionId}>{caption}&nbsp;{credit}</span>
+		</details>
+	</figcaption>
 )
 
 export default HeaderImageCaption;
+
+export {
+	captionId,
+};

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -204,7 +204,7 @@ const adHeight = '250px';
 
 export const adStyles = css`
     .ad-placeholder {
-        color: ${palette.neutral[46]};
+        color: ${palette.neutral[20]};
         background: ${palette.neutral[97]};
         clear: both;
 
@@ -223,7 +223,7 @@ export const adStyles = css`
                 background: none;
                 border: none;
                 font-size: 16px;
-                color: ${palette.neutral[46]};
+                color: ${palette.neutral[20]};
                 margin-top: -4px;
 
                 &::after {
@@ -231,6 +231,10 @@ export const adStyles = css`
                     ${icons}
                     content: "\\e04F";
                     font-size: 16px;
+                }
+
+                &:focus {
+                    text-decoration: underline;
                 }
             }
         }


### PR DESCRIPTION
## Why are you doing this?

Used the excellent [Firefox accessibility inspector](https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector) to improve the accessibility of article pages. Used the "check for issues" to inform changes.

FYI @SiAdcock

## Changes

- Switched to details/summary from checkox/label
- Better contrast on ads
- Clear labelling for figure captions
- Focus styles for ad buttons
