### PR TITLE
Bump to es2019 so we can use flat()

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "target": "es2019",
         // Enable strictest settings like strictNullChecks & noImplicitAny.
         "strict": true,
         // Import non-ES modules as default imports.


### PR DESCRIPTION
ads.ts was reporting compilation errors with `tsc`
