### PR TITLE
Handle Favicon

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -89,6 +89,8 @@ app.use("/public", express.static(path.resolve(__dirname, '../public')));
 app.use("/static", express.static(path.resolve(__dirname, '../dist')));
 app.use(compression());
 
+app.get('/favicon.ico', (_, res) => res.status(404).end());
+
 app.get('/*', async (req, res) => {
 
   try {


### PR DESCRIPTION
## Why are you doing this?

The server is currently returning `500` for favicon requests (and printing 'Unexpected CAPI response structure' to the logs) when the request for a favicon is made. This is happening because we ask CAPI for an article when given pretty much any path, which doesn't make sense when that path is `/favicon.ico`.

Requests for a favicon now return `404`, and we no longer get the unhelpful log message.

## Changes

- Added `404` result for favicon requests.
