### PR TITLE
CAPI Error Handling

### DIFF
--- a/src/capi.ts
+++ b/src/capi.ts
@@ -14,6 +14,13 @@ interface Capi {
     };
 }
 
+interface CapiError {
+    response?: {
+        message: string,
+    }
+    message?: string,
+};
+
 interface Series {
     webTitle?: string;
     webUrl?: string;
@@ -40,6 +47,17 @@ function parseCapi(capiResponse: string): Result<string, Capi> {
         return new Ok(JSON.parse(capiResponse));
     } catch (_) {
         return new Err('Could not parse the CAPI response');
+    }
+}
+
+function parseCapiError(capiResponse: string): Result<string, string> {
+    try {
+        const capiError: CapiError = JSON.parse(capiResponse);
+        const message = capiError.response?.message ?? capiError.message;
+
+        return new Ok(message ? `It came with this message: ${message}` : 'There was no message to explain why.');
+    } catch (_) {
+        return new Err('Could not parse the CAPI error');
     }
 }
 
@@ -80,6 +98,7 @@ export {
     Contributor,
     isFeature,
     parseCapi,
+    parseCapiError,
     isSingleContributor,
     capiEndpoint,
     articleSeries,

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -6,12 +6,16 @@ import { Option, fromNullable, None, Some } from 'types/option';
 import { isImage } from 'components/blocks/image';
 
 
-// ----- Types ----- //
+// ----- Parsing ----- //
 
-interface Capi {
-    response: {
-        content: Content;
-    };
+const enum ErrorStatus {
+    NotFound,
+    Unknown,
+}
+
+type Error = {
+    status: ErrorStatus,
+    message: string,
 }
 
 interface ErrorResponse {
@@ -28,6 +32,71 @@ interface ErrorMessage {
 // sometimes it returns that message nested inside a `response` object.
 type CapiError = ErrorResponse | ErrorMessage;
 
+const isErrorResponse = (error: CapiError): error is ErrorResponse => 'response' in error;
+const isErrorMessage = (error: CapiError): error is ErrorMessage => 'message' in error;
+
+function extractErrorMessage(capiError: CapiError): Option<string> {
+    if (isErrorResponse(capiError)) {
+        return new Some(capiError.response.message);
+    } else if (isErrorMessage(capiError)) {
+        return new Some(capiError.message);
+    }
+
+    return new None();
+}
+
+function parseCapiError(capiResponse: string): string {
+    try {
+        const capiError: CapiError = JSON.parse(capiResponse);
+
+        return extractErrorMessage(capiError)
+            .map(msg => `It came with this message: ${msg}`)
+            .withDefault('There was no message to explain why.');
+    } catch (e) {
+        return `I wasn\'t able to parse the error message because: ${e}`;
+    }
+}
+
+function parseContent(capiResponse: string): Result<string, Content> {
+    try {
+        const content = JSON.parse(capiResponse).response.content;
+
+        if (content === undefined) {
+            return new Err('I couldn\'t parse the CAPI response because the content field was missing.');
+        }
+        
+        return new Ok(content);
+    } catch (e) {
+        return new Err(`I couldn't parse the CAPI response because: ${e}`);
+    }
+}
+
+function getContentFromResponse(status: number, path: string, responseBody: string): Result<Error, Content> {
+
+    switch (status) {
+        case 200:
+            return parseContent(responseBody).mapError(message => ({
+                status: ErrorStatus.Unknown,
+                message,
+            }));
+    
+        case 404:
+            return new Err({
+                status: ErrorStatus.NotFound,
+                message: `CAPI says that it doesn't recognise this resource: ${path}`,
+            });
+        default:
+            return new Err({
+                status: ErrorStatus.Unknown,
+                message: `When I tried to talk to CAPI I received a ${status}. ${parseCapiError(responseBody)}`,
+            });
+    }
+
+}
+
+
+// ----- Lookups ----- //
+
 interface Series {
     webTitle?: string;
     webUrl?: string;
@@ -40,52 +109,26 @@ interface Contributor {
     bylineLargeImageUrl?: string;
 }
 
-
-// ----- Functions ----- //
-
 const tagsOfType = (type_: string) => (tags: Tag[]): Tag[] =>
     tags.filter((tag: Tag) => tag.type === type_);
 
 const isFeature = (content: Content): boolean =>
     content.tags.some(tag => tag.id === 'tone/features');
 
-function parseCapi(capiResponse: string): Result<string, Capi> {
-    try {
-        return new Ok(JSON.parse(capiResponse));
-    } catch (_) {
-        return new Err('Could not parse the CAPI response');
-    }
-}
-
-const isErrorResponse = (error: CapiError): error is ErrorResponse => 'response' in error;
-const isErrorMessage = (error: CapiError): error is ErrorMessage => 'message' in error;
-
-function errorMessage(capiError: CapiError): Option<string> {
-    if (isErrorResponse(capiError)) {
-        return new Some(capiError.response.message);
-    } else if (isErrorMessage(capiError)) {
-        return new Some(capiError.message);
-    }
-
-    return new None();
-}
-
-function parseCapiError(capiResponse: string): Result<string, string> {
-    try {
-        const capiError: CapiError = JSON.parse(capiResponse);
-        const message = errorMessage(capiError);
-
-        return new Ok(message
-            .map(msg => `It came with this message: ${msg}`)
-            .withDefault('There was no message to explain why.')
-        );
-    } catch (_) {
-        return new Err('Could not parse the CAPI error');
-    }
-}
-
 const isSingleContributor = (contributors: Contributor[]): boolean =>
     contributors.length === 1;
+
+const articleSeries = (content: Content): Tag =>
+    tagsOfType('series')(content.tags)[0];
+
+const articleContributors = (content: Content): Tag[] =>
+    tagsOfType('contributor')(content.tags);
+
+const articleMainImage = (content: Content): Option<BlockElement> =>
+    fromNullable(content.blocks.main.elements.filter(isImage)[0]);
+
+
+// ----- Functions ----- //
 
 // TODO: request less data from capi
 const capiEndpoint = (articleId: string, key: string): string => {
@@ -103,28 +146,18 @@ const capiEndpoint = (articleId: string, key: string): string => {
   
 }
 
-const articleSeries = (content: Content): Tag =>
-    tagsOfType('series')(content.tags)[0];
-
-const articleContributors = (content: Content): Tag[] =>
-    tagsOfType('contributor')(content.tags);
-
-const articleMainImage = (content: Content): Option<BlockElement> =>
-    fromNullable(content.blocks.main.elements.filter(isImage)[0]);
-
 
 // ----- Exports ----- //
 
 export {
-    Capi,
     Series,
     Contributor,
+    ErrorStatus as CapiError,
+    getContentFromResponse,
     isFeature,
-    parseCapi,
-    parseCapiError,
     isSingleContributor,
-    capiEndpoint,
     articleSeries,
     articleContributors,
     articleMainImage,
+    capiEndpoint,
 };

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -14,8 +14,8 @@ const enum ErrorStatus {
 }
 
 type Error = {
-    status: ErrorStatus,
-    message: string,
+    status: ErrorStatus;
+    message: string;
 }
 
 interface ErrorResponse {
@@ -71,7 +71,7 @@ function parseContent(capiResponse: string): Result<string, Content> {
     }
 }
 
-function getContentFromResponse(status: number, path: string, responseBody: string): Result<Error, Content> {
+function getContent(status: number, path: string, responseBody: string): Result<Error, Content> {
 
     switch (status) {
         case 200:
@@ -153,7 +153,7 @@ export {
     Series,
     Contributor,
     ErrorStatus as CapiError,
-    getContentFromResponse,
+    getContent,
     isFeature,
     isSingleContributor,
     articleSeries,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -14,7 +14,7 @@ import { Content } from 'capiThriftModels';
 import Article from 'components/news/article';
 import LiveblogArticle from 'components/liveblog/liveblogArticle';
 import { getConfigValue } from 'server/ssmConfig';
-import { CapiError, capiEndpoint, getContentFromResponse } from 'capi';
+import { CapiError, capiEndpoint, getContent } from 'capi';
 
 
 // ----- Setup ----- //
@@ -33,10 +33,10 @@ const enum Support {
 }
 
 type Supported = {
-  kind: Support.Supported,
+  kind: Support.Supported;
 } | {
-  kind: Support.Unsupported,
-  reason: string,
+  kind: Support.Unsupported;
+  reason: string;
 }
 
 function checkSupport(content: Content): Supported {
@@ -100,7 +100,7 @@ app.get('/*', async (req, res) => {
     const imageSalt = await getConfigValue<string>('apis.img.salt');
     const capiResponse = await fetch(capiEndpoint(articleId, key));
 
-    getContentFromResponse(capiResponse.status, articleId, await capiResponse.text()).either(
+    getContent(capiResponse.status, articleId, await capiResponse.text()).either(
       error => {
 
         if (error.status === CapiError.NotFound) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3,18 +3,18 @@
 import path from 'path';
 import fs from 'fs';
 import { promisify } from 'util';
-import express, { Response } from 'express';
+import express from 'express';
 import compression from 'compression';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import fetch, { Response as FetchResponse } from 'node-fetch';
+import fetch from 'node-fetch';
 
-import { fromUnsafe, Result, Ok, Err } from 'types/result';
+import { Result, Ok, Err } from 'types/result';
 import { Content } from 'capiThriftModels';
 import Article from 'components/news/article';
 import LiveblogArticle from 'components/liveblog/liveblogArticle';
 import { getConfigValue } from 'server/ssmConfig';
-import { Capi, parseCapi, capiEndpoint, parseCapiError } from 'capi';
+import { CapiError, capiEndpoint, getContentFromResponse } from 'capi';
 
 
 // ----- Setup ----- //
@@ -27,48 +27,47 @@ const templateFile = './src/articleTemplate.html';
 
 // ----- Functions ----- //
 
-const id = <A>(a: A): A => a;
+const enum Support {
+  Supported,
+  Unsupported,
+}
 
-function getContent(capi: Capi): Result<string, Content> {
+type Supported = {
+  kind: Support.Supported,
+} | {
+  kind: Support.Unsupported,
+  reason: string,
+}
 
-  const content = capi.response.content;
+function checkSupport(content: Content): Supported {
+
   const { fields, atoms } = content;
 
   if (fields.displayHint === 'immersive') {
-    return new Err('Immersive displayHint is not yet supported');
+    return { kind: Support.Unsupported, reason: 'The article contains an immersive displayHint' };
   }
 
   if (atoms) {
-    return new Err('Atoms not yet supported');
+    return { kind: Support.Unsupported, reason: 'The article contains atoms' };
   }
 
-  return new Ok(content);
+  return { kind: Support.Supported };
 
 }
 
-const getArticleComponent = (imageSalt: string) =>
-  function ArticleComponent(capi: Content): React.ReactElement {
-    switch (capi.type) {
-      case 'article':
-        return React.createElement(Article, { capi, imageSalt });
-      case 'liveblog':
-        return React.createElement(
-          LiveblogArticle,
-          { capi, isLive: true, imageSalt }
-        );
-      default:
-        return React.createElement('p', null, `${capi.type} not implemented yet`);
-    }
+function getArticleComponent(imageSalt: string, capi: Content): React.ReactElement {
+  switch (capi.type) {
+    case 'article':
+      return React.createElement(Article, { capi, imageSalt });
+    case 'liveblog':
+      return React.createElement(
+        LiveblogArticle,
+        { capi, isLive: true, imageSalt }
+      );
+    default:
+      return React.createElement('p', null, `${capi.type} not implemented yet`);
   }
-
-const generateArticleHtml = (capiResponse: string, imageSalt: string) =>
-  (data: string): Result<string, string> =>
-    parseCapi(capiResponse)
-      .andThen(capi => fromUnsafe(() => getContent(capi), 'Unexpected CAPI response structure'))
-      .andThen(id)
-      .map(getArticleComponent(imageSalt))
-      .map(renderToString)
-      .map(body => data.replace('<div id="root"></div>', `<div id="root">${body}</div>`))
+}
 
 async function readTemplate(): Promise<Result<string, string>> {
   try {
@@ -77,31 +76,6 @@ async function readTemplate(): Promise<Result<string, string>> {
   } catch (_) {
     return new Err('Could not read template file');
   }
-}
-
-function renderArticle(template: Result<string, string>, imageSalt: string) {
-
-  return async (capiResponse: FetchResponse): Promise<Result<string, string>> => {
-    const capiData = await capiResponse.text();
-
-    return template.andThen(generateArticleHtml(capiData, imageSalt));
-  };
-
-}
-
-async function capiError(capiResponse: FetchResponse): Promise<string> {
-
-  return parseCapiError(await capiResponse.text())
-    .either(
-      parseError => `Problem talking to CAPI. Received a ${capiResponse.status}, and I'm not sure why because: ${parseError}.`,
-      capiError => `When I tried to talk to CAPI I received a ${capiResponse.status}. ${capiError}`,
-    );
-
-  }
-
-function sendError(res: Response, message: string): void {
-  console.error(message);
-  res.status(500).end();
 }
 
 
@@ -126,27 +100,42 @@ app.get('/*', async (req, res) => {
     const imageSalt = await getConfigValue<string>('apis.img.salt');
     const capiResponse = await fetch(capiEndpoint(articleId, key));
 
-    switch (capiResponse.status) {
-      case 200:
+    getContentFromResponse(capiResponse.status, articleId, await capiResponse.text()).either(
+      error => {
 
-        (await renderArticle(template, imageSalt)(capiResponse)).either(
-          err => sendError(res, `Failed to render the article because: ${err}`),
-          html => res.send(html),
-        );
+        if (error.status === CapiError.NotFound) {
 
-        break;
-      
-      case 404:
-        console.warn(`Request for a resource that CAPI does not recognise: ${req.params[0]}`);
-        res.status(404).end();
-        break;
-      
-      default:
-        sendError(res, await capiError(capiResponse));
-    }
+          console.warn(error.message);
+          res.sendStatus(404);
+
+        } else {
+
+          console.error(error.message);
+          res.sendStatus(500);
+
+        }
+
+      },
+      content => {
+        const support = checkSupport(content);
+
+        if (support.kind === Support.Supported) {
+          const article = getArticleComponent(imageSalt, content);
+          const html = renderToString(article);
+
+          template
+            .map(file => file.replace('<div id="root"></div>', `<div id="root">${html}</div>`))
+            .map(document => res.send(document));
+        } else {
+          console.warn(`I can\'t render that type of content yet! ${support.reason}`);
+          res.sendStatus(415);
+        }
+      }
+    )
 
   } catch (e) {
-    sendError(res, `This error occurred, but I don't know why: ${e}`);
+    console.error(`This error occurred, but I don't know why: ${e}`);
+    res.sendStatus(500);
   }
 
 });

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -7,6 +7,7 @@ import { Monad } from './monad';
 
 interface ResultInterface<E, B> extends Monad<B> {
     either<C>(f: (e: E) => C, g: (b: B) => C): C;
+    mapError<F>(g: (e: E) => F): Result<F, B>;
 }
 
 class Ok<E, B> implements ResultInterface<E, B> {
@@ -23,6 +24,10 @@ class Ok<E, B> implements ResultInterface<E, B> {
 
     andThen<C>(f: (b: B) => Result<E, C>): Result<E, C> {
         return f(this.value);
+    }
+
+    mapError<F>(_g: (e: E) => F): Result<F, B> {
+        return new Ok(this.value);
     }
 
     constructor(value: B) {
@@ -45,6 +50,10 @@ class Err<E, B> implements ResultInterface<E, B> {
 
     andThen<C>(_f: (b: B) => Result<E, C>): Result<E, C> {
         return new Err(this.error);
+    }
+
+    mapError<F>(g: (e: E) => F): Result<F, B> {
+        return new Err(g(this.error));
     }
 
     constructor(error: E) {


### PR DESCRIPTION
## Why are you doing this?

Regardless of the response CAPI has been returning to us on an article request, we have been attempting to parse it as though it were successful. This has led to some unhelpful error messages, and made it harder to debug issues.

This PR adds some more granular handling of CAPI responses, and (hopefully) some more descriptive error messages. Depending on how this goes, I'm hoping to expand this method of error handling to other parts of the codebase.

## Changes

- Deleted the `Capi` type.
- Created some error types to handle different CAPI response structures.
- Wrote some parsing code to handle different CAPI responses, and migrated some logic to keep all CAPI handling code to one file (should make it easier to define what's used in DEV vs PROD once MAPI handles CAPI requests).
- Created new types to handle unsupported content (atoms, etc.).
- Stripped some complexity out of the server file, and (hopefully) made the `request -> render -> response` pipeline a bit clearer.
- Added `mapError` to the `Result` type.
