### PR TITLE
link style

### DIFF
--- a/src/components/immersive/immersiveStandfirst.tsx
+++ b/src/components/immersive/immersiveStandfirst.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bulletStyles, headlineFont, darkModeCss, basePx } from 'styles';
+import { bulletStyles, headlineFont, darkModeCss, basePx, linkStyle } from 'styles';
 import { transform } from 'contentTransformations';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
@@ -12,9 +12,7 @@ const StandfirstStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     font-size: 1.8rem;
     line-height: 2.4rem;
 
-    a {
-        color: ${kicker};
-    }
+    ${linkStyle(kicker)}
 
     p, ul {
         margin: 0;

--- a/src/components/liveblog/liveblogBlock.tsx
+++ b/src/components/liveblog/liveblogBlock.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { textSans, icons, basePx } from 'styles';
+import { textSans, icons, basePx, linkStyle } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
 import { palette } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
@@ -34,8 +34,8 @@ const LiveblogBlockStyles = ({ kicker }: PillarStyles, highlighted: boolean): Se
         margin-right: ${basePx(1)};
     }
 
-    .rich-link a {
-        color: ${kicker};
+    .rich-link {
+        ${linkStyle(kicker)}
     }
 
     blockquote {

--- a/src/components/news/articleStandfirst.tsx
+++ b/src/components/news/articleStandfirst.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { sidePadding, bulletStyles, headlineFont, darkModeCss } from 'styles';
+import { sidePadding, bulletStyles, headlineFont, darkModeCss, linkStyle } from 'styles';
 import { transform } from '../../contentTransformations';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
@@ -19,14 +19,11 @@ const StandfirstStyles = (feature: boolean, { kicker }: PillarStyles): Serialize
     font-size: 1.6rem;
     line-height: 2rem;
 
-    a {
-        color: ${kicker};
-    }
-
     p, ul {
         margin: 0;
     }
 
+    ${linkStyle(kicker)}
     ${bulletStyles(kicker)}
     ${sidePadding}
     ${feature ? StandfirstFeatureStyles : null}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -83,11 +83,21 @@ export const darkModeCss = (
     }
 `;
 
-// Styles shared across article types
-export const commonArticleStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
+export const linkStyle = (kicker: string): SerializedStyles => css`
     a {
         color: ${kicker};
+        text-decoration: none;
+        padding-bottom: 0.15em;
+        background-image: linear-gradient(${kicker} 0%, ${kicker} 100%);
+        background-repeat: repeat-x;
+        background-size: 1px 1px;
+        background-position: 0 bottom;
     }
+`
+
+// Styles shared across article types
+export const commonArticleStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
+    ${linkStyle(kicker)}
 
     .image img {
         width: 100%; 


### PR DESCRIPTION
## Why are you doing this?

Dotcom and the current templates use special link styles. I'm not sure of the origin or reason behind this but it looks to improve readability.

This PR uses the same styling.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/71197854-6dbaa080-228a-11ea-9631-8bbab6a1dc7e.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/71197862-71e6be00-228a-11ea-874d-072e116811a5.png" width="300px" /> |

