### PR TITLE
Create components rather than set html

### DIFF
--- a/src/components/immersive/immersiveStandfirst.tsx
+++ b/src/components/immersive/immersiveStandfirst.tsx
@@ -4,6 +4,7 @@ import { transform } from 'contentTransformations';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import { PillarStyles } from 'pillar';
+import { componentFromHtml } from 'renderBlocks';
 
 const StandfirstStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     ${headlineFont}
@@ -55,8 +56,11 @@ const ImmersiveStandfirst = ({
         StandfirstStyles(pillarStyles),
         StandfirstDarkStyles(pillarStyles)
     ]}>
-        <div dangerouslySetInnerHTML={{__html: transform(standfirst)}}/>
-        <address dangerouslySetInnerHTML={{__html: "By " + byline}}></address>
+        <div>{componentFromHtml(transform(standfirst))}</div>
+        <address>
+            <span>By </span>
+            {componentFromHtml(byline)}
+        </address>
     </div>
 
 export default ImmersiveStandfirst;

--- a/src/components/liveblog/liveblogByline.tsx
+++ b/src/components/liveblog/liveblogByline.tsx
@@ -10,6 +10,7 @@ import { formatDate } from 'date';
 import Avatar from 'components/shared/avatar';
 import LeftColumn from 'components/shared/leftColumn';
 import { PillarStyles, Pillar } from 'pillar';
+import { componentFromHtml } from 'renderBlocks';
 
 const LiveblogBylineStyles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
     background: ${liveblogBackground};
@@ -73,7 +74,7 @@ const LiveblogByline = ({
                     imageSalt={imageSalt}
                 />
                 <div className="author">
-                    <address dangerouslySetInnerHTML={{__html: byline}}></address>
+                    <address>{componentFromHtml(byline)}</address>
                     <time>{ formatDate(new Date(publicationDate)) }</time>
                     <div className="follow">Get alerts on this story</div>
                 </div>

--- a/src/components/liveblog/liveblogStandfirst.tsx
+++ b/src/components/liveblog/liveblogStandfirst.tsx
@@ -5,6 +5,7 @@ import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import LeftColumn from 'components/shared/leftColumn';
 import { PillarStyles } from 'pillar';
+import { componentFromHtml } from 'renderBlocks';
 
 const StandfirstStyles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
     padding-bottom: 6px;
@@ -32,7 +33,7 @@ interface LiveblogStandfirstProps {
 
 const LiveblogStandfirst = ({ standfirst, pillarStyles }: LiveblogStandfirstProps): JSX.Element =>
     <LeftColumn className={StandfirstStyles(pillarStyles)}>
-        <div dangerouslySetInnerHTML={{__html: transform(standfirst)}} />
+        <div>{componentFromHtml(transform(standfirst))}</div>
     </LeftColumn>
 
 export default LiveblogStandfirst;

--- a/src/components/news/articleByline.tsx
+++ b/src/components/news/articleByline.tsx
@@ -8,6 +8,7 @@ import { Contributor } from 'capi';
 import Avatar from 'components/shared/avatar';
 import Follow from 'components/shared/follow';
 import { PillarStyles } from 'pillar';
+import { componentFromHtml } from 'renderBlocks';
 
 const ArticleBylineStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     .author {
@@ -78,7 +79,7 @@ const ArticleByline = ({
                 imageSalt={imageSalt}
             />
             <div className="author">
-                <address dangerouslySetInnerHTML={{__html: byline}}></address>
+                <address>{componentFromHtml(byline)}</address>
                 <time className="date">{ formatDate(new Date(publicationDate)) }</time>
                 <Follow contributors={contributors} />
             </div>

--- a/src/components/news/articleStandfirst.tsx
+++ b/src/components/news/articleStandfirst.tsx
@@ -4,6 +4,7 @@ import { transform } from '../../contentTransformations';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import { PillarStyles } from 'pillar';
+import { componentFromHtml } from 'renderBlocks';
 
 const StandfirstFeatureStyles = `
     color: ${palette.neutral[46]};
@@ -60,7 +61,8 @@ const ArticleStandfirst = ({
             StandfirstStyles(feature, pillarStyles),
             StandfirstDarkStyles(pillarStyles)
         ]}
-        dangerouslySetInnerHTML={{__html: transform(standfirst)}}
-    />
+    >
+        {componentFromHtml(transform(standfirst))}
+    </div>
 
 export default ArticleStandfirst;

--- a/src/components/opinion/opinionHeadline.tsx
+++ b/src/components/opinion/opinionHeadline.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/core'
 import { palette } from '@guardian/src-foundations'
 import { PillarStyles } from 'pillar';
 import { until } from '@guardian/src-foundations/mq';
+import { componentFromHtml } from 'renderBlocks';
 
 const HeadlineStyles = css`
     padding: ${basePx(0, 0, 4, 0)};
@@ -46,7 +47,7 @@ const OpinionHeadline = ({
 }: OpinionHeadlineProps): JSX.Element =>
     <div css={[HeadlineStyles, HeadlineDarkStyles]}>
         <h1>{headline}</h1>
-        <address dangerouslySetInnerHTML={{__html: byline}}></address>
+        <address>{componentFromHtml(byline)}</address>
     </div>
 
 export default OpinionHeadline;

--- a/src/renderBlocks.ts
+++ b/src/renderBlocks.ts
@@ -59,7 +59,7 @@ function textElement(node: Node): ReactNode {
         case 'SPAN':
             return h('span', getAttrs(node), node.textContent);
         case 'HR':
-            return h('hr', getAttrs(node), node.textContent);
+            return h('hr', getAttrs(node), null);
         default:
             // Fallback to handle any element
             return h(
@@ -177,9 +177,15 @@ function render(bodyElements: BlockElement[], imageSalt: string, ads = true): Re
 
 }
 
+function componentFromHtml(html: string): ReactNode[] {
+    const fragment = JSDOM.fragment(transform(html))
+    return textBlock(fragment)
+}
+
 
 // ----- Exports ----- //
 
 export {
     render,
+    componentFromHtml,
 };


### PR DESCRIPTION
## Why are you doing this?
Replace all uses of `dangerouslySetInnerHtml` and reuse the jsdom code inside of `renderBlocks`.

We can reuse this `componentFromHtml` function whenever we receive individual html fields from capi.
