### PR TITLE
Re-write Blocks Rendering

### DIFF
--- a/src/ads.ts
+++ b/src/ads.ts
@@ -4,7 +4,7 @@ function insertAdPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
     const adIndices = [3, 9];
     const flattenedNodes = reactNodes.flat();
 
-    const isPara = (node: { type: string }): boolean => node.type === 'p';
+    const isPara = (node: { type: { name?: string } }): boolean => node.type?.name === 'Paragraph';
     const numParas = flattenedNodes.filter(isPara).length;
 
     const className = numParas < 15 ? 'ad-placeholder short' : 'ad-placeholder';

--- a/src/ads.ts
+++ b/src/ads.ts
@@ -4,7 +4,7 @@ function insertAdPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
     const adIndices = [3, 9];
     const flattenedNodes = reactNodes.flat();
 
-    const isPara = (node: { type: { name?: string } }): boolean => node.type?.name === 'Paragraph';
+    const isPara = (node: { type: { name?: string } }): boolean => node?.type?.name === 'Paragraph';
     const numParas = flattenedNodes.filter(isPara).length;
 
     const className = numParas < 15 ? 'ad-placeholder short' : 'ad-placeholder';

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -87,6 +87,7 @@ const toUrl = (salt: string, asset: Asset): Url =>
 
 export {
     Asset,
+    srcset,
     toSrcset,
     toUrl,
     transformUrl

--- a/src/block.ts
+++ b/src/block.ts
@@ -38,7 +38,7 @@ type Block = {
     linkText: string;
 } | {
     kind: ElementType.TWEET;
-    content: HTMLCollection;
+    content: NodeList;
 };
 
 type DocParser = (html: string) => DocumentFragment;
@@ -46,11 +46,11 @@ type DocParser = (html: string) => DocumentFragment;
 
 // ----- Parser ----- //
 
-const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, HTMLCollection> => {
+const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, NodeList> => {
     const blockquote = doc.querySelector('blockquote');
 
     if (blockquote !== null) {
-        return new Ok(blockquote.children);                    
+        return new Ok(blockquote.childNodes);
     }
 
     return new Err(`There was no blockquote element in the tweet with id: ${tweetId}`);
@@ -181,7 +181,7 @@ const Text = (props: { doc: DocumentFragment; pillar: Pillar }): ReactElement =>
     styledH(
         Fragment,
         null,
-        Array.from(props.doc.children).map((node, key) =>
+        Array.from(props.doc.childNodes).map((node, key) =>
             h(Fragment, { key }, textElement(props.pillar)(node))
         ),
     );
@@ -335,7 +335,7 @@ const Interactive = (props: { url: string }): ReactElement =>
         h('iframe', { src: props.url, height: 500 }, null)
     );
 
-const Tweet = (props: { content: HTMLCollection; pillar: Pillar }): ReactElement =>
+const Tweet = (props: { content: NodeList; pillar: Pillar }): ReactElement =>
     h('blockquote', null, ...Array.from(props.content).map(textElement(props.pillar)));
 
 const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number): ReactNode => {

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,0 +1,374 @@
+// ----- Imports ----- //
+
+import { ReactNode, createElement as h, Fragment } from 'react';
+import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
+import { from, until } from '@guardian/src-foundations/mq';
+import { palette } from '@guardian/src-foundations';
+
+import { BlockElement, ElementType } from 'capiThriftModels';
+import { Result, Ok, Err } from 'types/result';
+import { Option, fromNullable } from 'types/option';
+import { srcset, transformUrl } from 'asset';
+import { basePx, icons, headlineFont, darkModeCss, textSans } from 'styles';
+import { getPillarStyles, Pillar } from 'pillar';
+
+
+// ----- Types ----- //
+
+type Block = {
+    kind: ElementType.TEXT,
+    doc: DocumentFragment,
+} | {
+    kind: ElementType.IMAGE,
+    alt: string,
+    caption: string,
+    displayCredit: boolean,
+    credit: string,
+    file: string,
+} | {
+    kind: ElementType.PULLQUOTE,
+    quote: string,
+    attribution: Option<string>,
+} | {
+    kind: ElementType.INTERACTIVE,
+    url: string,
+} | {
+    kind: ElementType.RICH_LINK,
+    url: string,
+    linkText: string,
+} | {
+    kind: ElementType.TWEET,
+    content: HTMLCollection,
+};
+
+type DocParser = (html: string) => DocumentFragment;
+
+
+// ----- Parser ----- //
+
+const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, HTMLCollection> => {
+    const blockquote = doc.querySelector('blockquote');
+
+    if (blockquote !== null) {
+        return new Ok(blockquote.children);                    
+    }
+
+    return new Err(`There was no blockquote element in the tweet with id: ${tweetId}`);
+}
+
+const parser = (docParser: DocParser) => (block: BlockElement): Result<string, Block> => {
+    switch (block.type) {
+
+        case ElementType.TEXT:
+            return new Ok({ kind: ElementType.TEXT, doc: docParser(block.textTypeData.html) });
+
+        case ElementType.IMAGE:
+
+            const masterAsset = block.assets.find(asset => asset.typeData.isMaster);
+            const { alt, caption, displayCredit, credit } = block.imageTypeData;
+            const imageBlock: Option<Result<string, Block>> = fromNullable(masterAsset)
+                .map(asset => asset.file)
+                .map(file => new Ok({
+                    kind: ElementType.IMAGE,
+                    alt,
+                    caption,
+                    displayCredit,
+                    credit,
+                    file,
+                }));
+
+            return imageBlock.withDefault(new Err('I couldn\'t find a master asset'));
+
+        case ElementType.PULLQUOTE:
+
+            const { html: quote, attribution } = block.pullquoteTypeData;
+            return new Ok({
+                kind: ElementType.PULLQUOTE,
+                quote,
+                attribution: fromNullable(attribution),
+            });
+
+        case ElementType.INTERACTIVE:
+            const { iframeUrl } = block.interactiveTypeData;
+            return new Ok({ kind: ElementType.INTERACTIVE, url: iframeUrl });
+
+        case ElementType.RICH_LINK:
+
+            const { url, linkText } = block.richLinkTypeData;
+            return new Ok({ kind: ElementType.RICH_LINK, url, linkText });
+
+        case ElementType.TWEET:
+            return tweetContent(block.tweetTypeData.id, docParser(block.textTypeData.html))
+                .map(content => ({ kind: ElementType.TWEET, content }));
+
+        default:
+            return new Err(`I'm afraid I don't understand the block I was given: ${block.type}`);
+    }
+}
+
+const parseAll = (docParser: DocParser) => (blocks: BlockElement[]): Result<string, Block>[] =>
+    blocks.map(parser(docParser));
+
+
+// ----- Renderer ----- //
+
+// The nodeType for ELEMENT_NODE has the value 1.
+function isElement(node: Node): node is Element {
+    return node.nodeType === 1;
+}
+
+function getAttrs(node: Node): React.AnchorHTMLAttributes<string> {
+    if (isElement(node)) {
+        return Array.from(node.attributes).reduce((attrs, attr) => {
+            return { ...attrs, [attr.name]: attr.value };
+        }, {});
+    } else {
+        return {};
+    }
+}
+
+const Paragraph = (props: { children?: ReactNode }) =>
+    h('p', null, props.children);
+
+const anchorStyles = (colour: string): SerializedStyles => css`
+    color: ${colour};
+`;
+
+const Anchor = (props: { href: string, text: string, pillar: Pillar }) =>
+    styledH(
+        'a',
+        { css: anchorStyles(getPillarStyles(props.pillar).kicker), href: props.href },
+        props.text,
+    );
+
+const bulletStyles = (colour: string) => css`
+    color: transparent;
+
+    &::before {
+        content: '';
+        background-color: ${colour};
+        width: 1rem;
+        height: 1rem;
+        border-radius: .5rem;
+        display: inline-block;
+    }
+`;
+
+const Bullet = (props: { pillar: Pillar, text: string }) =>
+    h(Fragment, null,
+        styledH('span', { css: bulletStyles(getPillarStyles(props.pillar).kicker) }, '•'),
+        props.text.replace(/•/, ''),
+    );
+
+const textElement = (pillar: Pillar) => (node: Node): ReactNode => {
+    switch (node.nodeName) {
+        case 'P':
+            return h(Paragraph, null, ...Array.from(node.childNodes).map(textElement(pillar)));
+        case '#text':
+            const text = node.textContent;
+            return text?.includes('•') ? h(Bullet, { pillar: pillar, text }) : text;
+        case 'SPAN':
+            return node.textContent;
+        case 'A':
+            return h(Anchor, { href: getAttrs(node).href ?? '', text: node.textContent ?? '', pillar });
+        default:
+            return null;
+    }
+}
+
+const Text = (props: { doc: DocumentFragment, pillar: Pillar }) =>
+    styledH(
+        Fragment,
+        null,
+        Array.from(props.doc.children).map((node, key) =>
+            h(Fragment, { key }, textElement(props.pillar)(node))
+        ),
+    );
+
+const makeCaption = (caption: string, displayCredit: boolean, credit: string) =>
+    displayCredit ? `${caption} ${credit}` : caption;
+
+interface ImageProps {
+    url: string;
+    alt: string;
+    salt: string;
+    caption: string;
+    displayCredit: boolean;
+    credit: string;
+}
+
+const imageStyles = css`
+    margin-left: ${basePx(-1)};
+    margin-right: ${basePx(-1)};
+
+    ${from.phablet} {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    ${from.wide} {
+        margin: 1em 0;
+    }
+
+    img {
+        width: 100%; 
+    }
+
+    figcaption {
+        font-size: 1.4rem;
+        line-height: 1.8rem;
+        color: ${palette.neutral[46]};
+        ${textSans}
+
+        ${until.phablet} {
+            padding-left: ${basePx(1)};
+            padding-right: ${basePx(1)};
+        }
+    }
+`;
+
+const Image = ({ url, alt, salt, caption, displayCredit, credit }: ImageProps) =>
+    styledH('figure', { css: imageStyles },
+        h('img', {
+            sizes: '100%',
+            srcSet: srcset(salt)(url),
+            alt: alt,
+            src: transformUrl(salt, url, 500),
+        }),
+        h('figcaption', null, makeCaption(caption, displayCredit, credit)),
+    );
+
+const pullquoteStyles = (colour: string): SerializedStyles => css`
+    font-weight: 200;
+    font-size: 2.2rem;
+    line-height: 1.3;
+    color: ${colour};
+    ${headlineFont}
+    margin: 0;
+
+    p {
+        margin: 1em 0;
+
+        &::before {
+            ${icons}
+            font-size: 2.2rem;
+            content: '\\e11c';
+            display: inline-block;
+            margin-right: ${basePx(1)};
+        }
+    }
+
+    footer {
+        font-size: 1.8rem;
+        margin-top: 4px;
+
+        cite {
+            font-style: normal;
+        }
+    }
+`;
+
+const Pullquote = (props: { quote: string, attribution: Option<string>, pillar: Pillar }) =>
+    styledH('aside', { css: pullquoteStyles(getPillarStyles(props.pillar).kicker) },
+        h('blockquote', null,
+            h('p', null, props.quote)
+        )
+    );
+
+const richLinkWidth = '13.75rem';
+
+const richLinkStyles = css`
+    background: ${palette.neutral[97]};
+    padding: ${basePx(1)};
+
+    h1 {
+        margin: 0;
+    }
+
+    p {
+        margin: ${basePx(1, 0)};
+    }
+
+    span {
+        display: none;
+    }
+
+    a {
+        text-decoration: none;
+    }
+
+    float: left;
+    clear: left;
+    width: ${richLinkWidth};
+    margin: ${basePx(1, 2, 1, 0)};
+
+    ${from.wide} {
+        margin-left: calc(-${richLinkWidth} - 16px - 24px);
+    }
+
+    ${darkModeCss`
+        border-top: 1px solid ${palette.neutral[60]};
+        border-bottom: 1px solid ${palette.neutral[60]};
+        a {
+            &::before {
+                color: ${palette.neutral[60]};
+            }
+        }
+    `}
+`;
+
+const RichLink = (props: { url: string, linkText: string, pillar: Pillar }) =>
+    styledH('aside', { css: richLinkStyles },
+        h('h1', null, props.linkText),
+        h(Anchor, { href: props.url, pillar: props.pillar, text: 'Read more' }),
+    );
+
+const Interactive = (props: { url: string }) =>
+    h('figure', { className: 'interactive' },
+        h('iframe', { src: props.url, height: 500 }, null)
+    );
+
+const Tweet = (props: { content: HTMLCollection, pillar: Pillar }) =>
+    h('blockquote', null, ...Array.from(props.content).map(textElement(props.pillar)));
+
+const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number): ReactNode => {
+    switch (block.kind) {
+
+        case ElementType.TEXT:
+            return h(Text, { doc: block.doc, pillar, key });
+
+        case ElementType.IMAGE:
+            const { file, alt, caption, displayCredit, credit } = block;
+            return h(Image, { url: file, alt, salt, caption, displayCredit, credit, key });
+
+        case ElementType.PULLQUOTE:
+            const { quote, attribution } = block;
+            return h(Pullquote, { quote, attribution, pillar, key });
+
+        case ElementType.RICH_LINK:
+            const { url, linkText } = block;
+            return h(RichLink, { url, linkText, pillar, key });
+
+        case ElementType.INTERACTIVE:
+            return h(Interactive, { url: block.url, key });
+
+        case ElementType.TWEET:
+            return h(Tweet, { content: block.content, pillar, key });
+
+        default:
+            return null;
+
+    }
+}
+
+const renderAll = (salt: string) => (pillar: Pillar, blocks: Block[]): ReactNode[] =>
+    blocks.map(render(salt)(pillar));
+
+
+// ----- Exports ----- //
+
+export {
+    Block,
+    parseAll,
+    renderAll,
+};

--- a/src/block.ts
+++ b/src/block.ts
@@ -133,6 +133,12 @@ const Paragraph = (props: { children?: ReactNode }): ReactElement =>
 
 const anchorStyles = (colour: string): SerializedStyles => css`
     color: ${colour};
+    text-decoration: none;
+    padding-bottom: 0.15em;
+    background-image: linear-gradient(${colour} 0%, ${colour} 100%);
+    background-repeat: repeat-x;
+    background-size: 1px 1px;
+    background-position: 0 bottom;
 `;
 
 const Anchor = (props: { href: string; text: string; pillar: Pillar }): ReactElement =>
@@ -245,6 +251,10 @@ const pullquoteStyles = (colour: string): SerializedStyles => css`
     color: ${colour};
     ${headlineFont}
     margin: 0;
+
+    blockquote {
+        margin-left: 0;
+    }
 
     p {
         margin: 1em 0;

--- a/src/block.ts
+++ b/src/block.ts
@@ -161,6 +161,9 @@ const Bullet = (props: { pillar: Pillar; text: string }): ReactElement =>
         props.text.replace(/•/, ''),
     );
 
+const HeadingTwo = (props: { children?: ReactNode }) =>
+    h('h2', null, props.children);
+
 const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {
     switch (node.nodeName) {
         case 'P':
@@ -172,6 +175,8 @@ const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => 
             return node.textContent;
         case 'A':
             return h(Anchor, { href: getHref(node).withDefault(''), text: node.textContent ?? '', pillar, key });
+        case 'H2':
+            return h(HeadingTwo, { key }, Array.from(node.childNodes).map(textElement(pillar)));
         default:
             return null;
     }

--- a/src/block.ts
+++ b/src/block.ts
@@ -167,7 +167,7 @@ const textElement = (pillar: Pillar) => (node: Node): ReactNode => {
             return h(Paragraph, null, ...Array.from(node.childNodes).map(textElement(pillar)));
         case '#text':
             const text = node.textContent;
-            return text?.includes('•') ? h(Bullet, { pillar: pillar, text }) : text;
+            return text?.includes('•') ? h(Bullet, { pillar, text }) : text;
         case 'SPAN':
             return node.textContent;
         case 'A':

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { ReactNode, createElement as h, Fragment } from 'react';
+import { ReactNode, createElement as h, Fragment, ReactElement } from 'react';
 import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { from, until } from '@guardian/src-foundations/mq';
 import { palette } from '@guardian/src-foundations';
@@ -16,29 +16,29 @@ import { getPillarStyles, Pillar } from 'pillar';
 // ----- Types ----- //
 
 type Block = {
-    kind: ElementType.TEXT,
-    doc: DocumentFragment,
+    kind: ElementType.TEXT;
+    doc: DocumentFragment;
 } | {
-    kind: ElementType.IMAGE,
-    alt: string,
-    caption: string,
-    displayCredit: boolean,
-    credit: string,
-    file: string,
+    kind: ElementType.IMAGE;
+    alt: string;
+    caption: string;
+    displayCredit: boolean;
+    credit: string;
+    file: string;
 } | {
-    kind: ElementType.PULLQUOTE,
-    quote: string,
-    attribution: Option<string>,
+    kind: ElementType.PULLQUOTE;
+    quote: string;
+    attribution: Option<string>;
 } | {
-    kind: ElementType.INTERACTIVE,
-    url: string,
+    kind: ElementType.INTERACTIVE;
+    url: string;
 } | {
-    kind: ElementType.RICH_LINK,
-    url: string,
-    linkText: string,
+    kind: ElementType.RICH_LINK;
+    url: string;
+    linkText: string;
 } | {
-    kind: ElementType.TWEET,
-    content: HTMLCollection,
+    kind: ElementType.TWEET;
+    content: HTMLCollection;
 };
 
 type DocParser = (html: string) => DocumentFragment;
@@ -127,21 +127,21 @@ function getAttrs(node: Node): React.AnchorHTMLAttributes<string> {
     }
 }
 
-const Paragraph = (props: { children?: ReactNode }) =>
+const Paragraph = (props: { children?: ReactNode }): ReactElement =>
     h('p', null, props.children);
 
 const anchorStyles = (colour: string): SerializedStyles => css`
     color: ${colour};
 `;
 
-const Anchor = (props: { href: string, text: string, pillar: Pillar }) =>
+const Anchor = (props: { href: string; text: string; pillar: Pillar }): ReactElement =>
     styledH(
         'a',
         { css: anchorStyles(getPillarStyles(props.pillar).kicker), href: props.href },
         props.text,
     );
 
-const bulletStyles = (colour: string) => css`
+const bulletStyles = (colour: string): SerializedStyles => css`
     color: transparent;
 
     &::before {
@@ -154,7 +154,7 @@ const bulletStyles = (colour: string) => css`
     }
 `;
 
-const Bullet = (props: { pillar: Pillar, text: string }) =>
+const Bullet = (props: { pillar: Pillar; text: string }): ReactElement =>
     h(Fragment, null,
         styledH('span', { css: bulletStyles(getPillarStyles(props.pillar).kicker) }, '•'),
         props.text.replace(/•/, ''),
@@ -176,7 +176,7 @@ const textElement = (pillar: Pillar) => (node: Node): ReactNode => {
     }
 }
 
-const Text = (props: { doc: DocumentFragment, pillar: Pillar }) =>
+const Text = (props: { doc: DocumentFragment; pillar: Pillar }): ReactElement =>
     styledH(
         Fragment,
         null,
@@ -185,7 +185,7 @@ const Text = (props: { doc: DocumentFragment, pillar: Pillar }) =>
         ),
     );
 
-const makeCaption = (caption: string, displayCredit: boolean, credit: string) =>
+const makeCaption = (caption: string, displayCredit: boolean, credit: string): string =>
     displayCredit ? `${caption} ${credit}` : caption;
 
 interface ImageProps {
@@ -227,7 +227,7 @@ const imageStyles = css`
     }
 `;
 
-const Image = ({ url, alt, salt, caption, displayCredit, credit }: ImageProps) =>
+const Image = ({ url, alt, salt, caption, displayCredit, credit }: ImageProps): ReactElement =>
     styledH('figure', { css: imageStyles },
         h('img', {
             sizes: '100%',
@@ -268,7 +268,13 @@ const pullquoteStyles = (colour: string): SerializedStyles => css`
     }
 `;
 
-const Pullquote = (props: { quote: string, attribution: Option<string>, pillar: Pillar }) =>
+type PullquoteProps = {
+    quote: string;
+    attribution: Option<string>;
+    pillar: Pillar;
+};
+
+const Pullquote = (props: PullquoteProps): ReactElement =>
     styledH('aside', { css: pullquoteStyles(getPillarStyles(props.pillar).kicker) },
         h('blockquote', null,
             h('p', null, props.quote)
@@ -317,18 +323,18 @@ const richLinkStyles = css`
     `}
 `;
 
-const RichLink = (props: { url: string, linkText: string, pillar: Pillar }) =>
+const RichLink = (props: { url: string; linkText: string; pillar: Pillar }): ReactElement =>
     styledH('aside', { css: richLinkStyles },
         h('h1', null, props.linkText),
         h(Anchor, { href: props.url, pillar: props.pillar, text: 'Read more' }),
     );
 
-const Interactive = (props: { url: string }) =>
+const Interactive = (props: { url: string }): ReactElement =>
     h('figure', { className: 'interactive' },
         h('iframe', { src: props.url, height: 500 }, null)
     );
 
-const Tweet = (props: { content: HTMLCollection, pillar: Pillar }) =>
+const Tweet = (props: { content: HTMLCollection; pillar: Pillar }): ReactElement =>
     h('blockquote', null, ...Array.from(props.content).map(textElement(props.pillar)));
 
 const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number): ReactNode => {

--- a/src/block.ts
+++ b/src/block.ts
@@ -233,7 +233,7 @@ const Image = ({ url, alt, salt, caption, displayCredit, credit }: ImageProps): 
         h('img', {
             sizes: '100%',
             srcSet: srcset(salt)(url),
-            alt: alt,
+            alt,
             src: transformUrl(salt, url, 500),
         }),
         h('figcaption', null, makeCaption(caption, displayCredit, credit)),

--- a/src/block.ts
+++ b/src/block.ts
@@ -167,7 +167,7 @@ const Bullet = (props: { pillar: Pillar; text: string }): ReactElement =>
         props.text.replace(/•/, ''),
     );
 
-const HeadingTwo = (props: { children?: ReactNode }) =>
+const HeadingTwo = (props: { children?: ReactNode }): ReactElement =>
     h('h2', null, props.children);
 
 const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {

--- a/src/components/immersive/immersiveArticle.tsx
+++ b/src/components/immersive/immersiveArticle.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import ImmersiveHeaderImage from 'components/immersive/immersiveHeaderImage';
 import ImmersiveSeries from 'components/immersive/immersiveSeries';
 import ImmersiveHeadline from 'components/immersive/immersiveHeadline';
@@ -18,6 +18,7 @@ import { palette } from '@guardian/src-foundations';
 export interface ImmersiveArticleProps {
     capi: Content;
     imageSalt: string;
+    children: ReactNode[];
 }
 
 const MainDarkStyles = darkModeCss`
@@ -63,14 +64,13 @@ const HeaderImageStyles = css`
     }
 `;
 
-const ImmersiveArticle = ({ capi, imageSalt }: ImmersiveArticleProps): JSX.Element => {
+const ImmersiveArticle = ({ capi, imageSalt, children }: ImmersiveArticleProps): JSX.Element => {
 
-    const { fields, tags, webPublicationDate, pillarId, blocks } = capi;
+    const { fields, tags, webPublicationDate, pillarId } = capi;
     const series = articleSeries(capi);
     const pillar = pillarFromString(pillarId);
     const pillarStyles = getPillarStyles(pillar);
     const contributors = articleContributors(capi);
-    const bodyElements = blocks.body[0].elements;
     const mainImage = articleMainImage(capi);
 
     return (
@@ -103,10 +103,10 @@ const ImmersiveArticle = ({ capi, imageSalt }: ImmersiveArticleProps): JSX.Eleme
                 </header>
                 <ArticleBody
                     pillarStyles={pillarStyles}
-                    bodyElements={bodyElements}
-                    imageSalt={imageSalt}
                     className={[articleWidthStyles, DropCapStyles(pillarStyles), HeaderStyles]}
-                />
+                >
+                    {children}
+                </ArticleBody>
                 <footer css={articleWidthStyles}>
                     <Tags tags={tags}/>
                 </footer>

--- a/src/components/immersive/immersiveArticle.tsx
+++ b/src/components/immersive/immersiveArticle.tsx
@@ -31,6 +31,11 @@ const HeaderStyles = css`
         font-size: 2.6rem;
         line-height: 3.2rem;
         font-weight: 200;
+        margin-bottom: 8px;
+
+        &+p {
+            margin-top: 0;
+        }
     }
 `;
 

--- a/src/components/liveblog/liveblogBody.tsx
+++ b/src/components/liveblog/liveblogBody.tsx
@@ -15,6 +15,10 @@ const LiveBodyStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
         margin: 1em 0;
     }
 
+    figure {
+        margin: 1rem 0;
+    }
+
     ${commonArticleStyles(pillarStyles)}
     ${bulletStyles(pillarStyles.kicker)}
 

--- a/src/components/news/article.tsx
+++ b/src/components/news/article.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+// ----- Imports ----- //
+
+import React, { ReactNode } from 'react';
 
 import HeaderImage from '../shared/headerImage';
 import ArticleSeries from 'components/shared/articleSeries';
@@ -16,9 +18,13 @@ import { Keyline } from 'components/shared/keyline';
 import { isFeature, isAnalysis, articleSeries, articleContributors, articleMainImage } from 'capi';
 import { getPillarStyles, pillarFromString } from 'pillar';
 
+
+// ----- Component ----- //
+
 export interface ArticleProps {
     capi: Content;
     imageSalt: string;
+    children: ReactNode[];
 }
 
 const MainStyles = css`
@@ -49,15 +55,14 @@ const HeaderImageStyles = css`
     }
 `;
 
-const Article = ({ capi, imageSalt }: ArticleProps): JSX.Element => {
+const Article = ({ capi, imageSalt, children }: ArticleProps): JSX.Element => {
 
-    const { fields, tags, webPublicationDate, pillarId, blocks } = capi;
+    const { fields, tags, webPublicationDate, pillarId } = capi;
     const series = articleSeries(capi);
     const feature = isFeature(capi) || 'starRating' in fields;
     const pillar = pillarFromString(pillarId);
     const pillarStyles = getPillarStyles(pillar);
     const contributors = articleContributors(capi);
-    const bodyElements = blocks.body[0].elements;
     const mainImage = articleMainImage(capi);
 
     return (
@@ -95,12 +100,9 @@ const Article = ({ capi, imageSalt }: ArticleProps): JSX.Element => {
                         className={articleWidthStyles}
                     />
                 </header>
-                <ArticleBody
-                    pillarStyles={pillarStyles}
-                    bodyElements={bodyElements}
-                    imageSalt={imageSalt}
-                    className={[articleWidthStyles]}
-                />
+                <ArticleBody pillarStyles={pillarStyles} className={[articleWidthStyles]}>
+                    {children}
+                </ArticleBody>
                 <footer css={articleWidthStyles}>
                     <Tags tags={tags}/>
                 </footer>
@@ -108,5 +110,8 @@ const Article = ({ capi, imageSalt }: ArticleProps): JSX.Element => {
         </main>
     );
 }
+
+
+// ----- Exports ----- //
 
 export default Article;

--- a/src/components/opinion/opinionArticle.tsx
+++ b/src/components/opinion/opinionArticle.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import HeaderImage from 'components/shared/headerImage';
 import ArticleSeries from 'components/shared/articleSeries';
@@ -20,6 +20,7 @@ import { getPillarStyles, pillarFromString } from 'pillar';
 export interface OpinionArticleProps {
     capi: Content;
     imageSalt: string;
+    children: ReactNode[];
 }
 
 const MainStyles = css`
@@ -50,14 +51,13 @@ const HeaderImageStyles = css`
     }
 `;
 
-const OpinionArticle = ({ capi, imageSalt }: OpinionArticleProps): JSX.Element => {
+const OpinionArticle = ({ capi, imageSalt, children }: OpinionArticleProps): JSX.Element => {
 
-    const { fields, tags, webPublicationDate, pillarId, blocks } = capi;
+    const { fields, tags, webPublicationDate, pillarId } = capi;
     const series = articleSeries(capi);
     const pillar = pillarFromString(pillarId);
     const pillarStyles = getPillarStyles(pillar);
     const contributors = articleContributors(capi);
-    const bodyElements = blocks.body[0].elements;
     const mainImage = articleMainImage(capi);
 
     return (
@@ -96,12 +96,9 @@ const OpinionArticle = ({ capi, imageSalt }: OpinionArticleProps): JSX.Element =
                         className={HeaderImageStyles}
                     />
                 </header>
-                <ArticleBody
-                    pillarStyles={pillarStyles}
-                    bodyElements={bodyElements}
-                    imageSalt={imageSalt}
-                    className={[articleWidthStyles]}
-                />
+                <ArticleBody pillarStyles={pillarStyles} className={[articleWidthStyles]}>
+                    {children}
+                </ArticleBody>
                 <footer css={articleWidthStyles}>
                     <Tags tags={tags}/>
                 </footer>

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -28,6 +28,10 @@ const ArticleBodyStyles = css`
         }
     }
 
+    .interactive {
+        margin: 1rem 0;
+    }
+
     iframe {
         width: 100%;
         border: none;

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -1,21 +1,18 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import {
     sidePadding,
     darkModeCss,
-    commonArticleStyles,
     basePx,
     adStyles
 } from 'styles';
 import { palette } from '@guardian/src-foundations';
-import { from, until } from '@guardian/src-foundations/mq';
-import { render } from "renderBlocks";
-import { BlockElement } from 'capiThriftModels';
+import { from } from '@guardian/src-foundations/mq';
 import { PillarStyles } from 'pillar';
 
 const richLinkWidth = "13.75rem";
 
-const ArticleBodyStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
+const ArticleBodyStyles = css`
     position: relative;
     clear: both;
 
@@ -36,16 +33,8 @@ const ArticleBodyStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
         border: none;
     }
 
-    ${until.wide} {
-        figure:not(.interactive) {
-            margin-left: ${basePx(-1)};
-            margin-right: ${basePx(-1)};
-        }
-    }
-
     ${adStyles}
     ${sidePadding}
-    ${commonArticleStyles(pillarStyles)}
 `;
 
 const ArticleBodyDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
@@ -79,19 +68,17 @@ const ArticleBodyDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => 
 
 interface ArticleBodyProps {
     pillarStyles: PillarStyles;
-    bodyElements: BlockElement[];
-    imageSalt: string;
     className: SerializedStyles[];
+    children: ReactNode[];
 }
 
 const ArticleBody = ({
-    bodyElements,
     pillarStyles,
-    imageSalt,
     className,
+    children,
 }: ArticleBodyProps): JSX.Element =>
-    <div css={[ArticleBodyStyles(pillarStyles), ArticleBodyDarkStyles(pillarStyles), ...className]}>
-        {render(bodyElements, imageSalt).html}
+    <div css={[ArticleBodyStyles, ArticleBodyDarkStyles(pillarStyles), ...className]}>
+        {children}
     </div>
 
 export default ArticleBody;

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 import { css } from '@emotion/core';
 
 import Article from 'components/news/article';
@@ -67,7 +67,13 @@ interface BodyProps {
     capi: Content;
 }
 
-function getArticleSubtype(capi: Content): (bodyProps: BodyProps) => JSX.Element {
+interface ArticleProps {
+    imageSalt: string;
+    capi: Content;
+    children: ReactNode[];
+}
+
+function getArticleSubtype(capi: Content): FunctionComponent<ArticleProps> {
     if (pillarFromString(capi.pillarId) === Pillar.opinion) {
         return OpinionArticle;
     } else if (capi.fields.displayHint === 'immersive') {

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -72,7 +72,7 @@ function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
     }
 }
 
-type Partitioned<A, B> = { errs: A[], oks: B[] };
+type Partitioned<A, B> = { errs: A[]; oks: B[] };
 
 const partition = <A, B>(results: Result<A, B>[]): Partitioned<A, B> =>
     results.reduce(({ errs, oks }: Partitioned<A, B>, result) =>

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -72,6 +72,17 @@ function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
     }
 }
 
+type Partitioned<A, B> = { errs: A[], oks: B[] };
+
+const partition = <A, B>(results: Result<A, B>[]): Partitioned<A, B> =>
+    results.reduce(({ errs, oks }: Partitioned<A, B>, result) =>
+        result.either(
+            err => ({ errs: [ ...errs, err ], oks }),
+            ok => ({ errs, oks: [ ...oks, ok ] }),
+        ),
+        { errs: [], oks: [] },
+    );
+
 
 // ----- Exports ----- //
 
@@ -80,4 +91,5 @@ export {
     Ok,
     Err,
     fromUnsafe,
+    partition,
 };


### PR DESCRIPTION
## Why are you doing this?

I was starting to hit the limitations of the current approach in `renderBlocks`. The parsing of content from CAPI was too interleaved with the rendering layer. This was only causing minor problems server-side, but client-side we need to maintain state independent of the view and deal with updates to that state.

This splits out parsing and rendering so that they happen independent of one another. Both pieces of functionality are located in the new `block` module, written around the `Block` type. This may change later.

Currently this does not touch the liveblogs, as this PR is already pretty large. Changes there will happen in a future PR.

I've moved some styles around; I *think* everything looks OK, but please shout if you spot any problems.

## Changes

- Created new `block.ts` file to handle parsing and rendering of blocks
- Updated `page.tsx` to call the new parser and renderer
- Updated article and opinion components to use changes
- Updated ArticleBody to accept children over rendering directly
- Added a `partition` helper to Result
- Moved some global styles to specific components
- Updated handling of bullets to sidestep the need for string interpolation of HTML.
