### PR TITLE
Immersive article dark styles

### DIFF
--- a/src/components/immersive/immersiveArticle.tsx
+++ b/src/components/immersive/immersiveArticle.tsx
@@ -20,8 +20,15 @@ export interface ImmersiveArticleProps {
     imageSalt: string;
 }
 
+const MainStyles = css`
+    background: ${palette.neutral[97]};
+`;
+
+const MainDarkStyles = darkModeCss`
+    background: ${palette.neutral.darkMode};
+`;
+
 const BorderStyles = css`
-    ${darkModeCss`background: ${palette.neutral.darkMode};`}
     ${from.wide} {
         width: ${breakpoints.wide}px;
         margin: 0 auto;
@@ -38,7 +45,7 @@ const DropCapStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
         padding-right: ${basePx(1)};
         float: left;
     }
-`
+`;
 
 const HeaderImageStyles = css`
     figure {
@@ -61,7 +68,7 @@ const ImmersiveArticle = ({ capi, imageSalt }: ImmersiveArticleProps): JSX.Eleme
     const mainImage = articleMainImage(capi);
 
     return (
-        <main>
+        <main css={[MainStyles, MainDarkStyles]}>
             <article css={BorderStyles}>
                 <header>
                     <div css={articleWidthStyles}>

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -83,7 +83,7 @@ export const darkModeCss = (
     }
 `;
 
-export const linkStyle = (kicker: string): SerializedStyles => css`
+export const linkStyle = (kicker: string): string => `
     a {
         color: ${kicker};
         text-decoration: none;


### PR DESCRIPTION
## Why are you doing this?
Dark mode fixes on immersive articles. There was a white background in the wide breakpoint.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/71266406-3c9ca780-2340-11ea-9c88-7d0063cd0275.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/71266419-46260f80-2340-11ea-8a92-67137059dd16.png" width="300px" /> |
