### PR TITLE
missing byline text

### DIFF
--- a/src/components/news/articleStandfirst.tsx
+++ b/src/components/news/articleStandfirst.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { sidePadding, bulletStyles, headlineFont, darkModeCss, linkStyle } from 'styles';
-import { transform } from '../../contentTransformations';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import { PillarStyles } from 'pillar';

--- a/src/components/news/articleStandfirst.tsx
+++ b/src/components/news/articleStandfirst.tsx
@@ -59,7 +59,7 @@ const ArticleStandfirst = ({
             StandfirstDarkStyles(pillarStyles)
         ]}
     >
-        {componentFromHtml(transform(standfirst))}
+        {componentFromHtml(standfirst)}
     </div>
 
 export default ArticleStandfirst;

--- a/src/renderBlocks.ts
+++ b/src/renderBlocks.ts
@@ -179,7 +179,11 @@ function render(bodyElements: BlockElement[], imageSalt: string, ads = true): Re
 
 function componentFromHtml(html: string): ReactNode[] {
     const fragment = JSDOM.fragment(transform(html))
-    return textBlock(fragment)
+    let reactNodes = textBlock(fragment);
+    if (fragment?.lastChild?.nodeName === '#text') {
+        reactNodes.push(fragment.lastChild.textContent)
+    }
+    return reactNodes;
 }
 
 

--- a/src/renderBlocks.ts
+++ b/src/renderBlocks.ts
@@ -71,7 +71,7 @@ function textElement(node: Node): ReactNode {
 }
 
 function textBlock(fragment: DocumentFragment): ReactNode[] {
-    return Array.from(fragment.children).map(textElement);
+    return Array.from(fragment.childNodes).map(textElement);
 }
 
 function tweetBlock(fragment: DocumentFragment): ReactNode[] {
@@ -179,11 +179,7 @@ function render(bodyElements: BlockElement[], imageSalt: string, ads = true): Re
 
 function componentFromHtml(html: string): ReactNode[] {
     const fragment = JSDOM.fragment(transform(html))
-    const reactNodes = textBlock(fragment);
-    if (fragment?.lastChild?.nodeName === '#text') {
-        reactNodes.push(fragment.lastChild.textContent)
-    }
-    return reactNodes;
+    return textBlock(fragment);
 }
 
 

--- a/src/renderBlocks.ts
+++ b/src/renderBlocks.ts
@@ -179,7 +179,7 @@ function render(bodyElements: BlockElement[], imageSalt: string, ads = true): Re
 
 function componentFromHtml(html: string): ReactNode[] {
     const fragment = JSDOM.fragment(transform(html))
-    let reactNodes = textBlock(fragment);
+    const reactNodes = textBlock(fragment);
     if (fragment?.lastChild?.nodeName === '#text') {
         reactNodes.push(fragment.lastChild.textContent)
     }


### PR DESCRIPTION
## Changes

- Add the remaining text, this was getting cut off if the lastChild node was a text element..
- Removed the unnecessary transform in standfirst (as it now happens inside `componentFromHtml`)

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/71674120-58f20880-2d72-11ea-947d-554403cc4227.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/71674134-614a4380-2d72-11ea-9721-e5368c4693c6.png" width="300px" /> |
