### PR TITLE
shared and liveblog stories

### DIFF
--- a/src/components/liveblog/liveblog.stories.tsx
+++ b/src/components/liveblog/liveblog.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import LiveblogLoadMore from './liveblogLoadMore';
+import { pillarColours, Pillar } from 'pillar';
+import { withKnobs, object } from "@storybook/addon-knobs";
+
+export default { title: 'Liveblog', decorators: [withKnobs] };
+
+export const LoadMore = (): JSX.Element => <LiveblogLoadMore
+  pillarStyles={object("Pillar Styles", pillarColours[Pillar.news])}
+/>

--- a/src/components/shared/Tags.test.tsx
+++ b/src/components/shared/Tags.test.tsx
@@ -2,51 +2,15 @@ import React from 'react';
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Tags from 'components/shared/tags';
-import { Tag, TagType } from 'capiThriftModels';
 
 configure({ adapter: new Adapter() });
 
-describe('Keyline component renders as expected', () => {
-    const tagsProps: Tag[] = [{
-        id: "",
-        type: TagType.KEYWORD,
-        sectionId: "",
-        sectionName: "",
-        webTitle: "Tag title",
-        webUrl: "https://mapi.co.uk/tag",
-        apiUrl: "",
-        references: [{ id: "", type: "" }],
-        description: "",
-        bio: "",
-        bylineImageUrl: "",
-        bylineLargeImageUrl: "",
-        podcast: {
-            linkUrl: "",
-            copyright: "",
-            author: "",
-            subscriptionUrl: "",
-            explicit: false,
-            image: "",
-            categories: [],
-            podcastType: "",
-            googlePodcastsUrl: "",
-            spotifyUrl: ""
-        },
-        firstName: "",
-        lastName: "",
-        emailAddress: "",
-        twitterHandle: "",
-        activeSponsorships: [],
-        paidContentType: "",
-        paidContentCampaignColour: "",
-        rcsId: "",
-        r2ContributorId: "",
-        tagCategories: [""],
-        entityIds: [""],
-        campaignInformationType: "",
-        internalName: "",
-    }]
+const tagsProps = [{
+    webTitle: "Tag title",
+    webUrl: "https://mapi.co.uk/tag"
+}];
 
+describe('Keyline component renders as expected', () => {
     it('Renders link to tag', () => {
         const tags = shallow(<Tags tags={tagsProps} />)
         const link = tags.find('a')

--- a/src/components/shared/shared.stories.tsx
+++ b/src/components/shared/shared.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Tags from './tags';
+import { Keyline } from './keyline';
+import { Pillar } from 'pillar';
+import { withKnobs } from "@storybook/addon-knobs";
+export default { title: 'Shared', decorators: [withKnobs] };
+
+export const OpinionKeyline = (): JSX.Element => <Keyline
+    pillar={Pillar.opinion}
+    type={'article'}
+/>
+
+export const DefaultKeyline = (): JSX.Element => <Keyline
+    pillar={Pillar.news}
+    type={'article'}
+/>
+
+export const LiveblogKeyline = (): JSX.Element => <Keyline
+    pillar={Pillar.news}
+    type={'liveblog'}
+/>
+
+const tagsProps = [{
+    webTitle: "Tag title",
+    webUrl: "https://mapi.co.uk/tag"
+}];
+
+export const tags = (): JSX.Element => 
+    <Tags tags={[...tagsProps, ...tagsProps, ...tagsProps]} />
+
+ 

--- a/src/components/shared/shared.stories.tsx
+++ b/src/components/shared/shared.stories.tsx
@@ -17,7 +17,7 @@ export const DefaultKeyline = (): JSX.Element => <Keyline
 
 export const LiveblogKeyline = (): JSX.Element => <Keyline
     pillar={Pillar.news}
-    type={'liveblog'}
+    type="liveblog"
 />
 
 const tagsProps = [{

--- a/src/components/shared/shared.stories.tsx
+++ b/src/components/shared/shared.stories.tsx
@@ -7,7 +7,7 @@ export default { title: 'Shared', decorators: [withKnobs] };
 
 export const OpinionKeyline = (): JSX.Element => <Keyline
     pillar={Pillar.opinion}
-    type={'article'}
+    type="article"
 />
 
 export const DefaultKeyline = (): JSX.Element => <Keyline

--- a/src/components/shared/tags.tsx
+++ b/src/components/shared/tags.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { sidePadding, textSans, darkModeCss, basePx } from '../../styles';
 import { palette } from '@guardian/src-foundations';
-import { Tag } from 'capiThriftModels';
 
 const tagsStyles = (background: string = palette.neutral[97]): SerializedStyles => css`
     margin-top: 0;
@@ -43,7 +42,10 @@ const tagsDarkStyles = darkModeCss`
 `;
 
 interface TagsProps {
-    tags: Tag[];
+    tags: {
+        webUrl: string;
+        webTitle: string;
+    }[];
     background?: string;
 }
 


### PR DESCRIPTION
## Changes

- Liveblog story
- Shared story
- Simplify props for `Tags` component

New stories deployed to [GitHub pages](https://guardian.github.io/apps-rendering)