### PR TITLE
Remove blockquote left margin

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -118,6 +118,10 @@ export const commonArticleStyles = ({ kicker }: PillarStyles): SerializedStyles 
         ${headlineFont}
         margin: 0;
 
+        blockquote {
+            margin-left: 0;
+        }
+
         p {
             margin: 1em 0;
 


### PR DESCRIPTION
## Why are you doing this?
Blockquotes have a default margin in browsers like Chrome. The current templates design don't have this margin so this PR removes the default style.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/71673415-acfbed80-2d70-11ea-8b82-1f849b1a89bb.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/71673430-b8e7af80-2d70-11ea-8f53-8353cab7ccfe.png" width="300px" /> |
