### PR TITLE
Immersive design updates

### DIFF
--- a/src/components/immersive/immersiveArticle.tsx
+++ b/src/components/immersive/immersiveArticle.tsx
@@ -24,6 +24,15 @@ const MainDarkStyles = darkModeCss`
     background: ${palette.neutral.darkMode};
 `;
 
+const HeaderStyles = css`
+    h2 {
+        margin-top: 3.2rem;
+        font-size: 2.6rem;
+        line-height: 3.2rem;
+        font-weight: 200;
+    }
+`;
+
 const BorderStyles = css`
     ${from.wide} {
         width: ${breakpoints.wide}px;
@@ -32,7 +41,8 @@ const BorderStyles = css`
 `;
 
 const DropCapStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
-    p:first-of-type::first-letter {
+    p:first-child::first-letter,
+    .section-rule + p::first-letter {
         color: ${pillarStyles.kicker};
         font-weight: 100;
         font-style: normal;
@@ -95,7 +105,7 @@ const ImmersiveArticle = ({ capi, imageSalt }: ImmersiveArticleProps): JSX.Eleme
                     pillarStyles={pillarStyles}
                     bodyElements={bodyElements}
                     imageSalt={imageSalt}
-                    className={[articleWidthStyles, DropCapStyles(pillarStyles)]}
+                    className={[articleWidthStyles, DropCapStyles(pillarStyles), HeaderStyles]}
                 />
                 <footer css={articleWidthStyles}>
                     <Tags tags={tags}/>

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -90,7 +90,7 @@ const ArticleBody = ({
     imageSalt,
     className,
 }: ArticleBodyProps): JSX.Element =>
-    <div css={[...className, ArticleBodyStyles(pillarStyles), ArticleBodyDarkStyles(pillarStyles)]}>
+    <div css={[ArticleBodyStyles(pillarStyles), ArticleBodyDarkStyles(pillarStyles), ...className]}>
         {render(bodyElements, imageSalt).html}
     </div>
 


### PR DESCRIPTION
## Why are you doing this?

These styles move the immersive article designs closer to dotcom and the current templates.

## Changes

- Drop cap styles after section-rules
- Style first-child letters not first-of-type (see gu.com/world/2020/jan/03/visual-guide-airstrike-that-killed-qassam-suleimani-us-iran) 
- Special immersive headline styles

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/71730780-f87ace00-2e3a-11ea-8b59-7dfbe44f9cea.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/71730784-fe70af00-2e3a-11ea-8627-f76668f887bf.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/71730790-04ff2680-2e3b-11ea-88a9-ab594a8a1ed7.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/71730800-0cbecb00-2e3b-11ea-820b-be86b3ddd303.png" width="300px" /> |


