### PR TITLE
Set height on images

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -26,10 +26,8 @@ type Block = {
     displayCredit: boolean;
     credit: string;
     file: string;
-    typeData?: {
-        width: number;
-        height: number;
-    };
+    width: number;
+    height: number;
 } | {
     kind: ElementType.PULLQUOTE;
     quote: string;
@@ -72,15 +70,15 @@ const parser = (docParser: DocParser) => (block: BlockElement): Result<string, B
             const masterAsset = block.assets.find(asset => asset.typeData.isMaster);
             const { alt, caption, displayCredit, credit } = block.imageTypeData;
             const imageBlock: Option<Result<string, Block>> = fromNullable(masterAsset)
-                .map(asset => asset.file)
-                .map(file => new Ok({
+                .map(asset => new Ok({
                     kind: ElementType.IMAGE,
                     alt,
                     caption,
                     displayCredit,
                     credit,
-                    file,
-                    typeData: masterAsset?.typeData
+                    file: asset.file,
+                    width: asset.typeData.width,
+                    height: asset.typeData.height,
                 }));
 
             return imageBlock.withDefault(new Err('I couldn\'t find a master asset'));
@@ -219,10 +217,8 @@ interface ImageProps {
     caption: string;
     displayCredit: boolean;
     credit: string;
-    typeData?: {
-        width: number;
-        height: number;
-    };
+    width: number;
+    height: number;
 }
 
 const imageStyles = css`
@@ -255,11 +251,11 @@ const imageStyles = css`
     }
 `;
 
-const Image = (imageProps: ImageProps): ReactElement => {
-    const { url, alt, salt, caption, displayCredit, credit, typeData } = imageProps;
+const Image = (props: ImageProps): ReactElement => {
+    const { url, alt, salt, caption, displayCredit, credit, width, height } = props;
     return styledH('figure', { css: imageStyles },
         h('img', {
-            css: imageRatioStyles("100vw", typeData?.width ?? 5, typeData?.height ?? 3),
+            css: imageRatioStyles("100vw", width ?? 5, height ?? 3),
             sizes: '100%',
             srcSet: srcset(salt)(url),
             alt,
@@ -379,8 +375,8 @@ const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number)
             return text(block.doc, pillar);
 
         case ElementType.IMAGE:
-            const { file, alt, caption, displayCredit, credit, typeData } = block;
-            const props = { url: file, alt, salt, caption, displayCredit, credit, key, typeData };
+            const { file, alt, caption, displayCredit, credit, width, height } = block;
+            const props = { url: file, alt, salt, caption, displayCredit, credit, key, width, height };
             return h(Image, props);
 
         case ElementType.PULLQUOTE:

--- a/src/block.ts
+++ b/src/block.ts
@@ -29,7 +29,7 @@ type Block = {
     typeData?: {
         width: number;
         height: number;
-    }
+    };
 } | {
     kind: ElementType.PULLQUOTE;
     quote: string;
@@ -222,7 +222,7 @@ interface ImageProps {
     typeData?: {
         width: number;
         height: number;
-    }
+    };
 }
 
 const imageStyles = css`
@@ -255,8 +255,9 @@ const imageStyles = css`
     }
 `;
 
-const Image = ({ url, alt, salt, caption, displayCredit, credit, typeData }: ImageProps): ReactElement =>
-    styledH('figure', { css: imageStyles },
+const Image = (imageProps: ImageProps): ReactElement => {
+    const { url, alt, salt, caption, displayCredit, credit, typeData } = imageProps;
+    return styledH('figure', { css: imageStyles },
         h('img', {
             css: imageRatioStyles("100vw", typeData?.width ?? 5, typeData?.height ?? 3),
             sizes: '100%',
@@ -266,6 +267,7 @@ const Image = ({ url, alt, salt, caption, displayCredit, credit, typeData }: Ima
         }),
         h('figcaption', null, makeCaption(caption, displayCredit, credit)),
     );
+}
 
 const pullquoteStyles = (colour: string): SerializedStyles => css`
     font-weight: 200;
@@ -378,7 +380,8 @@ const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number)
 
         case ElementType.IMAGE:
             const { file, alt, caption, displayCredit, credit, typeData } = block;
-            return h(Image, { url: file, alt, salt, caption, displayCredit, credit, key, typeData });
+            const props = { url: file, alt, salt, caption, displayCredit, credit, key, typeData };
+            return h(Image, props);
 
         case ElementType.PULLQUOTE:
             const { quote, attribution } = block;

--- a/src/block.ts
+++ b/src/block.ts
@@ -376,8 +376,17 @@ const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number)
 
         case ElementType.IMAGE:
             const { file, alt, caption, displayCredit, credit, width, height } = block;
-            const props = { url: file, alt, salt, caption, displayCredit, credit, key, width, height };
-            return h(Image, props);
+            return h(Image, {
+                url: file,
+                alt,
+                salt,
+                caption,
+                displayCredit,
+                credit,
+                key,
+                width,
+                height
+            });
 
         case ElementType.PULLQUOTE:
             const { quote, attribution } = block;

--- a/src/block.ts
+++ b/src/block.ts
@@ -11,6 +11,7 @@ import { Option, fromNullable, Some, None } from 'types/option';
 import { srcset, transformUrl } from 'asset';
 import { basePx, icons, headlineFont, darkModeCss, textSans } from 'styles';
 import { getPillarStyles, Pillar } from 'pillar';
+import { imageRatioStyles } from 'components/blocks/image';
 
 
 // ----- Types ----- //
@@ -25,6 +26,10 @@ type Block = {
     displayCredit: boolean;
     credit: string;
     file: string;
+    typeData?: {
+        width: number;
+        height: number;
+    }
 } | {
     kind: ElementType.PULLQUOTE;
     quote: string;
@@ -75,6 +80,7 @@ const parser = (docParser: DocParser) => (block: BlockElement): Result<string, B
                     displayCredit,
                     credit,
                     file,
+                    typeData: masterAsset?.typeData
                 }));
 
             return imageBlock.withDefault(new Err('I couldn\'t find a master asset'));
@@ -213,6 +219,10 @@ interface ImageProps {
     caption: string;
     displayCredit: boolean;
     credit: string;
+    typeData?: {
+        width: number;
+        height: number;
+    }
 }
 
 const imageStyles = css`
@@ -245,9 +255,10 @@ const imageStyles = css`
     }
 `;
 
-const Image = ({ url, alt, salt, caption, displayCredit, credit }: ImageProps): ReactElement =>
+const Image = ({ url, alt, salt, caption, displayCredit, credit, typeData }: ImageProps): ReactElement =>
     styledH('figure', { css: imageStyles },
         h('img', {
+            css: imageRatioStyles("100vw", typeData?.width ?? 5, typeData?.height ?? 3),
             sizes: '100%',
             srcSet: srcset(salt)(url),
             alt,
@@ -366,8 +377,8 @@ const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number)
             return text(block.doc, pillar);
 
         case ElementType.IMAGE:
-            const { file, alt, caption, displayCredit, credit } = block;
-            return h(Image, { url: file, alt, salt, caption, displayCredit, credit, key });
+            const { file, alt, caption, displayCredit, credit, typeData } = block;
+            return h(Image, { url: file, alt, salt, caption, displayCredit, credit, key, typeData });
 
         case ElementType.PULLQUOTE:
             const { quote, attribution } = block;

--- a/src/components/blocks/image.ts
+++ b/src/components/blocks/image.ts
@@ -2,7 +2,7 @@
 
 import { createElement as h, ReactNode } from 'react';
 import * as AssetUtils from 'asset';
-import { css, jsx as styledH } from '@emotion/core';
+import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import { BlockElement } from 'capiThriftModels';
 import { from } from '@guardian/src-foundations/mq';
@@ -20,7 +20,7 @@ interface Image {
 
 // ----- Functions ----- //
 
-const imageRatioStyles = (sizes = "100vw", width: number, height: number) => css`
+const imageRatioStyles = (sizes = "100vw", width: number, height: number): SerializedStyles => css`
         --size: ${sizes};
         height: calc(var(--size) * ${height / width});
         background: ${palette.neutral[97]};

--- a/src/components/blocks/image.ts
+++ b/src/components/blocks/image.ts
@@ -6,6 +6,7 @@ import { css, jsx as styledH } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import { BlockElement } from 'capiThriftModels';
 import { from } from '@guardian/src-foundations/mq';
+import { fromNullable } from 'types/option';
 
 // ----- Setup ----- //
 
@@ -19,26 +20,35 @@ interface Image {
 
 // ----- Functions ----- //
 
+const imageRatioStyles = (sizes = "100vw", width: number, height: number) => css`
+        --size: ${sizes};
+        height: calc(var(--size) * ${height / width});
+        background: ${palette.neutral[97]};
+
+        ${from.wide} {
+            height: calc(620px * ${height / width});
+        }
+    `
+
 const isImage = (elem: BlockElement): boolean =>
   elem.type === 'image';
 
 const element = (sizes: string) => 
-    (alt: string, assets: AssetUtils.Asset[], salt: string): ReactNode =>
-        styledH('img', {
-            css: css`
-                --ratio: ${sizes};
-                height: calc(var(--ratio) * 0.58);
-                background: ${palette.neutral[97]};
+    (alt: string, assets: AssetUtils.Asset[], salt: string): ReactNode => {
+        const masterAsset = assets.find(asset => asset.typeData.isMaster);
+        const aspectRatio: number[] = fromNullable(masterAsset)
+            .map(asset => [asset.typeData.height, asset.typeData.width])
+            .withDefault([3, 5])
+        const [height, width] = aspectRatio;
 
-                ${from.wide} {
-                    height: calc(620px * 0.58);
-                }
-            `,
-            sizes,
-            srcSet: AssetUtils.toSrcset(salt, assets).withDefault(''),
-            alt,
-            src: AssetUtils.toUrl(salt, assets[0]),
-        });
+            return styledH('img', {
+                css: imageRatioStyles(sizes, width, height),
+                sizes,
+                srcSet: AssetUtils.toSrcset(salt, assets).withDefault(''),
+                alt,
+                src: AssetUtils.toUrl(salt, assets[0]),
+            });
+    }
 
 const immersiveImageElement = element('calc(80vh * 5/3)');
 const imageElement = element('100vw');
@@ -61,4 +71,5 @@ export {
     imageBlock,
     imageElement,
     immersiveImageElement,
+    imageRatioStyles,
 };

--- a/src/components/blocks/image.ts
+++ b/src/components/blocks/image.ts
@@ -5,6 +5,7 @@ import * as AssetUtils from 'asset';
 import { css, jsx as styledH } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import { BlockElement } from 'capiThriftModels';
+import { from } from '@guardian/src-foundations/mq';
 
 // ----- Setup ----- //
 
@@ -24,7 +25,15 @@ const isImage = (elem: BlockElement): boolean =>
 const element = (sizes: string) => 
     (alt: string, assets: AssetUtils.Asset[], salt: string): ReactNode =>
         styledH('img', {
-            css: css`height: calc(100vw * 3/4); background: ${palette.neutral[97]}`,
+            css: css`
+                --ratio: ${sizes};
+                height: calc(var(--ratio) * 0.58);
+                background: ${palette.neutral[97]};
+
+                ${from.wide} {
+                    height: calc(620px * 0.58);
+                }
+            `,
             sizes,
             srcSet: AssetUtils.toSrcset(salt, assets).withDefault(''),
             alt,
@@ -32,7 +41,7 @@ const element = (sizes: string) =>
         });
 
 const immersiveImageElement = element('calc(80vh * 5/3)');
-const imageElement = element('100%');
+const imageElement = element('100vw');
 
 function imageBlock(image: Image, assets: AssetUtils.Asset[], salt: string): ReactNode {
 

--- a/src/components/blocks/image.ts
+++ b/src/components/blocks/image.ts
@@ -2,6 +2,8 @@
 
 import { createElement as h, ReactNode } from 'react';
 import * as AssetUtils from 'asset';
+import { css, jsx as styledH } from '@emotion/core';
+import { palette } from '@guardian/src-foundations';
 import { BlockElement } from 'capiThriftModels';
 
 // ----- Setup ----- //
@@ -21,7 +23,8 @@ const isImage = (elem: BlockElement): boolean =>
 
 const element = (sizes: string) => 
     (alt: string, assets: AssetUtils.Asset[], salt: string): ReactNode =>
-        h('img', {
+        styledH('img', {
+            css: css`height: calc(100vw * 3/4); background: ${palette.neutral[97]}`,
             sizes,
             srcSet: AssetUtils.toSrcset(salt, assets).withDefault(''),
             alt,


### PR DESCRIPTION
## Why are you doing this?
Set a min height on images (with a background colour) to avoid content jumping when the images load.

This is not the same ratio as before. e.g. removing these styles will show a smaller image... maybe this calc needs changing or we pass another height param to the fastly image resizer?