### PR TITLE
Article Type - Encapsulate Pillar and Layout

### DIFF
--- a/src/article.ts
+++ b/src/article.ts
@@ -1,0 +1,79 @@
+// ----- Imports ----- //
+
+import { Pillar, pillarFromString } from 'pillar';
+import { Content } from 'capiThriftModels';
+import { isFeature, isAnalysis, isImmersive, isReview } from 'capi';
+
+
+// ----- Types ----- //
+
+const enum Layout {
+    Default,
+    Immersive,
+    Feature,
+    Review,
+    Analysis,
+    Opinion,
+    Liveblog,
+    Gallery,
+    Interactive,
+    Picture,
+    Video,
+    Audio,
+}
+
+type Article = {
+    layout: Layout;
+    pillar: Pillar;
+};
+
+
+// ----- Functions ----- //
+
+function layoutFromCapi(content: Content): Layout {
+    switch (content.type) {
+        case 'article':
+            if (pillarFromString(content.pillarId) === Pillar.opinion) {
+                return Layout.Opinion;
+            } else if (isImmersive(content)) {
+                return Layout.Immersive;
+            } else if (isFeature(content)) {
+                return Layout.Feature;
+            } else if (isReview(content)) {
+                return Layout.Review;
+            } else if (isAnalysis(content)) {
+                return Layout.Analysis;
+            }
+            return Layout.Default;
+        case 'liveblog':
+            return Layout.Liveblog;
+        case 'gallery':
+            return Layout.Gallery;
+        case 'interactive':
+            return Layout.Interactive;
+        case 'picture':
+            return Layout.Picture;
+        case 'video':
+            return Layout.Video;
+        case 'audio':
+            return Layout.Audio;
+        default:
+            return Layout.Default;
+    }    
+}
+
+function fromCapi(content: Content): Article {
+    return {
+        layout: layoutFromCapi(content),
+        pillar: pillarFromString(content.pillarId),
+    };
+}
+
+
+// ----- Exports ----- //
+
+export {
+    Layout,
+    Article,
+    fromCapi,
+};

--- a/src/article.ts
+++ b/src/article.ts
@@ -8,7 +8,7 @@ import { isFeature, isAnalysis, isImmersive, isReview } from 'capi';
 // ----- Types ----- //
 
 const enum Layout {
-    Default,
+    Standard,
     Immersive,
     Feature,
     Review,
@@ -44,7 +44,7 @@ function layoutFromCapi(content: Content): Layout {
             } else if (isAnalysis(content)) {
                 return Layout.Analysis;
             }
-            return Layout.Default;
+            return Layout.Standard;
         case 'liveblog':
             return Layout.Liveblog;
         case 'gallery':
@@ -58,7 +58,7 @@ function layoutFromCapi(content: Content): Layout {
         case 'audio':
             return Layout.Audio;
         default:
-            return Layout.Default;
+            return Layout.Standard;
     }    
 }
 

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -112,8 +112,14 @@ interface Contributor {
 const tagsOfType = (type_: string) => (tags: Tag[]): Tag[] =>
     tags.filter((tag: Tag) => tag.type === type_);
 
+const isImmersive = (content: Content): boolean =>
+    content.fields.displayHint === 'immersive';
+
 const isFeature = (content: Content): boolean =>
     content.tags.some(tag => tag.id === 'tone/features');
+
+const isReview = (content: Content): boolean =>
+    'starRating' in content.fields;
 
 const isAnalysis = (content: Content): boolean =>
     content.tags.some(tag => tag.id === 'tone/analysis');
@@ -161,12 +167,14 @@ export {
     Contributor,
     ErrorStatus as CapiError,
     getContent,
+    isImmersive,
     isFeature,
+    isReview,
+    isAnalysis,
     isSingleContributor,
     articleSeries,
     articleContributors,
     articleMainImage,
     capiEndpoint,
     includesTweets,
-    isAnalysis,
 };

--- a/src/components/immersive/immersiveArticle.tsx
+++ b/src/components/immersive/immersiveArticle.tsx
@@ -71,7 +71,12 @@ const HeaderImageStyles = css`
     }
 `;
 
-const ImmersiveArticle = ({ capi, imageSalt, article, children }: ImmersiveArticleProps): JSX.Element => {
+function ImmersiveArticle({
+    capi,
+    imageSalt,
+    article,
+    children,
+}: ImmersiveArticleProps): JSX.Element {
 
     const { fields, tags, webPublicationDate } = capi;
     const series = articleSeries(capi);

--- a/src/components/immersive/immersiveArticle.tsx
+++ b/src/components/immersive/immersiveArticle.tsx
@@ -12,12 +12,14 @@ import { from, breakpoints } from '@guardian/src-foundations/mq';
 import { css, SerializedStyles } from '@emotion/core';
 import { Keyline } from 'components/shared/keyline';
 import { articleSeries, articleContributors, articleMainImage } from 'capi';
-import { getPillarStyles, pillarFromString, PillarStyles } from 'pillar';
+import { getPillarStyles, PillarStyles } from 'pillar';
 import { palette } from '@guardian/src-foundations';
+import { Article } from 'article';
 
 export interface ImmersiveArticleProps {
     capi: Content;
     imageSalt: string;
+    article: Article;
     children: ReactNode[];
 }
 
@@ -69,12 +71,11 @@ const HeaderImageStyles = css`
     }
 `;
 
-const ImmersiveArticle = ({ capi, imageSalt, children }: ImmersiveArticleProps): JSX.Element => {
+const ImmersiveArticle = ({ capi, imageSalt, article, children }: ImmersiveArticleProps): JSX.Element => {
 
-    const { fields, tags, webPublicationDate, pillarId } = capi;
+    const { fields, tags, webPublicationDate } = capi;
     const series = articleSeries(capi);
-    const pillar = pillarFromString(pillarId);
-    const pillarStyles = getPillarStyles(pillar);
+    const pillarStyles = getPillarStyles(article.pillar);
     const contributors = articleContributors(capi);
     const mainImage = articleMainImage(capi);
 
@@ -98,7 +99,7 @@ const ImmersiveArticle = ({ capi, imageSalt, children }: ImmersiveArticleProps):
                             byline={fields.byline}
                         />
                     </div>
-                    <Keyline pillar={pillar} type={'article'}/>
+                    <Keyline article={article}/>
                     <ImmersiveByline
                         pillarStyles={pillarStyles}
                         publicationDate={webPublicationDate}

--- a/src/components/liveblog/liveblogArticle.tsx
+++ b/src/components/liveblog/liveblogArticle.tsx
@@ -14,7 +14,8 @@ import { css, SerializedStyles } from '@emotion/core'
 import { palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { articleMainImage, articleSeries, articleContributors } from 'capi';
-import { PillarStyles, pillarFromString, getPillarStyles } from 'pillar';
+import { PillarStyles, getPillarStyles } from 'pillar';
+import { Article } from 'article';
 
 const LiveblogArticleStyles: SerializedStyles = css`
     background: ${palette.neutral[97]};
@@ -47,15 +48,15 @@ const HeaderImageStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
 
 interface LiveblogArticleProps {
     capi: Content;
+    article: Article;
     imageSalt: string;
 }
 
-const LiveblogArticle = ({ capi, imageSalt }: LiveblogArticleProps): JSX.Element => {
+const LiveblogArticle = ({ capi, article, imageSalt }: LiveblogArticleProps): JSX.Element => {
 
-    const { fields, tags, webPublicationDate, pillarId, blocks } = capi;
+    const { fields, tags, webPublicationDate, blocks } = capi;
     const series = articleSeries(capi);
-    const pillar = pillarFromString(pillarId);
-    const pillarStyles = getPillarStyles(pillar);
+    const pillarStyles = getPillarStyles(article.pillar);
     const contributors = articleContributors(capi);
     const bodyElements = blocks.body;
     const image = articleMainImage(capi);
@@ -69,7 +70,7 @@ const LiveblogArticle = ({ capi, imageSalt }: LiveblogArticleProps): JSX.Element
                 <LiveblogByline
                     byline={fields.bylineHtml}
                     pillarStyles={pillarStyles}
-                    pillar={pillar}
+                    article={article}
                     publicationDate={webPublicationDate}
                     contributors={contributors}
                     imageSalt={imageSalt}

--- a/src/components/liveblog/liveblogByline.tsx
+++ b/src/components/liveblog/liveblogByline.tsx
@@ -9,8 +9,9 @@ import { Contributor } from '../../capi';
 import { formatDate } from 'date';
 import Avatar from 'components/shared/avatar';
 import LeftColumn from 'components/shared/leftColumn';
-import { PillarStyles, Pillar } from 'pillar';
+import { PillarStyles } from 'pillar';
 import { componentFromHtml } from 'renderBlocks';
+import { Article } from 'article';
 
 const LiveblogBylineStyles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
     background: ${liveblogBackground};
@@ -51,7 +52,7 @@ interface LiveblogBylineProps {
     pillarStyles: PillarStyles;
     publicationDate: string;
     contributors: Contributor[];
-    pillar: Pillar;
+    article: Article;
     imageSalt: string;
 }
 
@@ -60,13 +61,13 @@ const LiveblogByline = ({
     pillarStyles,
     publicationDate,
     contributors,
-    pillar,
+    article,
     imageSalt
 }: LiveblogBylineProps): JSX.Element => {
     
     return (
         <div css={[LiveblogBylineStyles(pillarStyles)]}>
-            <Keyline pillar={pillar} type={'liveblog'}/>
+            <Keyline article={article}/>
             <LeftColumn>
                 <Avatar
                     contributors={contributors}

--- a/src/components/news/article.tsx
+++ b/src/components/news/article.tsx
@@ -15,8 +15,9 @@ import { palette } from '@guardian/src-foundations';
 import { from, breakpoints } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/core';
 import { Keyline } from 'components/shared/keyline';
-import { isFeature, isAnalysis, articleSeries, articleContributors, articleMainImage } from 'capi';
-import { getPillarStyles, pillarFromString } from 'pillar';
+import { isAnalysis, articleSeries, articleContributors, articleMainImage } from 'capi';
+import { getPillarStyles } from 'pillar';
+import { Layout, Article } from 'article';
 
 
 // ----- Component ----- //
@@ -24,6 +25,7 @@ import { getPillarStyles, pillarFromString } from 'pillar';
 export interface ArticleProps {
     capi: Content;
     imageSalt: string;
+    article: Article;
     children: ReactNode[];
 }
 
@@ -55,13 +57,12 @@ const HeaderImageStyles = css`
     }
 `;
 
-const Article = ({ capi, imageSalt, children }: ArticleProps): JSX.Element => {
+const Article = ({ capi, imageSalt, article, children }: ArticleProps): JSX.Element => {
 
-    const { fields, tags, webPublicationDate, pillarId } = capi;
+    const { fields, tags, webPublicationDate } = capi;
     const series = articleSeries(capi);
-    const feature = isFeature(capi) || 'starRating' in fields;
-    const pillar = pillarFromString(pillarId);
-    const pillarStyles = getPillarStyles(pillar);
+    const feature = article.layout === Layout.Feature || article.layout === Layout.Review;
+    const pillarStyles = getPillarStyles(article.pillar);
     const contributors = articleContributors(capi);
     const mainImage = articleMainImage(capi);
 
@@ -90,7 +91,7 @@ const Article = ({ capi, imageSalt, children }: ArticleProps): JSX.Element => {
                             className={articleWidthStyles}
                         />
                     </div>
-                    <Keyline pillar={pillar} type={'article'}/>
+                    <Keyline article={article}/>
                     <ArticleByline
                         byline={fields.bylineHtml}
                         pillarStyles={pillarStyles}

--- a/src/components/opinion/opinionArticle.tsx
+++ b/src/components/opinion/opinionArticle.tsx
@@ -53,7 +53,7 @@ const HeaderImageStyles = css`
     }
 `;
 
-const OpinionArticle = ({ capi, imageSalt, article, children }: OpinionArticleProps): JSX.Element => {
+function OpinionArticle({ capi, imageSalt, article, children }: OpinionArticleProps): JSX.Element {
 
     const { fields, tags, webPublicationDate } = capi;
     const series = articleSeries(capi);

--- a/src/components/opinion/opinionArticle.tsx
+++ b/src/components/opinion/opinionArticle.tsx
@@ -15,11 +15,13 @@ import { from, breakpoints } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/core';
 import { Keyline } from 'components/shared/keyline';
 import { articleSeries, articleContributors, articleMainImage } from 'capi';
-import { getPillarStyles, pillarFromString } from 'pillar';
+import { getPillarStyles } from 'pillar';
+import { Article } from 'article';
 
 export interface OpinionArticleProps {
     capi: Content;
     imageSalt: string;
+    article: Article;
     children: ReactNode[];
 }
 
@@ -51,12 +53,11 @@ const HeaderImageStyles = css`
     }
 `;
 
-const OpinionArticle = ({ capi, imageSalt, children }: OpinionArticleProps): JSX.Element => {
+const OpinionArticle = ({ capi, imageSalt, article, children }: OpinionArticleProps): JSX.Element => {
 
-    const { fields, tags, webPublicationDate, pillarId } = capi;
+    const { fields, tags, webPublicationDate } = capi;
     const series = articleSeries(capi);
-    const pillar = pillarFromString(pillarId);
-    const pillarStyles = getPillarStyles(pillar);
+    const pillarStyles = getPillarStyles(article.pillar);
     const contributors = articleContributors(capi);
     const mainImage = articleMainImage(capi);
 
@@ -77,7 +78,7 @@ const OpinionArticle = ({ capi, imageSalt, children }: OpinionArticleProps): JSX
                         imageSalt={imageSalt}
                         className={articleWidthStyles}
                     />
-                    <Keyline pillar={pillar} type={'article'}/>
+                    <Keyline article={article}/>
                     <ArticleStandfirst
                             standfirst={fields.standfirst}
                             feature={true}

--- a/src/components/shared/Keyline.test.tsx
+++ b/src/components/shared/Keyline.test.tsx
@@ -3,24 +3,28 @@ import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Keyline } from 'components/shared/keyline';
 import { Pillar } from 'pillar';
+import { Layout } from 'article';
 
 configure({ adapter: new Adapter() });
 
 describe('Keyline component renders as expected', () => {
     it('Renders styles for liveblogs', () => {
-        const keyline = shallow(<Keyline pillar={Pillar.opinion} type="liveblog"/>)
+        const article = { pillar: Pillar.opinion, layout: Layout.Liveblog };
+        const keyline = shallow(<Keyline article={article}/>);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
         expect(keyline.props().css.styles).toContain("opacity:.4;")
     })
 
     it('Renders styles for opinion pillar articles', () => {
-        const keyline = shallow(<Keyline pillar={Pillar.opinion} type="article"/>)
+        const article = { pillar: Pillar.opinion, layout: Layout.Default };
+        const keyline = shallow(<Keyline article={article}/>);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
         expect(keyline.props().css.styles).toContain("height:24px;")
     })
 
     it('Renders styles for news pillar articles', () => {
-        const keyline = shallow(<Keyline pillar={Pillar.news} type="article"/>)
+        const article = { pillar: Pillar.news, layout: Layout.Default };
+        const keyline = shallow(<Keyline article={article}/>);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
     })
 });

--- a/src/components/shared/Keyline.test.tsx
+++ b/src/components/shared/Keyline.test.tsx
@@ -16,14 +16,14 @@ describe('Keyline component renders as expected', () => {
     })
 
     it('Renders styles for opinion pillar articles', () => {
-        const article = { pillar: Pillar.opinion, layout: Layout.Default };
+        const article = { pillar: Pillar.opinion, layout: Layout.Standard };
         const keyline = shallow(<Keyline article={article}/>);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
         expect(keyline.props().css.styles).toContain("height:24px;")
     })
 
     it('Renders styles for news pillar articles', () => {
-        const article = { pillar: Pillar.news, layout: Layout.Default };
+        const article = { pillar: Pillar.news, layout: Layout.Standard };
         const keyline = shallow(<Keyline article={article}/>);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
     })

--- a/src/components/shared/keyline.tsx
+++ b/src/components/shared/keyline.tsx
@@ -4,6 +4,7 @@ import { darkModeCss, wideContentWidth, wideColumnWidth, baseMultiply } from 'st
 import { palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { Pillar } from 'pillar';
+import { Article, Layout } from 'article';
 
 const BaseStyles = css`
     height: 12px;
@@ -43,15 +44,15 @@ const KeylineDarkStyles = darkModeCss`
 `;
 
 
-export const Keyline = ({ pillar, type }: { pillar: Pillar; type: string }): JSX.Element => {
-    const SelectedKeylineStyles = ((pillar, type): SerializedStyles => {
-        if (type === 'liveblog') return KeylineLiveblogStyles;
+export const Keyline = ({ article: { pillar, layout } }: { article: Article }): JSX.Element => {
+    const SelectedKeylineStyles = ((pillar, layout): SerializedStyles => {
+        if (layout === Layout.Liveblog) return KeylineLiveblogStyles;
         switch (pillar) {
             case Pillar.opinion:
                 return KeylineOpinionStyles;
             default:
                 return KeylineNewsStyles;
-        }})(pillar, type);
+        }})(pillar, layout);
     
     return <hr css={[BaseStyles, SelectedKeylineStyles, KeylineDarkStyles]} />
 }

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -3,7 +3,7 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 import { css } from '@emotion/core';
 
-import Article from 'components/news/article';
+import ArticleComponent from 'components/news/article';
 import LiveblogArticle from 'components/liveblog/liveblogArticle';
 import OpinionArticle from 'components/opinion/opinionArticle';
 import ImmersiveArticle from 'components/immersive/immersiveArticle';
@@ -17,6 +17,7 @@ import { renderAll, parseAll } from 'block';
 import { JSDOM } from 'jsdom';
 import { partition } from 'types/result';
 import { insertAdPlaceholders } from 'ads';
+import { Article, fromCapi } from 'article';
 
 
 // ----- Components ----- //
@@ -70,6 +71,7 @@ interface BodyProps {
 interface ArticleProps {
     imageSalt: string;
     capi: Content;
+    article: Article;
     children: ReactNode[];
 }
 
@@ -80,26 +82,27 @@ function getArticleSubtype(capi: Content): FunctionComponent<ArticleProps> {
         return ImmersiveArticle;
     }
   
-    return Article;
+    return ArticleComponent;
   }
 
 function ArticleBody({ capi, imageSalt }: BodyProps): React.ReactElement {
+    const article = fromCapi(capi);
+
     switch (capi.type) {
         case 'article':
             const parsedBlocks = parseAll(JSDOM.fragment)(capi.blocks.body[0].elements);
             const body = partition(parsedBlocks).oks;
-            const pillar = pillarFromString(capi.pillarId);
             const Component = getArticleSubtype(capi);
 
             return <>
-                <Component capi={capi} imageSalt={imageSalt}>
-                    {insertAdPlaceholders(renderAll(imageSalt)(pillar, body))}
+                <Component capi={capi} imageSalt={imageSalt} article={article}>
+                    {insertAdPlaceholders(renderAll(imageSalt)(article.pillar, body))}
                 </Component>
                 <script src="/assets/article.js"></script>
             </>;
         case 'liveblog':
             return <>
-                <LiveblogArticle capi={capi} imageSalt={imageSalt} />
+                <LiveblogArticle capi={capi} article={article} imageSalt={imageSalt} />
                 <script src="/assets/liveblog.js"></script>
             </>;
         default:


### PR DESCRIPTION
## Why are you doing this?

I think all articles are described by two key pieces of information. First is the `Pillar`, which we have an existing type for. Second is a less well-defined concept that I've called "layout". This is basically a description of the various ways articles vary in design based on a number of factors:

- Is it an opinion piece?
- Is it an analysis?
- Does it have the feature tone?
- Is it a liveblog?
- Does it have the 'immersive' `displayHint`?

etc.

I've attempted to define a sum type called `Layout` to capture these differences, which can be derived from the fields available in the CAPI response.

A given article will fall in the set created by taking the product of `Pillar` and `Layout`, as any article layout can theoretically fall under any of the Pillars. Therefore I've created the `Article` product type to describe this:

```ts
type Article = {
    layout: Layout;
    pillar: Pillar;
};
```

FYI @gtrufitt @oliverlloyd 

## Changes

- Added `Article` product type, encapsulates `Pillar` and `Layout`
- All articles can now use this product type
- `Layout` is derived from a range of CAPI fields
- Added further CAPI helpers to check if an article is a 'review' or an 'immersive'
