### PR TITLE
Hex to rgba function

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -12,6 +12,7 @@ import { srcset, transformUrl } from 'asset';
 import { basePx, icons, headlineFont, darkModeCss, textSans } from 'styles';
 import { getPillarStyles, Pillar } from 'pillar';
 import { imageRatioStyles } from 'components/blocks/image';
+import { hexToRGBA } from 'lib';
 
 
 // ----- Types ----- //
@@ -139,7 +140,7 @@ const anchorStyles = (colour: string): SerializedStyles => css`
     color: ${colour};
     text-decoration: none;
     padding-bottom: 0.15em;
-    background-image: linear-gradient(${colour} 0%, ${colour} 100%);
+    background-image: linear-gradient(${hexToRGBA(colour, .4)} 0%, ${hexToRGBA(colour, .4)} 100%);
     background-repeat: repeat-x;
     background-size: 1px 1px;
     background-position: 0 bottom;

--- a/src/block.ts
+++ b/src/block.ts
@@ -12,8 +12,6 @@ import { srcset, transformUrl } from 'asset';
 import { basePx, icons, headlineFont, darkModeCss, textSans } from 'styles';
 import { getPillarStyles, Pillar } from 'pillar';
 import { imageRatioStyles } from 'components/blocks/image';
-import { hexToRGBA } from 'lib';
-
 
 // ----- Types ----- //
 
@@ -140,7 +138,7 @@ const anchorStyles = (colour: string): SerializedStyles => css`
     color: ${colour};
     text-decoration: none;
     padding-bottom: 0.15em;
-    background-image: linear-gradient(${hexToRGBA(colour, .4)} 0%, ${hexToRGBA(colour, .4)} 100%);
+    background-image: linear-gradient(${colour}66 0%, ${colour}66 100%);
     background-repeat: repeat-x;
     background-size: 1px 1px;
     background-position: 0 bottom;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -2,15 +2,8 @@
 
 const compose = <A, B, C>(f: (_b: B) => C, g: (_a: A) => B) => (a: A): C => f(g(a));
 
-const hexToRGBA = (hex: string, alpha: number): string => {
-    const [r, g, b] = hex.match(/\w\w/g)
-      ?.map((x: string): number => parseInt(x, 16)) ?? [0, 0, 0];
-    return `rgba(${r},${g},${b},${alpha})`;
-  };
-
 // ----- Exports ----- //
 
 export {
     compose,
-    hexToRGBA,
 };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,7 +3,8 @@
 const compose = <A, B, C>(f: (_b: B) => C, g: (_a: A) => B) => (a: A): C => f(g(a));
 
 const hexToRGBA = (hex: string, alpha: number): string => {
-    const [r, g, b] = hex.match(/\w\w/g)?.map(x => parseInt(x, 16)) ?? [0, 0, 0];
+    const [r, g, b] = hex.match(/\w\w/g)
+      ?.map((x: string): number => parseInt(x, 16)) ?? [0, 0, 0];
     return `rgba(${r},${g},${b},${alpha})`;
   };
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -2,9 +2,14 @@
 
 const compose = <A, B, C>(f: (_b: B) => C, g: (_a: A) => B) => (a: A): C => f(g(a));
 
+const hexToRGBA = (hex: string, alpha: number): string => {
+    const [r, g, b] = hex.match(/\w\w/g)?.map(x => parseInt(x, 16)) ?? [0, 0, 0];
+    return `rgba(${r},${g},${b},${alpha})`;
+  };
 
 // ----- Exports ----- //
 
 export {
     compose,
+    hexToRGBA,
 };


### PR DESCRIPTION
## Why are you doing this?

This will let us use hex colours from the design system with opacities. Updates link styles to match current templates.

## Changes
- Add opacity to Anchor hex values

