### PR TITLE
Use Article In Headline

### DIFF
--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -15,7 +15,7 @@ import { palette } from '@guardian/src-foundations';
 import { from, breakpoints } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/core';
 import { Keyline } from 'components/shared/keyline';
-import { isAnalysis, articleSeries, articleContributors, articleMainImage } from 'capi';
+import { articleSeries, articleContributors, articleMainImage } from 'capi';
 import { getPillarStyles } from 'pillar';
 import { Layout, Article } from 'article';
 
@@ -79,10 +79,8 @@ const Article = ({ capi, imageSalt, article, children }: ArticleProps): JSX.Elem
                         <ArticleSeries series={series} pillarStyles={pillarStyles}/>
                         <ArticleHeadline
                             headline={fields.headline}
-                            feature={feature}
+                            article={article}
                             rating={String(fields.starRating)}
-                            pillarStyles={pillarStyles}
-                            analysis={isAnalysis(capi)}
                         />
                         <ArticleStandfirst
                             standfirst={fields.standfirst}

--- a/src/components/standard/articleHeadline.tsx
+++ b/src/components/standard/articleHeadline.tsx
@@ -3,8 +3,9 @@ import ArticleRating from 'components/shared/articleRating';
 import { basePx, sidePadding, headlineFont, darkModeCss, headlineFontStyles } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
 import { palette } from '@guardian/src-foundations'
-import { PillarStyles } from 'pillar';
+import { getPillarStyles } from 'pillar';
 import { until } from '@guardian/src-foundations/mq';
+import { Layout, Article } from 'article';
 
 const AnalysisHeadlineStyles = (kicker: string): SerializedStyles => css`
     font-weight: 200;
@@ -16,17 +17,25 @@ const AnalysisHeadlineStyles = (kicker: string): SerializedStyles => css`
         background-position: ${basePx(1)} 0;
     }
 `
-const HeadlineStyles = (feature: boolean, analysis: boolean, { featureHeadline, kicker }: PillarStyles): SerializedStyles => css`
-    padding: ${basePx(0, 0, 4, 0)};
-    h1 {
-        ${headlineFontStyles}
-        ${headlineFont}
-        ${sidePadding}
-        font-weight: ${feature ? 700 : 500};
-        color: ${feature ? featureHeadline : palette.neutral[7]};
-        ${analysis ? AnalysisHeadlineStyles(kicker) : null}
-    }
-`;
+function HeadlineStyles({ layout, pillar }: Article): SerializedStyles {
+
+    const isFeature = layout === Layout.Feature;
+    const isAnalysis = layout === Layout.Analysis;
+    const { featureHeadline, kicker } = getPillarStyles(pillar);
+
+    return css`
+        padding: ${basePx(0, 0, 4, 0)};
+        h1 {
+            ${headlineFontStyles}
+            ${headlineFont}
+            ${sidePadding}
+            font-weight: ${isFeature ? 700 : 500};
+            color: ${isFeature ? featureHeadline : palette.neutral[7]};
+            ${isAnalysis ? AnalysisHeadlineStyles(kicker) : null}
+        }
+    `;
+
+}
 
 const HeadlineDarkStyles = darkModeCss`
     background: ${palette.neutral.darkMode};
@@ -38,20 +47,16 @@ const HeadlineDarkStyles = darkModeCss`
 
 interface ArticleHeadlineProps {
     headline: string;
-    feature: boolean;
-    analysis: boolean;
-    pillarStyles: PillarStyles;
+    article: Article;
     rating?: string;
 }
 
 const ArticleHeadline = ({
     headline,
-    feature,
-    analysis,
-    pillarStyles,
+    article,
     rating,
 }: ArticleHeadlineProps): JSX.Element =>
-    <div css={[HeadlineStyles(feature, analysis, pillarStyles), HeadlineDarkStyles]}>
+    <div css={[HeadlineStyles(article), HeadlineDarkStyles]}>
         <h1>{headline}</h1>
         { rating ? <ArticleRating rating={rating} /> : null }
     </div>


### PR DESCRIPTION
## Why are you doing this?

Reduce props sent to headline component using `Article` type. Follow-up to #129.

## Changes

- Dropped individual props from headline component and derived them instead from `Article`.
