### PR TITLE
Expand Article Type

### DIFF
--- a/src/ads.test.ts
+++ b/src/ads.test.ts
@@ -1,10 +1,11 @@
 import { insertAdPlaceholders } from './ads';
 import { ReactNode } from 'react';
-import { Block, renderAll } from 'block';
+import { renderAll } from 'renderer';
 import { ElementType } from 'capiThriftModels';
 import { JSDOM } from 'jsdom';
 import { Pillar } from 'pillar';
 import { compose } from 'lib';
+import { Block } from 'article';
 
 const textBlock = (nodes: string[]): Block =>
     ({

--- a/src/components/immersive/article.tsx
+++ b/src/components/immersive/article.tsx
@@ -104,7 +104,7 @@ function ImmersiveArticle({
                             byline={fields.byline}
                         />
                     </div>
-                    <Keyline article={article}/>
+                    <Keyline {...article} />
                     <ImmersiveByline
                         pillarStyles={pillarStyles}
                         publicationDate={webPublicationDate}

--- a/src/components/immersive/article.tsx
+++ b/src/components/immersive/article.tsx
@@ -113,7 +113,7 @@ function ImmersiveArticle({
                     />
                 </header>
                 <ArticleBody
-                    pillarStyles={pillarStyles}
+                    pillar={article.pillar}
                     className={[articleWidthStyles, DropCapStyles(pillarStyles), HeaderStyles]}
                 >
                     {children}

--- a/src/components/liveblog/byline.tsx
+++ b/src/components/liveblog/byline.tsx
@@ -85,7 +85,7 @@ const LiveblogByline = ({
     
     return (
         <div css={[LiveblogBylineStyles(pillarStyles)]}>
-            <Keyline article={article}/>
+            <Keyline {...article} />
             <LeftColumn>
                 <section>
                     <div className="byline">

--- a/src/components/opinion/article.tsx
+++ b/src/components/opinion/article.tsx
@@ -96,7 +96,7 @@ function OpinionArticle({ capi, imageSalt, article, children }: OpinionArticlePr
                         imageSalt={imageSalt}
                         className={articleWidthStyles}
                     />
-                    <Keyline article={article}/>
+                    <Keyline {...article} />
                     <ArticleStandfirst
                             article={article}
                             className={articleWidthStyles}

--- a/src/components/opinion/article.tsx
+++ b/src/components/opinion/article.tsx
@@ -99,8 +99,7 @@ function OpinionArticle({ capi, imageSalt, article, children }: OpinionArticlePr
                     <Keyline article={article}/>
                     <ArticleStandfirst
                             standfirst={fields.standfirst}
-                            feature={true}
-                            pillarStyles={pillarStyles}
+                            article={article}
                             className={articleWidthStyles}
                     />
 

--- a/src/components/opinion/article.tsx
+++ b/src/components/opinion/article.tsx
@@ -84,7 +84,7 @@ function OpinionArticle({ capi, imageSalt, article, children }: OpinionArticlePr
             <article css={BorderStyles}>
                 <header>
                     <div css={articleWidthStyles}>
-                        <ArticleSeries series={series} pillarStyles={pillarStyles}/>
+                        <ArticleSeries series={series} pillar={article.pillar}/>
                         <OpinionHeadline
                             byline={fields.bylineHtml}
                             headline={fields.headline}
@@ -98,7 +98,6 @@ function OpinionArticle({ capi, imageSalt, article, children }: OpinionArticlePr
                     />
                     <Keyline article={article}/>
                     <ArticleStandfirst
-                            standfirst={fields.standfirst}
                             article={article}
                             className={articleWidthStyles}
                     />
@@ -124,7 +123,7 @@ function OpinionArticle({ capi, imageSalt, article, children }: OpinionArticlePr
                         className={HeaderImageStyles}
                     />
                 </header>
-                <ArticleBody pillarStyles={pillarStyles} className={[articleWidthStyles]}>
+                <ArticleBody pillar={article.pillar} className={[articleWidthStyles]}>
                     {children}
                 </ArticleBody>
                 <footer css={articleWidthStyles}>

--- a/src/components/shared/Keyline.test.tsx
+++ b/src/components/shared/Keyline.test.tsx
@@ -10,21 +10,21 @@ configure({ adapter: new Adapter() });
 describe('Keyline component renders as expected', () => {
     it('Renders styles for liveblogs', () => {
         const article = { pillar: Pillar.opinion, layout: Layout.Liveblog };
-        const keyline = shallow(<Keyline article={article}/>);
+        const keyline = shallow(<Keyline {...article} />);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
         expect(keyline.props().css.styles).toContain("opacity:.4;")
     })
 
     it('Renders styles for opinion pillar articles', () => {
         const article = { pillar: Pillar.opinion, layout: Layout.Standard };
-        const keyline = shallow(<Keyline article={article}/>);
+        const keyline = shallow(<Keyline {...article} />);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
         expect(keyline.props().css.styles).toContain("height:24px;")
     })
 
     it('Renders styles for news pillar articles', () => {
         const article = { pillar: Pillar.news, layout: Layout.Standard };
-        const keyline = shallow(<Keyline article={article}/>);
+        const keyline = shallow(<Keyline {...article} />);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
     })
 });

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -8,7 +8,7 @@ import {
 } from 'styles';
 import { palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { PillarStyles } from 'pillar';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
 
 const richLinkWidth = "13.75rem";
 
@@ -71,17 +71,17 @@ const ArticleBodyDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => 
 `;
 
 interface ArticleBodyProps {
-    pillarStyles: PillarStyles;
+    pillar: Pillar;
     className: SerializedStyles[];
     children: ReactNode[];
 }
 
 const ArticleBody = ({
-    pillarStyles,
+    pillar,
     className,
     children,
 }: ArticleBodyProps): JSX.Element =>
-    <div css={[ArticleBodyStyles, ArticleBodyDarkStyles(pillarStyles), ...className]}>
+    <div css={[ArticleBodyStyles, ArticleBodyDarkStyles(getPillarStyles(pillar)), ...className]}>
         {children}
     </div>
 

--- a/src/components/shared/articleSeries.tsx
+++ b/src/components/shared/articleSeries.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { sidePadding, headlineFont } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
 import { Series } from '../../capi';
-import { PillarStyles } from 'pillar';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
 
 const ArticleSeriesStyles = ({ kicker }: PillarStyles): SerializedStyles => css`    
     a {
@@ -18,14 +18,14 @@ const ArticleSeriesStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
 
 interface ArticleSeriesProps {
     series: Series;
-    pillarStyles: PillarStyles;
+    pillar: Pillar;
 }
 
-const ArticleSeries = ({ series, pillarStyles }: ArticleSeriesProps): JSX.Element | null => {
+const ArticleSeries = ({ series, pillar }: ArticleSeriesProps): JSX.Element | null => {
 
     if (series) {
         return (
-            <nav css={ArticleSeriesStyles(pillarStyles)}>
+            <nav css={ArticleSeriesStyles(getPillarStyles(pillar))}>
                 <a href={series.webUrl}>{series.webTitle}</a>
             </nav>
         )

--- a/src/components/shared/keyline.tsx
+++ b/src/components/shared/keyline.tsx
@@ -4,7 +4,7 @@ import { darkModeCss, wideContentWidth, wideColumnWidth, baseMultiply } from 'st
 import { palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { Pillar } from 'pillar';
-import { Article, Layout } from 'article';
+import { Layout } from 'article';
 
 const BaseStyles = css`
     height: 12px;
@@ -43,8 +43,12 @@ const KeylineDarkStyles = darkModeCss`
     background-image: repeating-linear-gradient(${palette.neutral[20]}, ${palette.neutral[20]} 1px, transparent 1px, transparent 3px);
 `;
 
+type Props = {
+    pillar: Pillar;
+    layout: Layout;
+};
 
-export const Keyline = ({ article: { pillar, layout } }: { article: Article }): JSX.Element => {
+export const Keyline = ({ pillar, layout }: Props): JSX.Element => {
     const SelectedKeylineStyles = ((pillar, layout): SerializedStyles => {
         if (layout === Layout.Liveblog) return KeylineLiveblogStyles;
         switch (pillar) {

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -1,23 +1,22 @@
 // ----- Imports ----- //
 
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { ReactNode, ReactElement } from 'react';
 import { css } from '@emotion/core';
 
-import ArticleComponent from 'components/standard/article';
+import Standard from 'components/standard/article';
 import LiveblogArticle from 'components/liveblog/article';
-import OpinionArticle from 'components/opinion/article';
-import ImmersiveArticle from 'components/immersive/article';
+import Opinion from 'components/opinion/article';
+import Immersive from 'components/immersive/article';
 
-import { Pillar, pillarFromString } from 'pillar';
 import { Content } from 'capiThriftModels';
 import { includesTweets } from 'capi';
 import { fontFace } from 'styles';
 import { None, Some } from 'types/option';
-import { renderAll, parseAll } from 'block';
+import { renderAll } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { partition } from 'types/result';
 import { insertAdPlaceholders } from 'ads';
-import { Article, fromCapi } from 'article';
+import { fromCapi, Layout } from 'article';
 
 
 // ----- Components ----- //
@@ -68,43 +67,53 @@ interface BodyProps {
     capi: Content;
 }
 
-interface ArticleProps {
-    imageSalt: string;
-    capi: Content;
-    article: Article;
-    children: ReactNode[];
-}
-
-function getArticleSubtype(capi: Content): FunctionComponent<ArticleProps> {
-    if (pillarFromString(capi.pillarId) === Pillar.opinion) {
-        return OpinionArticle;
-    } else if (capi.fields.displayHint === 'immersive') {
-        return ImmersiveArticle;
-    }
-  
-    return ArticleComponent;
-  }
+const WithScript = (props: { src: string; children: ReactNode }): ReactElement =>
+    <>
+        {props.children}
+        <script src={props.src}></script>
+    </>
 
 function ArticleBody({ capi, imageSalt }: BodyProps): React.ReactElement {
-    const article = fromCapi(capi);
+    const article = fromCapi(JSDOM.fragment)(capi);
+    const body = partition(article.blocks).oks;
+    const content = insertAdPlaceholders(renderAll(imageSalt)(article.pillar, body));
+    const articleScript = '/assets/article.js';
+    const liveblogScript = '/assets/liveblog.js';
 
-    switch (capi.type) {
-        case 'article':
-            const parsedBlocks = parseAll(JSDOM.fragment)(capi.blocks.body[0].elements);
-            const body = partition(parsedBlocks).oks;
-            const Component = getArticleSubtype(capi);
-
-            return <>
-                <Component capi={capi} imageSalt={imageSalt} article={article}>
-                    {insertAdPlaceholders(renderAll(imageSalt)(article.pillar, body))}
-                </Component>
-                <script src="/assets/article.js"></script>
-            </>;
-        case 'liveblog':
-            return <>
-                <LiveblogArticle capi={capi} article={article} imageSalt={imageSalt} />
-                <script src="/assets/liveblog.js"></script>
-            </>;
+    switch (article.layout) {
+        case Layout.Opinion:
+            return (
+                <WithScript src={articleScript}>
+                    <Opinion capi={capi} imageSalt={imageSalt} article={article}>
+                        {content}
+                    </Opinion>
+                </WithScript>
+            );
+        case Layout.Immersive:
+            return (
+                <WithScript src={articleScript}>
+                    <Immersive capi={capi} imageSalt={imageSalt} article={article}>
+                        {content}
+                    </Immersive>
+                </WithScript>
+            );
+        case Layout.Standard:
+        case Layout.Feature:
+        case Layout.Analysis:
+        case Layout.Review:
+            return (
+                <WithScript src={articleScript}>
+                    <Standard imageSalt={imageSalt} article={article}>
+                        {content}
+                    </Standard>
+                </WithScript>
+            );
+        case Layout.Liveblog:
+            return (
+                <WithScript src={liveblogScript}>
+                    <LiveblogArticle capi={capi} article={article} imageSalt={imageSalt} />
+                </WithScript>
+            );
         default:
             return <p>{capi.type} not implemented yet</p>;
     }

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -73,12 +73,12 @@ const Article = ({ imageSalt, article, children }: ArticleProps): JSX.Element =>
                     />
                     <ArticleStandfirst article={article} className={articleWidthStyles} />
                 </div>
-                <Keyline article={article}/>
+                <Keyline {...article} />
                 <section css={articleWidthStyles}>
                     <ArticleByline article={article} imageSalt={imageSalt} />
                     {article.commentable
-                            ? <CommentCount count={0} colour={getPillarStyles(article.pillar).kicker}/>
-                            : null}
+                        ? <CommentCount count={0} colour={getPillarStyles(article.pillar).kicker}/>
+                        : null}
                 </section>
             </header>
             <ArticleBody pillar={article.pillar} className={[articleWidthStyles]}>

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -10,13 +10,11 @@ import ArticleByline from 'components/standard/byline';
 import { CommentCount } from 'components/shared/commentCount'
 import ArticleBody from 'components/shared/articleBody';
 import Tags from 'components/shared/tags';
-import { Content } from 'capiThriftModels';
 import { darkModeCss, articleWidthStyles } from 'styles';
 import { palette } from '@guardian/src-foundations';
 import { from, breakpoints } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/core';
 import { Keyline } from 'components/shared/keyline';
-import { articleSeries, articleContributors, articleMainImage } from 'capi';
 import { getPillarStyles } from 'pillar';
 import { Article } from 'article';
 
@@ -24,7 +22,6 @@ import { Article } from 'article';
 // ----- Component ----- //
 
 export interface ArticleProps {
-    capi: Content;
     imageSalt: string;
     article: Article;
     children: ReactNode[];
@@ -58,60 +55,40 @@ const HeaderImageStyles = css`
     }
 `;
 
-const Article = ({ capi, imageSalt, article, children }: ArticleProps): JSX.Element => {
-
-    const { fields, tags, webPublicationDate } = capi;
-    const series = articleSeries(capi);
-    const pillarStyles = getPillarStyles(article.pillar);
-    const contributors = articleContributors(capi);
-    const mainImage = articleMainImage(capi);
-
-    return (
-        <main css={[MainStyles, MainDarkStyles]}>
-            <article css={BorderStyles}>
-                <header>
-                    <HeaderImage
-                        image={mainImage}
-                        imageSalt={imageSalt}
-                        className={HeaderImageStyles}
+const Article = ({ imageSalt, article, children }: ArticleProps): JSX.Element =>
+    <main css={[MainStyles, MainDarkStyles]}>
+        <article css={BorderStyles}>
+            <header>
+                <HeaderImage
+                    image={article.mainImage}
+                    imageSalt={imageSalt}
+                    className={HeaderImageStyles}
+                />
+                <div css={articleWidthStyles}>
+                    <ArticleSeries series={article.series} pillar={article.pillar} />
+                    <ArticleHeadline
+                        headline={article.headline}
+                        article={article}
+                        rating={String(article.starRating)}
                     />
-                    <div css={articleWidthStyles}>
-                        <ArticleSeries series={series} pillarStyles={pillarStyles}/>
-                        <ArticleHeadline
-                            headline={fields.headline}
-                            article={article}
-                            rating={String(fields.starRating)}
-                        />
-                        <ArticleStandfirst
-                            standfirst={fields.standfirst}
-                            article={article}
-                            className={articleWidthStyles}
-                        />
-                    </div>
-                    <Keyline article={article}/>
-                    <section css={articleWidthStyles}>
-                        <ArticleByline
-                            byline={fields.bylineHtml}
-                            pillarStyles={pillarStyles}
-                            publicationDate={webPublicationDate}
-                            contributors={contributors}
-                            imageSalt={imageSalt}
-                        />
-                        {fields.commentable
-                                ? <CommentCount count={0} colour={pillarStyles.kicker}/>
-                                : null}
-                    </section>
-                </header>
-                <ArticleBody pillarStyles={pillarStyles} className={[articleWidthStyles]}>
-                    {children}
-                </ArticleBody>
-                <footer css={articleWidthStyles}>
-                    <Tags tags={tags}/>
-                </footer>
-            </article>
-        </main>
-    );
-}
+                    <ArticleStandfirst article={article} className={articleWidthStyles} />
+                </div>
+                <Keyline article={article}/>
+                <section css={articleWidthStyles}>
+                    <ArticleByline article={article} imageSalt={imageSalt} />
+                    {article.commentable
+                            ? <CommentCount count={0} colour={getPillarStyles(article.pillar).kicker}/>
+                            : null}
+                </section>
+            </header>
+            <ArticleBody pillar={article.pillar} className={[articleWidthStyles]}>
+                {children}
+            </ArticleBody>
+            <footer css={articleWidthStyles}>
+                <Tags tags={article.tags}/>
+            </footer>
+        </article>
+    </main>
 
 
 // ----- Exports ----- //

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -18,7 +18,7 @@ import { css } from '@emotion/core';
 import { Keyline } from 'components/shared/keyline';
 import { articleSeries, articleContributors, articleMainImage } from 'capi';
 import { getPillarStyles } from 'pillar';
-import { Layout, Article } from 'article';
+import { Article } from 'article';
 
 
 // ----- Component ----- //
@@ -62,7 +62,6 @@ const Article = ({ capi, imageSalt, article, children }: ArticleProps): JSX.Elem
 
     const { fields, tags, webPublicationDate } = capi;
     const series = articleSeries(capi);
-    const feature = article.layout === Layout.Feature || article.layout === Layout.Review;
     const pillarStyles = getPillarStyles(article.pillar);
     const contributors = articleContributors(capi);
     const mainImage = articleMainImage(capi);
@@ -85,8 +84,7 @@ const Article = ({ capi, imageSalt, article, children }: ArticleProps): JSX.Elem
                         />
                         <ArticleStandfirst
                             standfirst={fields.standfirst}
-                            feature={feature}
-                            pillarStyles={pillarStyles}
+                            article={article}
                             className={articleWidthStyles}
                         />
                     </div>

--- a/src/components/standard/byline.tsx
+++ b/src/components/standard/byline.tsx
@@ -57,8 +57,10 @@ const ArticleBylineDarkStyles = ({ inverted }: PillarStyles): SerializedStyles =
     }
 `;
 
-const Author = (props: { byline: Option<DocumentFragment>, pillar: Pillar }): JSX.Element | null =>
+const Author = (props: { byline: Option<DocumentFragment>; pillar: Pillar }): JSX.Element | null =>
     props.byline.map<JSX.Element | null>((bylineHtml: DocumentFragment) =>
+        // This is not an iterator, ESLint is confused
+        // eslint-disable-next-line react/jsx-key
         <address>{renderText(bylineHtml, props.pillar)}</address>
     ).withDefault(null);
 

--- a/src/components/standard/byline.tsx
+++ b/src/components/standard/byline.tsx
@@ -4,11 +4,12 @@ import { sidePadding, textSans, darkModeCss } from 'styles';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import { formatDate } from 'date';
-import { Contributor } from 'capi';
 import Avatar from 'components/shared/avatar';
 import Follow from 'components/shared/follow';
-import { PillarStyles } from 'pillar';
-import { componentFromHtml } from 'renderBlocks';
+import { PillarStyles, getPillarStyles, Pillar } from 'pillar';
+import { Option } from 'types/option';
+import { renderText } from 'renderer';
+import { Article } from 'article';
 
 const ArticleBylineStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     width: 80%;
@@ -56,36 +57,37 @@ const ArticleBylineDarkStyles = ({ inverted }: PillarStyles): SerializedStyles =
     }
 `;
 
+const Author = (props: { byline: Option<DocumentFragment>, pillar: Pillar }): JSX.Element | null =>
+    props.byline.map<JSX.Element | null>((bylineHtml: DocumentFragment) =>
+        <address>{renderText(bylineHtml, props.pillar)}</address>
+    ).withDefault(null);
+
 interface ArticleBylineProps {
-    byline?: string;
-    pillarStyles: PillarStyles;
-    publicationDate: string;
-    contributors: Contributor[];
+    article: Article;
     imageSalt: string;
 }
 
-const ArticleByline = ({
-    byline,
-    pillarStyles,
-    publicationDate,
-    contributors,
-    imageSalt
-}: ArticleBylineProps): JSX.Element =>
-    <div
-        css={[ArticleBylineStyles(pillarStyles), ArticleBylineDarkStyles(pillarStyles)]}
-    >
-        <div css={sidePadding}>
-            <Avatar
-                contributors={contributors}
-                bgColour={pillarStyles.inverted}
-                imageSalt={imageSalt}
-            />
-            <div className="author">
-                { byline ? <address>{componentFromHtml(byline)}</address> : null }
-                <time className="date">{ formatDate(new Date(publicationDate)) }</time>
-                <Follow contributors={contributors} />
+function ArticleByline({ article, imageSalt }: ArticleBylineProps): JSX.Element {
+    const pillarStyles = getPillarStyles(article.pillar);
+
+    return (
+        <div
+            css={[ArticleBylineStyles(pillarStyles), ArticleBylineDarkStyles(pillarStyles)]}
+        >
+            <div css={sidePadding}>
+                <Avatar
+                    contributors={article.contributors}
+                    bgColour={pillarStyles.inverted}
+                    imageSalt={imageSalt}
+                />
+                <div className="author">
+                    <Author byline={article.bylineHtml} pillar={article.pillar} />
+                    <time className="date">{ formatDate(new Date(article.publishDate)) }</time>
+                    <Follow contributors={article.contributors} />
+                </div>
             </div>
         </div>
-    </div>
+    );
+}
 
 export default ArticleByline;

--- a/src/components/standard/standfirst.tsx
+++ b/src/components/standard/standfirst.tsx
@@ -3,7 +3,7 @@ import { sidePadding, bulletStyles, headlineFont, darkModeCss, linkStyle } from 
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import { getPillarStyles } from 'pillar';
-import { componentFromHtml } from 'renderBlocks';
+import { renderText } from 'renderer';
 import { Article, Layout } from 'article';
 
 const StandfirstFeatureStyles = `
@@ -45,14 +45,13 @@ const StandfirstDarkStyles = ({ pillar }: Article): SerializedStyles => darkMode
 `;
 
 interface Props {
-    standfirst: string;
     article: Article;
     className: SerializedStyles;
 }
 
-const Standfirst = ({ standfirst, article, className }: Props): JSX.Element =>
+const Standfirst = ({ article, className }: Props): JSX.Element =>
     <div css={[className, StandfirstStyles(article), StandfirstDarkStyles(article)]}>
-        {componentFromHtml(standfirst)}
+        {renderText(article.standfirst, article.pillar)}
     </div>
 
 export default Standfirst;

--- a/src/components/standard/standfirst.tsx
+++ b/src/components/standard/standfirst.tsx
@@ -44,19 +44,15 @@ const StandfirstDarkStyles = ({ pillar }: Article): SerializedStyles => darkMode
     }
 `;
 
-interface ArticleStandfirstProps {
+interface Props {
     standfirst: string;
     article: Article;
     className: SerializedStyles;
 }
 
-const ArticleStandfirst = ({
-    standfirst,
-    article,
-    className,
-}: ArticleStandfirstProps): JSX.Element =>
+const Standfirst = ({ standfirst, article, className }: Props): JSX.Element =>
     <div css={[className, StandfirstStyles(article), StandfirstDarkStyles(article)]}>
         {componentFromHtml(standfirst)}
     </div>
 
-export default ArticleStandfirst;
+export default Standfirst;

--- a/src/components/standard/standfirst.tsx
+++ b/src/components/standard/standfirst.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { sidePadding, bulletStyles, headlineFont, darkModeCss, linkStyle } from 'styles';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
-import { PillarStyles } from 'pillar';
+import { getPillarStyles } from 'pillar';
 import { componentFromHtml } from 'renderBlocks';
+import { Article, Layout } from 'article';
 
 const StandfirstFeatureStyles = `
     color: ${palette.neutral[46]};
@@ -13,51 +14,48 @@ const StandfirstFeatureStyles = `
     line-height: 2.4rem;
 `;
 
-const StandfirstStyles = (feature: boolean, { kicker }: PillarStyles): SerializedStyles => css`
-    padding-bottom: 6px;
-    font-weight: 500;
-    font-size: 1.6rem;
-    line-height: 2rem;
+function StandfirstStyles({ pillar, layout }: Article): SerializedStyles {
+    const { kicker } = getPillarStyles(pillar);
+    const includeFeatureStyles = layout === Layout.Feature || layout === Layout.Review;
 
-    p, ul {
-        margin: 0;
-    }
+    return css`
+        padding-bottom: 6px;
+        font-weight: 500;
+        font-size: 1.6rem;
+        line-height: 2rem;
 
-    ${linkStyle(kicker)}
-    ${bulletStyles(kicker)}
-    ${sidePadding}
-    ${feature ? StandfirstFeatureStyles : null}
-`;
+        p, ul {
+            margin: 0;
+        }
 
-const StandfirstDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
+        ${linkStyle(kicker)}
+        ${bulletStyles(kicker)}
+        ${sidePadding}
+        ${includeFeatureStyles ? StandfirstFeatureStyles : null}
+    `;
+}
+
+const StandfirstDarkStyles = ({ pillar }: Article): SerializedStyles => darkModeCss`
     background: ${palette.neutral.darkMode};
     color: ${palette.neutral[86]};
 
     a {
-        color: ${inverted};
+        color: ${getPillarStyles(pillar).inverted};
     }
 `;
 
 interface ArticleStandfirstProps {
     standfirst: string;
-    feature: boolean;
-    pillarStyles: PillarStyles;
+    article: Article;
     className: SerializedStyles;
 }
 
 const ArticleStandfirst = ({
     standfirst,
-    pillarStyles,
-    feature,
-    className
+    article,
+    className,
 }: ArticleStandfirstProps): JSX.Element =>
-    <div
-        css={[
-            className,
-            StandfirstStyles(feature, pillarStyles),
-            StandfirstDarkStyles(pillarStyles)
-        ]}
-    >
+    <div css={[className, StandfirstStyles(article), StandfirstDarkStyles(article)]}>
         {componentFromHtml(standfirst)}
     </div>
 


### PR DESCRIPTION
## Why are you doing this?

This solves a few problems:

- The code to parse the data coming in from CAPI is separate from the view code.
- The parsing code lives in one place, `article.ts`, so any changes (for example if the data structure is modified or expanded) should result in minimal code changes.
- Usage of `JSDOM` no longer breaks storybook/client-side code because a) it happens higher up the stack at the parsing stage, not inside React components, and b) its usage has been abstracted into a generic "document parser", which can be replaced by `DOMParser` on the client if needs be.

FYI @oliverlloyd @gtrufitt you may be interested in the `article.ts`, `page.tsx` and `renderer.ts` files.

## Changes

- Added fields to `Article` to include all data needed to render article
- Moved CAPI parsing code from `block.ts` into `article.ts`
- Split renderer code out from `block.ts` into own file
- Deleted `block.ts` file
- Migrated standard article to use `Article` type instead of CAPI
- Some refactoring of standard standfirst
