### PR TITLE
Language: en-US -> en

### DIFF
--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -130,7 +130,7 @@ function Page({ content, imageSalt }: Props): JSX.Element {
         : null
 
     return (
-        <html lang="en-US" css={PageStyles}>
+        <html lang="en-GB" css={PageStyles}>
             <head>
                 <title>{content.id}</title>
                 <meta charSet="UTF-8" />

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -130,7 +130,7 @@ function Page({ content, imageSalt }: Props): JSX.Element {
         : null
 
     return (
-        <html lang="en-GB" css={PageStyles}>
+        <html lang="en" css={PageStyles}>
             <head>
                 <title>{content.id}</title>
                 <meta charSet="UTF-8" />


### PR DESCRIPTION
## Why are you doing this?

I think this makes more sense as the default for now. However, as we have several variations of English content (thinking about US and AU here), perhaps we want to do one of the following as an alternative:

1. Use `en` to specify English generically, without tying it to a specific region.
2. Editionalise this attribute, so it specifies `en-GB`, `en-US`, `en-AU` etc. for different editions.

As far as I can tell, dotcom seem to do option 1. Is this correct @gtrufitt @shtukas @nicl ?

## Changes

- Updated the html `lang` attribute to use `GB` instead of `US`.
