### PR TITLE
Refactor Opinion To Match Standard

### DIFF
--- a/src/components/opinion/article.tsx
+++ b/src/components/opinion/article.tsx
@@ -1,36 +1,32 @@
+// ----- Imports ----- //
+
 import React, { ReactNode } from 'react';
+import { css } from '@emotion/core';
+import { palette } from '@guardian/src-foundations';
+import { from, breakpoints } from '@guardian/src-foundations/mq';
 
 import HeaderImage from 'components/shared/headerImage';
 import ArticleSeries from 'components/shared/articleSeries';
-import OpinionHeadline from 'components/opinion/headline';
+import Headline from 'components/opinion/headline';
 import ArticleStandfirst from 'components/standard/standfirst';
-import OpinionByline from 'components/opinion/byline';
+import Byline from 'components/opinion/byline';
 import ArticleBody from 'components/shared/articleBody';
 import Tags from 'components/shared/tags';
-import OpinionCutout from 'components/opinion/cutout';
-import { Content } from 'capiThriftModels';
+import Cutout from 'components/opinion/cutout';
 import { darkModeCss, articleWidthStyles, basePx } from 'styles';
-import { palette } from '@guardian/src-foundations';
-import { from, breakpoints } from '@guardian/src-foundations/mq';
-import { css } from '@emotion/core';
 import { Keyline } from 'components/shared/keyline';
-import { articleSeries, articleContributors, articleMainImage } from 'capi';
 import { CommentCount } from 'components/shared/commentCount';
 import { getPillarStyles } from 'pillar';
 import { Article } from 'article';
 
-export interface OpinionArticleProps {
-    capi: Content;
-    imageSalt: string;
-    article: Article;
-    children: ReactNode[];
-}
 
-const MainStyles = css`
+// ----- Styles ----- //
+
+const Styles = css`
     background: ${palette.opinion.faded};
 `;
 
-const MainDarkStyles = darkModeCss`
+const DarkStyles = darkModeCss`
     background: ${palette.neutral.darkMode};
 `;
 
@@ -72,66 +68,69 @@ const topBorder = css`
     }
 `;
 
-function OpinionArticle({ capi, imageSalt, article, children }: OpinionArticleProps): JSX.Element {
-    const { fields, tags, webPublicationDate } = capi;
-    const series = articleSeries(capi);
-    const pillarStyles = getPillarStyles(article.pillar);
-    const contributors = articleContributors(capi);
-    const mainImage = articleMainImage(capi);
 
-    return (
-        <main css={[MainStyles, MainDarkStyles]}>
-            <article css={BorderStyles}>
-                <header>
-                    <div css={articleWidthStyles}>
-                        <ArticleSeries series={series} pillar={article.pillar}/>
-                        <OpinionHeadline
-                            byline={fields.bylineHtml}
-                            headline={fields.headline}
-                            pillarStyles={pillarStyles}
-                        />
-                    </div>
-                    <OpinionCutout 
-                        contributors={contributors}
-                        imageSalt={imageSalt}
-                        className={articleWidthStyles}
-                    />
-                    <Keyline {...article} />
-                    <ArticleStandfirst
-                            article={article}
-                            className={articleWidthStyles}
-                    />
+// ----- Component ----- //
 
-                    <section css={[articleWidthStyles, topBorder]}>
-                        <OpinionByline
-                            pillarStyles={pillarStyles}
-                            publicationDate={webPublicationDate}
-                            contributors={contributors}
-                        />
-                        {fields.commentable
-                                ? <CommentCount
-                                    count={0}
-                                    colour={pillarStyles.kicker}
-                                    className={CommentCountStyles}
-                                  />
-                                : null}
-                    </section>
-
-                    <HeaderImage
-                        image={mainImage}
-                        imageSalt={imageSalt}
-                        className={HeaderImageStyles}
-                    />
-                </header>
-                <ArticleBody pillar={article.pillar} className={[articleWidthStyles]}>
-                    {children}
-                </ArticleBody>
-                <footer css={articleWidthStyles}>
-                    <Tags tags={tags}/>
-                </footer>
-            </article>
-        </main>
-    );
+interface Props {
+    imageSalt: string;
+    article: Article;
+    children: ReactNode[];
 }
 
-export default OpinionArticle;
+const Opinion = ({ imageSalt, article, children }: Props): JSX.Element =>
+    <main css={[Styles, DarkStyles]}>
+        <article css={BorderStyles}>
+            <header>
+                <div css={articleWidthStyles}>
+                    <ArticleSeries series={article.series} pillar={article.pillar}/>
+                    <Headline
+                        byline={article.bylineHtml}
+                        headline={article.headline}
+                        pillar={article.pillar}
+                    />
+                </div>
+                <Cutout 
+                    contributors={article.contributors}
+                    imageSalt={imageSalt}
+                    className={articleWidthStyles}
+                />
+                <Keyline {...article} />
+                <ArticleStandfirst
+                    article={article}
+                    className={articleWidthStyles}
+                />
+
+                <section css={[articleWidthStyles, topBorder]}>
+                    <Byline
+                        pillar={article.pillar}
+                        publicationDate={article.publishDate}
+                        contributors={article.contributors}
+                    />
+                    {article.commentable
+                        ? <CommentCount
+                            count={0}
+                            colour={getPillarStyles(article.pillar).kicker}
+                            className={CommentCountStyles}
+                            />
+                        : null}
+                </section>
+
+                <HeaderImage
+                    image={article.mainImage}
+                    imageSalt={imageSalt}
+                    className={HeaderImageStyles}
+                />
+            </header>
+            <ArticleBody pillar={article.pillar} className={[articleWidthStyles]}>
+                {children}
+            </ArticleBody>
+            <footer css={articleWidthStyles}>
+                <Tags tags={article.tags}/>
+            </footer>
+        </article>
+    </main>
+
+
+// ----- Exports ----- //
+
+export default Opinion;

--- a/src/components/opinion/byline.tsx
+++ b/src/components/opinion/byline.tsx
@@ -1,13 +1,19 @@
+// ----- Imports ----- //
+
 import React from 'react';
-import { sidePadding, textSans, darkModeCss, basePx } from 'styles';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
+
+import { sidePadding, textSans, darkModeCss, basePx } from 'styles';
 import { formatDate } from 'date';
 import { Contributor } from 'capi';
 import Follow from 'components/shared/follow';
-import { PillarStyles } from 'pillar';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
 
-const OpinionBylineStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
+
+// ----- Styles ----- //
+
+const Styles = ({ kicker }: PillarStyles): SerializedStyles => css`
     width: 80%;
     float: left;
     display: inline-block;
@@ -30,7 +36,7 @@ const OpinionBylineStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     }
 `;
 
-const OpinionBylineDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
+const DarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
     background: ${palette.neutral.darkMode};
     color: ${palette.neutral[86]};
 
@@ -45,26 +51,31 @@ const OpinionBylineDarkStyles = ({ inverted }: PillarStyles): SerializedStyles =
     }
 `;
 
-interface OpinionBylineProps {
-    pillarStyles: PillarStyles;
+
+// ----- Component ----- //
+
+interface Props {
+    pillar: Pillar;
     publicationDate: string;
     contributors: Contributor[];
 }
 
-const OpinionByline = ({
-    pillarStyles,
-    publicationDate,
-    contributors,
-}: OpinionBylineProps): JSX.Element =>
-    <div
-        css={[OpinionBylineStyles(pillarStyles), OpinionBylineDarkStyles(pillarStyles)]}
-    >
-        <div css={sidePadding}>
-            <div className="author">
-                <time>{ formatDate(new Date(publicationDate)) }</time>
-                <Follow contributors={contributors} />
+const Byline = ({ pillar, publicationDate, contributors }: Props): JSX.Element => {
+    const pillarStyles = getPillarStyles(pillar);
+
+    return (
+        <div css={[Styles(pillarStyles), DarkStyles(pillarStyles)]}>
+            <div css={sidePadding}>
+                <div className="author">
+                    <time>{ formatDate(new Date(publicationDate)) }</time>
+                    <Follow contributors={contributors} />
+                </div>
             </div>
         </div>
-    </div>
+    );
+};
 
-export default OpinionByline;
+
+// ----- Exports ----- //
+
+export default Byline;

--- a/src/components/opinion/cutout.tsx
+++ b/src/components/opinion/cutout.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+// ----- Imports ----- //
 
+import React from 'react';
 import { css, SerializedStyles } from '@emotion/core';
+
 import { Contributor, isSingleContributor } from 'capi';
 import { transformUrl } from 'asset';
 
+
+// ----- Constants ----- //
+
 const imageWidth = 68;
 
-const OpinionCutoutStyles = css`
+
+// ----- Styles ----- //
+
+const Styles = css`
     position: relative;
 `;
 
@@ -17,23 +25,22 @@ const ImageStyles = css`
     top: -54px;
 `;
 
-interface OpinionCutoutProps {
+
+// ----- Component ----- //
+
+interface Props {
     contributors: Contributor[];
     imageSalt: string;
     className: SerializedStyles;
 }
 
-const OpinionCutout = ({
-    contributors,
-    imageSalt,
-    className
-}: OpinionCutoutProps): JSX.Element | null => {
+const Cutout = ({ contributors, imageSalt, className }: Props): JSX.Element | null => {
     const [contributor] = contributors;
 
     if (isSingleContributor(contributors) && contributor.bylineLargeImageUrl) {
         const imgSrc = transformUrl(imageSalt, contributor.bylineLargeImageUrl, imageWidth*3);
         return (
-            <div css={[className, OpinionCutoutStyles]}>
+            <div css={[className, Styles]}>
                 <img css={ImageStyles} src={imgSrc} alt={contributor.webTitle}/>
             </div>
         );
@@ -43,4 +50,7 @@ const OpinionCutout = ({
 
 }
 
-export default OpinionCutout;
+
+// ----- Exports ----- //
+
+export default Cutout;

--- a/src/components/opinion/headline.tsx
+++ b/src/components/opinion/headline.tsx
@@ -1,12 +1,19 @@
+// ----- Imports ----- //
+
 import React from 'react';
-import { basePx, headlineFont, darkModeCss, headlineFontStyles } from 'styles';
 import { css } from '@emotion/core'
 import { palette } from '@guardian/src-foundations'
-import { PillarStyles } from 'pillar';
 import { until } from '@guardian/src-foundations/mq';
-import { componentFromHtml } from 'renderBlocks';
 
-const HeadlineStyles = css`
+import { basePx, headlineFont, darkModeCss, headlineFontStyles } from 'styles';
+import { Pillar } from 'pillar';
+import Author from 'components/shared/author';
+import { Option } from 'types/option';
+
+
+// ----- Styles ----- //
+
+const Styles = css`
     padding: ${basePx(0, 0, 4, 0)};
     
     ${until.wide} {
@@ -30,26 +37,29 @@ const HeadlineStyles = css`
     }
 `;
 
-const HeadlineDarkStyles = darkModeCss`
+const DarkStyles = darkModeCss`
     background: ${palette.neutral.darkMode};
     h1 {
         color: ${palette.neutral[86]};
     }
 `;
 
-interface OpinionHeadlineProps {
-    byline?: string;
+
+// ----- Component ----- //
+
+interface Props {
+    byline: Option<DocumentFragment>;
     headline: string;
-    pillarStyles: PillarStyles;
+    pillar: Pillar;
 }
 
-const OpinionHeadline = ({
-    byline,
-    headline
-}: OpinionHeadlineProps): JSX.Element =>
-    <div css={[HeadlineStyles, HeadlineDarkStyles]}>
+const Headline = ({ byline, headline, pillar }: Props): JSX.Element =>
+    <div css={[Styles, DarkStyles]}>
         <h1>{headline}</h1>
-        { byline ? <address>{componentFromHtml(byline)}</address> : null }
+        <Author byline={byline} pillar={pillar} />
     </div>
 
-export default OpinionHeadline;
+
+// ----- Exports ----- //
+
+export default Headline;

--- a/src/components/shared/author.tsx
+++ b/src/components/shared/author.tsx
@@ -1,0 +1,27 @@
+// ----- Imports ----- //
+
+import { createElement as h } from 'react';
+
+import { renderText } from 'renderer';
+import { Pillar } from 'pillar';
+import { Option } from 'types/option';
+
+
+// ----- Component ----- //
+
+interface Props {
+    byline: Option<DocumentFragment>;
+    pillar: Pillar;
+}
+
+const Author = (props: Props): JSX.Element | null =>
+    props.byline.map<JSX.Element | null>((bylineHtml: DocumentFragment) =>
+        // This is not an iterator, ESLint is confused
+        // eslint-disable-next-line react/jsx-key
+        h('address', null, renderText(bylineHtml, props.pillar))
+    ).withDefault(null);
+
+
+// ----- Exports ----- //
+
+export default Author;

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -99,7 +99,7 @@ function ArticleBody({ capi, imageSalt }: BodyProps): React.ReactElement {
         case Layout.Opinion:
             return (
                 <WithScript src={articleScript}>
-                    <Opinion capi={capi} imageSalt={imageSalt} article={article}>
+                    <Opinion imageSalt={imageSalt} article={article}>
                         {content}
                     </Opinion>
                 </WithScript>

--- a/src/components/standard/byline.tsx
+++ b/src/components/standard/byline.tsx
@@ -8,10 +8,9 @@ import { sidePadding, textSans, darkModeCss } from 'styles';
 import { formatDate } from 'date';
 import Avatar from 'components/shared/avatar';
 import Follow from 'components/shared/follow';
-import { PillarStyles, getPillarStyles, Pillar } from 'pillar';
-import { Option } from 'types/option';
-import { renderText } from 'renderer';
+import { PillarStyles, getPillarStyles } from 'pillar';
 import { Article } from 'article';
+import Author from 'components/shared/author';
 
 
 // ----- Styles ----- //
@@ -62,21 +61,6 @@ const DarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss
         }
     }
 `;
-
-
-// ----- Subcomponents ----- //
-
-interface AuthorProps {
-    byline: Option<DocumentFragment>;
-    pillar: Pillar;
-}
-
-const Author = (props: AuthorProps): JSX.Element | null =>
-    props.byline.map<JSX.Element | null>((bylineHtml: DocumentFragment) =>
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
-        <address>{renderText(bylineHtml, props.pillar)}</address>
-    ).withDefault(null);
 
 
 // ----- Component ----- //


### PR DESCRIPTION
## Why are you doing this?

This brings the changes made to the 'Standard' article over to Opinion. It also makes `Author` a standalone shared component. It's mostly renaming and re-ordering.

## Changes

- Updated file structure
- Updated naming conventions
- Extracted Author into shared component
- Removed need to pass CAPI object to Opinion
