### PR TITLE
Refactor Immersive Article

### DIFF
--- a/src/components/immersive/article.tsx
+++ b/src/components/immersive/article.tsx
@@ -1,29 +1,26 @@
+// ----- Imports ----- //
+
 import React, { ReactNode } from 'react';
-import ImmersiveHeaderImage from 'components/immersive/headerImage';
-import ImmersiveSeries from 'components/immersive/series';
-import ImmersiveHeadline from 'components/immersive/headline';
-import ImmersiveStandfirst from 'components/immersive/standfirst';
-import ImmersiveByline from 'components/immersive/byline';
+import { css, SerializedStyles } from '@emotion/core';
+import { palette } from '@guardian/src-foundations';
+import { from, breakpoints } from '@guardian/src-foundations/mq';
+
+import HeaderImage from 'components/immersive/headerImage';
+import Series from 'components/immersive/series';
+import Headline from 'components/immersive/headline';
+import Standfirst from 'components/immersive/standfirst';
+import Byline from 'components/immersive/byline';
 import ArticleBody from 'components/shared/articleBody';
 import Tags from 'components/shared/tags';
-import { Content } from 'capiThriftModels';
 import { articleWidthStyles, basePx, darkModeCss } from 'styles';
-import { from, breakpoints } from '@guardian/src-foundations/mq';
-import { css, SerializedStyles } from '@emotion/core';
 import { Keyline } from 'components/shared/keyline';
-import { articleSeries, articleContributors, articleMainImage } from 'capi';
-import { getPillarStyles, PillarStyles } from 'pillar';
-import { palette } from '@guardian/src-foundations';
+import { getPillarStyles, Pillar } from 'pillar';
 import { Article } from 'article';
 
-export interface ImmersiveArticleProps {
-    capi: Content;
-    imageSalt: string;
-    article: Article;
-    children: ReactNode[];
-}
 
-const MainDarkStyles = darkModeCss`
+// ----- Styles ----- //
+
+const DarkStyles = darkModeCss`
     background: ${palette.neutral.darkMode};
 `;
 
@@ -48,18 +45,22 @@ const BorderStyles = css`
     }
 `;
 
-const DropCapStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
-    p:first-child::first-letter,
-    .section-rule + p::first-letter {
-        color: ${pillarStyles.kicker};
-        font-weight: 100;
-        font-style: normal;
-        font-size: 7em;
-        line-height: 1;
-        padding-right: ${basePx(1)};
-        float: left;
-    }
-`;
+const DropCapStyles = (pillar: Pillar): SerializedStyles => {
+    const { kicker } = getPillarStyles(pillar);
+
+    return css`
+        p:first-child::first-letter,
+        .section-rule + p::first-letter {
+            color: ${kicker};
+            font-weight: 100;
+            font-style: normal;
+            font-size: 7em;
+            line-height: 1;
+            padding-right: ${basePx(1)};
+            float: left;
+        }
+    `;
+}
 
 const HeaderImageStyles = css`
     figure {
@@ -71,59 +72,56 @@ const HeaderImageStyles = css`
     }
 `;
 
-function ImmersiveArticle({
-    capi,
-    imageSalt,
-    article,
-    children,
-}: ImmersiveArticleProps): JSX.Element {
 
-    const { fields, tags, webPublicationDate } = capi;
-    const series = articleSeries(capi);
-    const pillarStyles = getPillarStyles(article.pillar);
-    const contributors = articleContributors(capi);
-    const mainImage = articleMainImage(capi);
+// ----- Component ----- //
 
-    return (
-        <main css={MainDarkStyles}>
-            <article css={BorderStyles}>
-                <header>
-                    <div css={articleWidthStyles}>
-                        <ImmersiveHeaderImage
-                            image={mainImage}
-                            imageSalt={imageSalt}
-                            className={HeaderImageStyles}
-                        />
-                        <ImmersiveSeries series={series} pillarStyles={pillarStyles}/>
-                        <ImmersiveHeadline headline={fields.headline}/>
-                        <ImmersiveStandfirst
-                            standfirst={fields.standfirst}
-                            pillarStyles={pillarStyles}
-                            className={articleWidthStyles}
-                            bylineHtml={fields.bylineHtml}
-                            byline={fields.byline}
-                        />
-                    </div>
-                    <Keyline {...article} />
-                    <ImmersiveByline
-                        pillarStyles={pillarStyles}
-                        publicationDate={webPublicationDate}
-                        contributors={contributors}
-                        className={articleWidthStyles}
-                    />
-                </header>
-                <ArticleBody
-                    pillar={article.pillar}
-                    className={[articleWidthStyles, DropCapStyles(pillarStyles), HeaderStyles]}
-                >
-                    {children}
-                </ArticleBody>
-                <footer css={articleWidthStyles}>
-                    <Tags tags={tags}/>
-                </footer>
-            </article>
-        </main>
-    );
+interface Props {
+    imageSalt: string;
+    article: Article;
+    children: ReactNode[];
 }
 
-export default ImmersiveArticle;
+const Immersive = ({ imageSalt, article, children }: Props): JSX.Element =>
+    <main css={DarkStyles}>
+        <article css={BorderStyles}>
+            <header>
+                <div css={articleWidthStyles}>
+                    <HeaderImage
+                        image={article.mainImage}
+                        imageSalt={imageSalt}
+                        className={HeaderImageStyles}
+                    />
+                    <Series series={article.series} pillar={article.pillar}/>
+                    <Headline headline={article.headline}/>
+                    <Standfirst
+                        standfirst={article.standfirst}
+                        pillar={article.pillar}
+                        className={articleWidthStyles}
+                        bylineHtml={article.bylineHtml}
+                        byline={article.byline}
+                    />
+                </div>
+                <Keyline {...article} />
+                <Byline
+                    pillar={article.pillar}
+                    publicationDate={article.publishDate}
+                    contributors={article.contributors}
+                    className={articleWidthStyles}
+                />
+            </header>
+            <ArticleBody
+                pillar={article.pillar}
+                className={[articleWidthStyles, DropCapStyles(article.pillar), HeaderStyles]}
+            >
+                {children}
+            </ArticleBody>
+            <footer css={articleWidthStyles}>
+                <Tags tags={article.tags}/>
+            </footer>
+        </article>
+    </main>
+
+
+// ----- Exports ----- //
+
+export default Immersive;

--- a/src/components/immersive/byline.tsx
+++ b/src/components/immersive/byline.tsx
@@ -1,13 +1,19 @@
+// ----- Imports ----- //
+
 import React from 'react';
-import Follow from 'components/shared/follow';
-import { sidePadding, textSans, darkModeCss, basePx } from 'styles';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
+
+import Follow from 'components/shared/follow';
+import { sidePadding, textSans, darkModeCss, basePx } from 'styles';
 import { formatDate } from 'date';
 import { Contributor } from 'capi';
-import { PillarStyles } from 'pillar';
+import { PillarStyles, getPillarStyles, Pillar } from 'pillar';
 
-const BylineStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
+
+// ----- Styles ----- //
+
+const Styles = ({ kicker }: PillarStyles): SerializedStyles => css`
     .author {
         margin: ${basePx(1, 0, 2, 0)};
 
@@ -26,7 +32,7 @@ const BylineStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     }
 `;
 
-const BylineDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
+const DarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
     background: ${palette.neutral.darkMode};
     color: ${palette.neutral[86]};
 
@@ -41,30 +47,32 @@ const BylineDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkM
     }
 `;
 
-interface ImmersiveBylineProps {
-    pillarStyles: PillarStyles;
+
+// ----- Component ----- //
+
+interface Props {
+    pillar: Pillar;
     publicationDate: string;
     contributors: Contributor[];
     className: SerializedStyles;
 }
 
-const ImmersiveByline = ({
-    pillarStyles,
-    publicationDate,
-    contributors,
-    className,
-}: ImmersiveBylineProps): JSX.Element =>
-    <div css={[
-        className,
-        BylineStyles(pillarStyles),
-        BylineDarkStyles(pillarStyles)]}
-    >
-        <div css={sidePadding}>
-            <div className="author">
-                <time>{ formatDate(new Date(publicationDate)) }</time>
-                <Follow contributors={contributors} />
+function Byline({ pillar, publicationDate, contributors, className }: Props): JSX.Element {
+    const pillarStyles = getPillarStyles(pillar);
+
+    return (
+        <div css={[className, Styles(pillarStyles), DarkStyles(pillarStyles)]}>
+            <div css={sidePadding}>
+                <div className="author">
+                    <time>{ formatDate(new Date(publicationDate)) }</time>
+                    <Follow contributors={contributors} />
+                </div>
             </div>
         </div>
-    </div>
+    );
+}
 
-export default ImmersiveByline;
+
+// ----- Exports ----- //
+
+export default Byline;

--- a/src/components/immersive/headerImage.tsx
+++ b/src/components/immersive/headerImage.tsx
@@ -1,12 +1,18 @@
+// ----- Imports ----- //
+
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/core'
+import { from } from '@guardian/src-foundations/mq';
+
 import { BlockElement } from 'capiThriftModels';
 import { immersiveImageElement } from 'components/blocks/image';
-import { from } from '@guardian/src-foundations/mq';
 import { wideContentWidth } from 'styles';
 import { Option } from 'types/option';
 
-const headerImageStyles = css`
+
+// ----- Styles ----- //
+
+const Styles = css`
     figure {
         position: relative;
 
@@ -27,27 +33,27 @@ const headerImageStyles = css`
     }
 `;
 
-interface HeaderImageProps {
+
+// ----- Component ----- //
+
+interface Props {
     image: Option<BlockElement>;
     imageSalt: string;
     className?: SerializedStyles | null;
 }
 
-const HeaderImage = ({ className, image, imageSalt }: HeaderImageProps): JSX.Element | null => {
-
-    const headerImage: Option<JSX.Element | null> = image.map(({ imageTypeData, assets }) =>
+const HeaderImage = ({ className, image, imageSalt }: Props): JSX.Element | null =>
+    image.map<JSX.Element | null>(({ imageTypeData, assets }) =>
         // This is not an iterator, ESLint is confused
         // eslint-disable-next-line react/jsx-key
-        <div css={[className, headerImageStyles]}>
+        <div css={[className, Styles]}>
             <figure>
                 { immersiveImageElement(imageTypeData.alt, assets, imageSalt) }
             </figure>
         </div>
-    );
+    ).withDefault(null);
 
-    // Needed to provide TypeScript with enough type information.
-    return headerImage.withDefault(null);
 
-}
+// ----- Exports ----- //
 
 export default HeaderImage;

--- a/src/components/immersive/headline.tsx
+++ b/src/components/immersive/headline.tsx
@@ -1,9 +1,15 @@
+// ----- Imports ----- //
+
 import React from 'react';
-import { basePx, headlineFont, darkModeCss, headlineFontStyles } from 'styles';
 import { css } from '@emotion/core'
 import { palette } from '@guardian/src-foundations'
 
-const HeadlineStyles = css`
+import { basePx, headlineFont, darkModeCss, headlineFontStyles } from 'styles';
+
+
+// ----- Styles ----- //
+
+const Styles = css`
     padding: ${basePx(.5, 1, 3, 1)};
     background: ${palette.neutral[7]};
     position: relative;
@@ -18,20 +24,24 @@ const HeadlineStyles = css`
     }
 `;
 
-const HeadlineDarkStyles = darkModeCss`
+const DarkStyles = darkModeCss`
     background: ${palette.neutral.darkMode};
     color: ${palette.neutral[86]};
 `;
 
-interface ImmersiveHeadlineProps {
+
+// ----- Component ----- //
+
+interface Props {
     headline: string;
 }
 
-const ImmersiveHeadline = ({
-    headline
-}: ImmersiveHeadlineProps): JSX.Element =>
-    <div css={[HeadlineStyles, HeadlineDarkStyles]}>
+const Headline = ({ headline }: Props): JSX.Element =>
+    <div css={[Styles, DarkStyles]}>
         <h1>{headline}</h1>
     </div>
 
-export default ImmersiveHeadline;
+
+// ----- Exports ----- //
+
+export default Headline;

--- a/src/components/immersive/series.tsx
+++ b/src/components/immersive/series.tsx
@@ -1,11 +1,17 @@
+// ----- Imports ----- //
+
 import React from 'react';
-import { headlineFont, basePx } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
-import { Series } from 'capi';
-import { PillarStyles } from 'pillar';
 import { palette } from '@guardian/src-foundations';
 
-const SeriesStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
+import { headlineFont, basePx } from 'styles';
+import { Series } from 'capi';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
+
+
+// ----- Styles ----- //
+
+const Styles = ({ kicker }: PillarStyles): SerializedStyles => css`
     background: ${kicker};
     padding: ${basePx(.5, 1)};
     display: inline-block;
@@ -23,23 +29,29 @@ const SeriesStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     }
 `;
 
-interface ImmersiveSeriesProps {
+
+// ----- Component ----- //
+
+interface Props {
     series: Series;
-    pillarStyles: PillarStyles;
+    pillar: Pillar;
 }
 
-const ImmersiveSeries = ({ series, pillarStyles }: ImmersiveSeriesProps): JSX.Element | null => {
+const Series = ({ series, pillar }: Props): JSX.Element | null => {
 
     if (series) {
         return (
-            <nav css={SeriesStyles(pillarStyles)}>
+            <nav css={Styles(getPillarStyles(pillar))}>
                 <a href={series.webUrl}>{series.webTitle}</a>
             </nav>
-        )
+        );
     }
 
     return null;
 
 }
 
-export default ImmersiveSeries;
+
+// ----- Exports ----- //
+
+export default Series;

--- a/src/components/immersive/standfirst.tsx
+++ b/src/components/immersive/standfirst.tsx
@@ -1,11 +1,18 @@
+// ----- Imports ----- //
+
 import React from 'react';
-import { bulletStyles, headlineFont, darkModeCss, basePx, linkStyle } from 'styles';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
-import { PillarStyles } from 'pillar';
-import { componentFromHtml } from 'renderBlocks';
 
-const StandfirstStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
+import { bulletStyles, headlineFont, darkModeCss, basePx, linkStyle } from 'styles';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
+import { renderText } from 'renderer';
+import { Option } from 'types/option';
+
+
+// ----- Styles ----- //
+
+const Styles = ({ kicker }: PillarStyles): SerializedStyles => css`
     ${headlineFont}
     color: ${palette.neutral[46]};
     font-weight: 400;
@@ -26,7 +33,7 @@ const StandfirstStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     ${bulletStyles(kicker)}
 `;
 
-const StandfirstDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
+const DarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
     background: ${palette.neutral.darkMode};
     color: ${palette.neutral[86]};
 
@@ -35,47 +42,50 @@ const StandfirstDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => d
     }
 `;
 
-interface ArticleStandfirstProps {
-    standfirst: string;
-    pillarStyles: PillarStyles;
+
+// ----- Component ----- //
+
+interface Props {
+    standfirst: DocumentFragment;
+    byline: string;
+    bylineHtml: Option<DocumentFragment>;
+    pillar: Pillar;
     className: SerializedStyles;
-    byline?: string;
-    bylineHtml?: string;
 }
 
-const ImmersiveStandfirst = ({
+const Standfirst = ({
     standfirst,
-    pillarStyles,
-    className,
     byline,
-    bylineHtml
-}: ArticleStandfirstProps): JSX.Element => {
+    bylineHtml,
+    pillar,
+    className,
+}: Props): JSX.Element => {
+    const pillarStyles = getPillarStyles(pillar);
 
-    let standfirstHtml;
-
-    if (byline && bylineHtml) {
-        if (standfirst.includes(byline)) {
-            standfirstHtml = <div>{componentFromHtml(standfirst.replace(byline, bylineHtml))}</div>
+    const content = bylineHtml.map(html => {
+        if (byline !== '' && standfirst.textContent?.includes(byline)) {
+            return <div>{renderText(standfirst, pillar)}</div>;
         } else {
-            standfirstHtml = <div>
-                <div>{componentFromHtml(standfirst)}</div>
-                <address>
-                    <span>By </span>
-                    {componentFromHtml(bylineHtml)}
-                </address>
-            </div>
+            return (
+                <div>
+                    <div>{renderText(standfirst, pillar)}</div>
+                    <address>
+                        <span>By </span>
+                        {renderText(html, pillar)}
+                    </address>
+                </div>
+            );
         }
-    } else {
-        standfirstHtml = <div>{componentFromHtml(standfirst)}</div>
-    }
+    }).withDefault(<div>{ renderText(standfirst, pillar) }</div>)
 
-    return <div css={[
-        className,
-        StandfirstStyles(pillarStyles),
-        StandfirstDarkStyles(pillarStyles)
-    ]}>
-        { standfirstHtml }
-    </div>
+    return (
+        <div css={[ className, Styles(pillarStyles), DarkStyles(pillarStyles) ]}>
+            { content }
+        </div>
+    );
 }
 
-export default ImmersiveStandfirst;
+
+// ----- Exports ----- //
+
+export default Standfirst;

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -107,7 +107,7 @@ function ArticleBody({ capi, imageSalt }: BodyProps): React.ReactElement {
         case Layout.Immersive:
             return (
                 <WithScript src={articleScript}>
-                    <Immersive capi={capi} imageSalt={imageSalt} article={article}>
+                    <Immersive imageSalt={imageSalt} article={article}>
                         {content}
                     </Immersive>
                 </WithScript>


### PR DESCRIPTION
## Why are you doing this?

Continuing the work from #138 and #145, this tidies up the immersive article and migrates it over to use the new `Article` type.

**Note:** This is likely to reinstate the bug fixed in #122. As this PR is blocking #146, we've decided to fix that in a follow-up.

## Changes

- Used new `Article` type
- Improved type hinting for `HeaderImage`
- Removed need to pass `Capi` type to immersives
- Tidied structure and naming of immersive components
