### PR TITLE
Rename Block to BodyElement

### DIFF
--- a/src/ads.test.ts
+++ b/src/ads.test.ts
@@ -5,23 +5,23 @@ import { ElementType } from 'capiThriftModels';
 import { JSDOM } from 'jsdom';
 import { Pillar } from 'pillar';
 import { compose } from 'lib';
-import { Block } from 'article';
+import { BodyElement } from 'article';
 
-const textBlock = (nodes: string[]): Block =>
+const textElement = (nodes: string[]): BodyElement =>
     ({
         kind: ElementType.TEXT,
         doc: JSDOM.fragment(nodes.join('')),
     });
 
-const generateParas = (paras: number): Block =>
-    textBlock(Array(paras).fill('<p>foo</p>'));
+const generateParas = (paras: number): BodyElement =>
+    textElement(Array(paras).fill('<p>foo</p>'));
 
-const render = (textBlock: Block): ReactNode[] =>
-    renderAll('dummySalt')(Pillar.news, [textBlock]);
+const render = (element: BodyElement): ReactNode[] =>
+    renderAll('dummySalt')(Pillar.news, [element]);
 
 const renderParagraphs = compose(render, generateParas);
 
-const renderTextBlock = compose(render, textBlock);
+const renderTextElement = compose(render, textElement);
 
 describe('Adds the correct number of ad placeholders', () => {
     test('Adds no placeholders for 2 paragraphs', () => {
@@ -81,7 +81,7 @@ describe('Adds short classname correctly', () => {
 
 describe('Handles different DOM structures', () => {
     test('Does not count other tag types', () => {
-        const text = renderTextBlock([
+        const text = renderTextElement([
             '<p></p>',
             '<p></p>',
             '<div></div>',
@@ -95,7 +95,7 @@ describe('Handles different DOM structures', () => {
     });
 
     test('Inserts placeholders at correct positions with other types of tags', () => {
-        const text = renderTextBlock([
+        const text = renderTextElement([
             '<p></p>',
             '<p></p>',
             '<span></span>',

--- a/src/article.ts
+++ b/src/article.ts
@@ -84,7 +84,9 @@ const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, No
     return new Err(`There was no blockquote element in the tweet with id: ${tweetId}`);
 }
 
-const parseElement = (docParser: DocParser) => (element: BlockElement): Result<string, BodyElement> => {
+const parseElement =
+    (docParser: DocParser) => (element: BlockElement): Result<string, BodyElement> => {
+
     switch (element.type) {
 
         case ElementType.TEXT:
@@ -133,9 +135,11 @@ const parseElement = (docParser: DocParser) => (element: BlockElement): Result<s
         default:
             return new Err(`I'm afraid I don't understand the element I was given: ${element.type}`);
     }
+
 }
 
-const parseElements = (docParser: DocParser) => (elements: BlockElement[]): Result<string, BodyElement>[] =>
+const parseElements =
+    (docParser: DocParser) => (elements: BlockElement[]): Result<string, BodyElement>[] =>
     elements.map(parseElement(docParser));
 
 function parseLayout(content: Content): Layout {

--- a/src/article.ts
+++ b/src/article.ts
@@ -37,11 +37,11 @@ type Article = {
     series: Tag;
     commentable: boolean;
     starRating: Option<number>;
-    blocks: Result<string, Block>[];
+    body: Result<string, BodyElement>[];
     tags: Tag[];
 };
 
-type Block = {
+type BodyElement = {
     kind: ElementType.TEXT;
     doc: DocumentFragment;
 } | {
@@ -84,7 +84,7 @@ const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, No
     return new Err(`There was no blockquote element in the tweet with id: ${tweetId}`);
 }
 
-const parseBlock = (docParser: DocParser) => (block: BlockElement): Result<string, Block> => {
+const parseElement = (docParser: DocParser) => (block: BlockElement): Result<string, BodyElement> => {
     switch (block.type) {
 
         case ElementType.TEXT:
@@ -94,7 +94,7 @@ const parseBlock = (docParser: DocParser) => (block: BlockElement): Result<strin
 
             const masterAsset = block.assets.find(asset => asset.typeData.isMaster);
             const { alt, caption, displayCredit, credit } = block.imageTypeData;
-            const imageBlock: Option<Result<string, Block>> = fromNullable(masterAsset)
+            const imageBlock: Option<Result<string, BodyElement>> = fromNullable(masterAsset)
                 .map(asset => new Ok({
                     kind: ElementType.IMAGE,
                     alt,
@@ -135,8 +135,8 @@ const parseBlock = (docParser: DocParser) => (block: BlockElement): Result<strin
     }
 }
 
-const parseBlocks = (docParser: DocParser) => (blocks: BlockElement[]): Result<string, Block>[] =>
-    blocks.map(parseBlock(docParser));
+const parseElements = (docParser: DocParser) => (blocks: BlockElement[]): Result<string, BodyElement>[] =>
+    blocks.map(parseElement(docParser));
 
 function parseLayout(content: Content): Layout {
     switch (content.type) {
@@ -184,7 +184,7 @@ const fromCapi = (docParser: DocParser) => (content: Content): Article =>
         series: articleSeries(content),
         commentable: content.fields.commentable,
         starRating: fromNullable(content.fields.starRating),
-        blocks: parseBlocks(docParser)(content.blocks.body[0].elements),
+        body: parseElements(docParser)(content.blocks.body[0].elements),
         tags: content.tags,
     });
 
@@ -194,6 +194,6 @@ const fromCapi = (docParser: DocParser) => (content: Content): Article =>
 export {
     Article,
     Layout,
-    Block,
+    BodyElement,
     fromCapi,
 };

--- a/src/article.ts
+++ b/src/article.ts
@@ -84,16 +84,16 @@ const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, No
     return new Err(`There was no blockquote element in the tweet with id: ${tweetId}`);
 }
 
-const parseElement = (docParser: DocParser) => (block: BlockElement): Result<string, BodyElement> => {
-    switch (block.type) {
+const parseElement = (docParser: DocParser) => (element: BlockElement): Result<string, BodyElement> => {
+    switch (element.type) {
 
         case ElementType.TEXT:
-            return new Ok({ kind: ElementType.TEXT, doc: docParser(block.textTypeData.html) });
+            return new Ok({ kind: ElementType.TEXT, doc: docParser(element.textTypeData.html) });
 
         case ElementType.IMAGE:
 
-            const masterAsset = block.assets.find(asset => asset.typeData.isMaster);
-            const { alt, caption, displayCredit, credit } = block.imageTypeData;
+            const masterAsset = element.assets.find(asset => asset.typeData.isMaster);
+            const { alt, caption, displayCredit, credit } = element.imageTypeData;
             const imageBlock: Option<Result<string, BodyElement>> = fromNullable(masterAsset)
                 .map(asset => new Ok({
                     kind: ElementType.IMAGE,
@@ -110,7 +110,7 @@ const parseElement = (docParser: DocParser) => (block: BlockElement): Result<str
 
         case ElementType.PULLQUOTE:
 
-            const { html: quote, attribution } = block.pullquoteTypeData;
+            const { html: quote, attribution } = element.pullquoteTypeData;
             return new Ok({
                 kind: ElementType.PULLQUOTE,
                 quote,
@@ -118,25 +118,25 @@ const parseElement = (docParser: DocParser) => (block: BlockElement): Result<str
             });
 
         case ElementType.INTERACTIVE:
-            const { iframeUrl } = block.interactiveTypeData;
+            const { iframeUrl } = element.interactiveTypeData;
             return new Ok({ kind: ElementType.INTERACTIVE, url: iframeUrl });
 
         case ElementType.RICH_LINK:
 
-            const { url, linkText } = block.richLinkTypeData;
+            const { url, linkText } = element.richLinkTypeData;
             return new Ok({ kind: ElementType.RICH_LINK, url, linkText });
 
         case ElementType.TWEET:
-            return tweetContent(block.tweetTypeData.id, docParser(block.tweetTypeData.html))
+            return tweetContent(element.tweetTypeData.id, docParser(element.tweetTypeData.html))
                 .map(content => ({ kind: ElementType.TWEET, content }));
 
         default:
-            return new Err(`I'm afraid I don't understand the block I was given: ${block.type}`);
+            return new Err(`I'm afraid I don't understand the element I was given: ${element.type}`);
     }
 }
 
-const parseElements = (docParser: DocParser) => (blocks: BlockElement[]): Result<string, BodyElement>[] =>
-    blocks.map(parseElement(docParser));
+const parseElements = (docParser: DocParser) => (elements: BlockElement[]): Result<string, BodyElement>[] =>
+    elements.map(parseElement(docParser));
 
 function parseLayout(content: Content): Layout {
     switch (content.type) {

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -90,7 +90,7 @@ const WithScript = (props: { src: string; children: ReactNode }): ReactElement =
 
 function ArticleBody({ capi, imageSalt }: BodyProps): React.ReactElement {
     const article = fromCapi(JSDOM.fragment)(capi);
-    const body = partition(article.blocks).oks;
+    const body = partition(article.body).oks;
     const content = insertAdPlaceholders(renderAll(imageSalt)(article.pillar, body));
     const articleScript = '/assets/article.js';
     const liveblogScript = '/assets/liveblog.js';

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -270,7 +270,7 @@ const Interactive = (props: { url: string }): ReactElement =>
 const Tweet = (props: { content: NodeList; pillar: Pillar; key: number }): ReactElement =>
     h('blockquote', { key: props.key }, ...Array.from(props.content).map(textElement(props.pillar)));
 
-const render = (salt: string) => (pillar: Pillar) => (element: BodyElement, key: number): ReactNode => {
+const render = (salt: string, pillar: Pillar) => (element: BodyElement, key: number): ReactNode => {
     switch (element.kind) {
 
         case ElementType.TEXT:
@@ -311,7 +311,7 @@ const render = (salt: string) => (pillar: Pillar) => (element: BodyElement, key:
 }
 
 const renderAll = (salt: string) => (pillar: Pillar, elements: BodyElement[]): ReactNode[] =>
-    elements.map(render(salt)(pillar));
+    elements.map(render(salt, pillar));
 
 
 // ----- Exports ----- //

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -11,7 +11,7 @@ import { srcset, transformUrl } from 'asset';
 import { basePx, icons, headlineFont, darkModeCss, textSans } from 'styles';
 import { getPillarStyles, Pillar } from 'pillar';
 import { imageRatioStyles } from 'components/blocks/image';
-import { Block } from 'article';
+import { BodyElement } from 'article';
 
 
 // ----- Renderer ----- //
@@ -270,14 +270,14 @@ const Interactive = (props: { url: string }): ReactElement =>
 const Tweet = (props: { content: NodeList; pillar: Pillar; key: number }): ReactElement =>
     h('blockquote', { key: props.key }, ...Array.from(props.content).map(textElement(props.pillar)));
 
-const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number): ReactNode => {
-    switch (block.kind) {
+const render = (salt: string) => (pillar: Pillar) => (element: BodyElement, key: number): ReactNode => {
+    switch (element.kind) {
 
         case ElementType.TEXT:
-            return text(block.doc, pillar);
+            return text(element.doc, pillar);
 
         case ElementType.IMAGE:
-            const { file, alt, caption, displayCredit, credit, width, height } = block;
+            const { file, alt, caption, displayCredit, credit, width, height } = element;
             return h(Image, {
                 url: file,
                 alt,
@@ -291,18 +291,18 @@ const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number)
             });
 
         case ElementType.PULLQUOTE:
-            const { quote, attribution } = block;
+            const { quote, attribution } = element;
             return h(Pullquote, { quote, attribution, pillar, key });
 
         case ElementType.RICH_LINK:
-            const { url, linkText } = block;
+            const { url, linkText } = element;
             return h(RichLink, { url, linkText, pillar, key });
 
         case ElementType.INTERACTIVE:
-            return h(Interactive, { url: block.url, key });
+            return h(Interactive, { url: element.url, key });
 
         case ElementType.TWEET:
-            return h(Tweet, { content: block.content, pillar, key });
+            return h(Tweet, { content: element.content, pillar, key });
 
         default:
             return null;
@@ -310,8 +310,8 @@ const render = (salt: string) => (pillar: Pillar) => (block: Block, key: number)
     }
 }
 
-const renderAll = (salt: string) => (pillar: Pillar, blocks: Block[]): ReactNode[] =>
-    blocks.map(render(salt)(pillar));
+const renderAll = (salt: string) => (pillar: Pillar, elements: BodyElement[]): ReactNode[] =>
+    elements.map(render(salt)(pillar));
 
 
 // ----- Exports ----- //


### PR DESCRIPTION
## Why are you doing this?

I named the `Block` type poorly, as it doesn't match up with the data structure in the blocks API. This is likely to cause confusion, particularly on the liveblog. This PR renames that type to more accurately reflect its usage in the API.

## Changes

- Renamed `Block` type to `BodyElement`.
- Updated terminology across the codebase to match.
