### PR TITLE
Use Article Type on Liveblog

### DIFF
--- a/src/components/immersive/article.tsx
+++ b/src/components/immersive/article.tsx
@@ -15,7 +15,7 @@ import Tags from 'components/shared/tags';
 import { articleWidthStyles, basePx, darkModeCss } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { getPillarStyles, Pillar } from 'pillar';
-import { Article } from 'article';
+import { Standard } from 'article';
 
 
 // ----- Styles ----- //
@@ -77,7 +77,7 @@ const HeaderImageStyles = css`
 
 interface Props {
     imageSalt: string;
-    article: Article;
+    article: Standard;
     children: ReactNode[];
 }
 

--- a/src/components/liveblog/article.tsx
+++ b/src/components/liveblog/article.tsx
@@ -9,13 +9,11 @@ import LiveblogBody from 'components/liveblog/body';
 import HeaderImage from 'components/shared/headerImage';
 import Tags from 'components/shared/tags';
 import { wideColumnWidth, baseMultiply, darkModeCss } from 'styles';
-import { Content } from 'capiThriftModels';
 import { css, SerializedStyles } from '@emotion/core'
 import { palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { articleMainImage, articleSeries, articleContributors } from 'capi';
 import { PillarStyles, getPillarStyles } from 'pillar';
-import { Article } from 'article';
+import { Liveblog } from 'article';
 
 const LiveblogArticleStyles: SerializedStyles = css`
     background: ${palette.neutral[97]};
@@ -47,47 +45,31 @@ const HeaderImageStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
 `;
 
 interface LiveblogArticleProps {
-    capi: Content;
-    article: Article;
+    article: Liveblog;
     imageSalt: string;
 }
 
-const LiveblogArticle = ({ capi, article, imageSalt }: LiveblogArticleProps): JSX.Element => {
-
-    const { fields, tags, webPublicationDate, blocks } = capi;
-    const series = articleSeries(capi);
-    const pillarStyles = getPillarStyles(article.pillar);
-    const contributors = articleContributors(capi);
-    const bodyElements = blocks.body;
-    const image = articleMainImage(capi);
+const LiveblogArticle = ({ article, imageSalt }: LiveblogArticleProps): JSX.Element => {
 
     return (
         <main css={LiveblogArticleStyles}>
             <div css={BorderStyles}>
-                <LiveblogSeries series={series} pillarStyles={pillarStyles} />
-                <LiveblogHeadline headline={fields.headline} pillarStyles={pillarStyles} />
-                <LiveblogStandfirst standfirst={fields.standfirst} pillarStyles={pillarStyles} />
-                <LiveblogByline
-                    byline={fields.bylineHtml}
-                    pillarStyles={pillarStyles}
-                    article={article}
-                    publicationDate={webPublicationDate}
-                    contributors={contributors}
-                    imageSalt={imageSalt}
-                    commentable={fields.commentable}
-                />
+                <LiveblogSeries series={article.series} pillar={article.pillar} />
+                <LiveblogHeadline headline={article.headline} pillar={article.pillar} />
+                <LiveblogStandfirst standfirst={article.standfirst} pillar={article.pillar} />
+                <LiveblogByline article={article} imageSalt={imageSalt} />
                 <HeaderImage
-                    image={image}
+                    image={article.mainImage}
                     imageSalt={imageSalt}
-                    className={HeaderImageStyles(pillarStyles)}
+                    className={HeaderImageStyles(getPillarStyles(article.pillar))}
                 />
-                <LiveblogKeyEvents bodyElements={bodyElements} pillarStyles={pillarStyles} />
+                <LiveblogKeyEvents blocks={article.blocks} pillar={article.pillar} />
                 <LiveblogBody
-                    bodyElements={bodyElements}
-                    pillarStyles={pillarStyles}
+                    blocks={article.blocks}
+                    pillar={article.pillar}
                     imageSalt={imageSalt}
                 />
-                <Tags tags={tags} background={palette.neutral[93]} />
+                <Tags tags={article.tags} background={palette.neutral[93]} />
             </div>
         </main>
     );

--- a/src/components/liveblog/block.tsx
+++ b/src/components/liveblog/block.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { textSans, icons, basePx, linkStyle } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
 import { palette } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
 import { makeRelativeDate, formatDate } from 'date';
 import LeftColumn from 'components/shared/leftColumn';
-import { PillarStyles } from 'pillar';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
 
 const LiveblogBlockStyles = ({ kicker }: PillarStyles, highlighted: boolean): SerializedStyles => css`
     background: ${palette.neutral[100]};
@@ -58,12 +58,12 @@ const LiveblogBlockStyles = ({ kicker }: PillarStyles, highlighted: boolean): Se
 `;
 
 interface LiveblogBlockProps {
-    pillarStyles: PillarStyles;
+    pillar: Pillar;
     highlighted: boolean;
     firstPublishedDate: Date;
     lastModifiedDate: Date;
     title: string;
-    children: JSX.Element;
+    children: ReactNode;
 }
 
 interface TitleProps {
@@ -79,22 +79,22 @@ const Title = ({ title, highlighted }: TitleProps): JSX.Element | null => {
     return title ? <h3><span css={highlighted ? TitleStyles : null}>{title}</span></h3> : null;
 }
 
-const LiveblogBlock = (props: LiveblogBlockProps): JSX.Element => {
-    const {
-        pillarStyles,
-        highlighted,
-        title,
-        children,
-        firstPublishedDate,
-        lastModifiedDate
-    } = props;
+const LiveblogBlock = ({
+    pillar,
+    highlighted,
+    title,
+    children,
+    firstPublishedDate,
+    lastModifiedDate,
+}: LiveblogBlockProps): JSX.Element => {
     const relativeDate = makeRelativeDate(firstPublishedDate);
     const timeAgo = relativeDate ? <time>{relativeDate}</time> : null;
+
     return (
         <article>
             <LeftColumn
                 columnContent={timeAgo}
-                className={LiveblogBlockStyles(pillarStyles, highlighted)}
+                className={LiveblogBlockStyles(getPillarStyles(pillar), highlighted)}
             >
                 <Title highlighted={highlighted} title={title} />
                 {children}

--- a/src/components/liveblog/body.tsx
+++ b/src/components/liveblog/body.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { bulletStyles, commonArticleStyles } from 'styles';
 import LiveblogBlock from './block';
 import LiveblogLoadMore from './loadMore';
-import { render } from 'renderBlocks';
-import { Block } from 'capiThriftModels';
 
 import { css, SerializedStyles } from '@emotion/core'
-import { PillarStyles } from 'pillar';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
+import { LiveBlock } from 'article';
+import { renderAll } from 'renderer';
+import { partition } from 'types/result';
 
 const LiveBodyStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
     .rich-link,
@@ -28,35 +29,37 @@ const LiveBodyStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
 `;
 
 interface LiveblogBodyProps {
-    pillarStyles: PillarStyles;
-    bodyElements: Block[];
+    pillar: Pillar;
+    blocks: LiveBlock[];
     imageSalt: string;
 }
 
-const LiveblogBody= ({ pillarStyles, bodyElements, imageSalt }: LiveblogBodyProps): JSX.Element => {
-    const initialBlocks = bodyElements.slice(0, 7);
+const LiveblogBody = ({ pillar, blocks, imageSalt }: LiveblogBodyProps): JSX.Element => {
+
+    const initialBlocks = blocks.slice(0, 7);
     const LoadMore = ({ total }: { total: number }): JSX.Element | null => total > 10
-        ? <LiveblogLoadMore pillarStyles={pillarStyles}/> 
+        ? <LiveblogLoadMore pillar={pillar}/> 
         : null;
-    const ads = false;
+
     return (
-        <article css={LiveBodyStyles(pillarStyles)}>
+        <article css={LiveBodyStyles(getPillarStyles(pillar))}>
             {
-                initialBlocks.map((block: Block) => {
+                initialBlocks.map((block: LiveBlock) => {
                     return <LiveblogBlock
                         key={block.id}
-                        pillarStyles={pillarStyles} 
-                        highlighted={!!block.attributes.keyEvent}
+                        pillar={pillar} 
+                        highlighted={block.isKeyEvent}
                         title={block.title}
-                        firstPublishedDate={block.firstPublishedDate}
-                        lastModifiedDate={block.lastModifiedDate}>
-                            <>{render(block.elements, imageSalt, ads).html}</>
+                        firstPublishedDate={block.firstPublished}
+                        lastModifiedDate={block.lastModified}>
+                            <>{ renderAll(imageSalt)(pillar, partition(block.body).oks) }</>
                         </LiveblogBlock>
                 })
             }
-            <LoadMore total={bodyElements.length}/>
+            <LoadMore total={blocks.length}/>
         </article>
-    )
+    );
+
 }
 
 export default LiveblogBody;

--- a/src/components/liveblog/byline.tsx
+++ b/src/components/liveblog/byline.tsx
@@ -1,16 +1,15 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { textSans, basePx } from 'styles';
 import { Keyline } from '../shared/keyline';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
-import { Contributor } from '../../capi';
 import { formatDate } from 'date';
 import Avatar from 'components/shared/avatar';
 import LeftColumn from 'components/shared/leftColumn';
-import { PillarStyles } from 'pillar';
-import { componentFromHtml } from 'renderBlocks';
+import { PillarStyles, getPillarStyles } from 'pillar';
 import { CommentCount } from 'components/shared/commentCount';
 import { Article } from 'article';
+import { renderText } from 'renderer';
 
 const LiveblogBylineStyles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
     background: ${liveblogBackground};
@@ -65,25 +64,19 @@ const commentCount = ({ liveblogBackground }: PillarStyles): SerializedStyles =>
 `
 
 interface LiveblogBylineProps {
-    byline?: string;
-    pillarStyles: PillarStyles;
-    publicationDate: string;
-    contributors: Contributor[];
     article: Article;
     imageSalt: string;
-    commentable: boolean;
 }
 
-const LiveblogByline = ({
-    byline,
-    pillarStyles,
-    publicationDate,
-    contributors,
-    article,
-    imageSalt,
-    commentable
-}: LiveblogBylineProps): JSX.Element => {
-    
+const LiveblogByline = ({ article, imageSalt}: LiveblogBylineProps): JSX.Element => {
+    const pillarStyles = getPillarStyles(article.pillar);
+
+    const byline = article.bylineHtml.map<ReactNode>(html =>
+        // This is not an iterator, ESLint is confused
+        // eslint-disable-next-line react/jsx-key
+        <address>{ renderText(html, article.pillar) }</address>
+    ).withDefault(null);
+
     return (
         <div css={[LiveblogBylineStyles(pillarStyles)]}>
             <Keyline {...article} />
@@ -91,18 +84,18 @@ const LiveblogByline = ({
                 <section>
                     <div className="byline">
                         <Avatar
-                            contributors={contributors}
+                            contributors={article.contributors}
                             bgColour={pillarStyles.featureHeadline}
                             imageSalt={imageSalt}
                         />
                         <div className="author">
-                            { byline ? <address>{componentFromHtml(byline)}</address> : null }
-                            <time>{ formatDate(new Date(publicationDate)) }</time>
+                            { byline }
+                            <time>{ formatDate(new Date(article.publishDate)) }</time>
                             <div className="follow">Get alerts on this story</div>
                         </div>
                     </div>
 
-                    {commentable
+                    {article.commentable
                         ? <CommentCount
                             count={0}
                             colour={palette.neutral[100]}

--- a/src/components/liveblog/headline.tsx
+++ b/src/components/liveblog/headline.tsx
@@ -3,7 +3,7 @@ import { basePx, headlineFont, headlineFontStyles } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
 import { palette } from '@guardian/src-foundations'
 import LeftColumn from 'components/shared/leftColumn';
-import { PillarStyles } from 'pillar';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
 
 const LiveblogHeadlineStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     padding: ${basePx(0, 0, 4, 0)};
@@ -18,11 +18,11 @@ const LiveblogHeadlineStyles = ({ kicker }: PillarStyles): SerializedStyles => c
 
 interface LiveblogHeadlineProps {
     headline: string;
-    pillarStyles: PillarStyles;
+    pillar: Pillar;
 }
 
-const LiveblogHeadline = ({ headline, pillarStyles }: LiveblogHeadlineProps): JSX.Element =>
-    <LeftColumn className={LiveblogHeadlineStyles(pillarStyles)}>
+const LiveblogHeadline = ({ headline, pillar }: LiveblogHeadlineProps): JSX.Element =>
+    <LeftColumn className={LiveblogHeadlineStyles(getPillarStyles(pillar))}>
         <h1>{ headline }</h1>
     </LeftColumn>
 

--- a/src/components/liveblog/keyEvents.tsx
+++ b/src/components/liveblog/keyEvents.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { icons, basePx, headlineFont } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
 import { palette } from '@guardian/src-foundations';
-import { Block } from 'capiThriftModels';
 import { makeRelativeDate } from 'date';
-import { PillarStyles } from 'pillar';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
+import { LiveBlock } from 'article';
 
 const LiveblogKeyEventsStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     background: ${palette.neutral[100]};
@@ -135,21 +135,21 @@ const LiveblogKeyEventsStyles = ({ kicker }: PillarStyles): SerializedStyles => 
 `;
 
 interface LiveblogKeyEventsProps {
-    pillarStyles: PillarStyles;
-    bodyElements: Block[];
+    pillar: Pillar;
+    blocks: LiveBlock[];
 }
 
-const LiveblogKeyEvents = ({ pillarStyles, bodyElements }: LiveblogKeyEventsProps): JSX.Element => {
-    const keyEvents = bodyElements.filter(elem => elem.attributes.keyEvent as boolean).slice(0, 7);
+const LiveblogKeyEvents = ({ pillar, blocks }: LiveblogKeyEventsProps): JSX.Element => {
+    const keyEvents = blocks.filter(elem => elem.isKeyEvent).slice(0, 7);
     return (
-        <section css={LiveblogKeyEventsStyles(pillarStyles)}>
+        <section css={LiveblogKeyEventsStyles(getPillarStyles(pillar))}>
             <details>
                 <summary><h2>Key Events ({keyEvents.length})</h2></summary>
                 <ul>
-                    {keyEvents.map((event, index) => {
-                        const relativeDate = makeRelativeDate(event.firstPublishedDate);
+                    {keyEvents.map(event => {
+                        const relativeDate = makeRelativeDate(event.firstPublished);
                         const time = relativeDate ? <time>{relativeDate}</time> : null;
-                        return <li key={index}>
+                        return <li key={event.id}>
                             { time }
                             <a>{event.title}</a>
                         </li>

--- a/src/components/liveblog/liveblog.stories.tsx
+++ b/src/components/liveblog/liveblog.stories.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import LiveblogLoadMore from './loadMore';
-import { pillarColours, Pillar } from 'pillar';
-import { withKnobs, object } from "@storybook/addon-knobs";
+import { Pillar } from 'pillar';
+import { withKnobs, select } from "@storybook/addon-knobs";
 
 export default { title: 'Liveblog', decorators: [withKnobs] };
 
 export const LoadMore = (): JSX.Element => <LiveblogLoadMore
-  pillarStyles={object("Pillar Styles", pillarColours[Pillar.news])}
+  pillar={select(
+    "Pillar",
+    [ Pillar.news, Pillar.opinion, Pillar.sport, Pillar.arts, Pillar.lifestyle ],
+    Pillar.news,
+  )}
 />

--- a/src/components/liveblog/loadMore.tsx
+++ b/src/components/liveblog/loadMore.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { sidePadding, icons, textSans } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
 import { palette } from '@guardian/src-foundations';
-import { PillarStyles } from 'pillar';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
 
 const LiveblogLoadMoreStyles = ({ kicker }: PillarStyles): SerializedStyles => css`    
     all: unset;
@@ -32,9 +32,13 @@ const LiveblogLoadMoreStyles = ({ kicker }: PillarStyles): SerializedStyles => c
     }
 `;
 
-const LiveblogLoadMore = ({ pillarStyles }: { pillarStyles: PillarStyles }): JSX.Element => {
+interface Props {
+    pillar: Pillar;
+}
+
+const LiveblogLoadMore = ({ pillar }: Props): JSX.Element => {
     return (
-        <button css={LiveblogLoadMoreStyles(pillarStyles)}>
+        <button css={LiveblogLoadMoreStyles(getPillarStyles(pillar))}>
             <span>View more updates</span>
         </button>
     )

--- a/src/components/liveblog/series.tsx
+++ b/src/components/liveblog/series.tsx
@@ -4,7 +4,7 @@ import { css, SerializedStyles } from '@emotion/core'
 import { palette } from '@guardian/src-foundations';
 import { Series } from '../../capi';
 import LeftColumn from 'components/shared/leftColumn';
-import { PillarStyles } from 'pillar';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
 import { from } from '@guardian/src-foundations/mq';
 
 const LiveblogSeriesStyles = ({ kicker }: PillarStyles): SerializedStyles => css`    
@@ -26,14 +26,14 @@ const LiveblogSeriesStyles = ({ kicker }: PillarStyles): SerializedStyles => css
 
 interface LiveblogSeriesProps {
     series: Series;
-    pillarStyles: PillarStyles;
+    pillar: Pillar;
 }
 
-const LiveblogSeries = ({ series, pillarStyles }: LiveblogSeriesProps): JSX.Element | null => {
+const LiveblogSeries = ({ series, pillar }: LiveblogSeriesProps): JSX.Element | null => {
 
     if (series) {
         return (
-            <LeftColumn className={LiveblogSeriesStyles(pillarStyles)}>
+            <LeftColumn className={LiveblogSeriesStyles(getPillarStyles(pillar))}>
                 <a href={series.webUrl}>{series.webTitle}</a>
             </LeftColumn>
         );

--- a/src/components/liveblog/standfirst.tsx
+++ b/src/components/liveblog/standfirst.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { bulletStyles } from 'styles';
-import { transform } from '../../contentTransformations';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import LeftColumn from 'components/shared/leftColumn';
-import { PillarStyles } from 'pillar';
-import { componentFromHtml } from 'renderBlocks';
+import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
+import { renderText } from 'renderer';
 
 const StandfirstStyles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
     padding-bottom: 6px;
@@ -27,13 +26,13 @@ const StandfirstStyles = ({ liveblogBackground }: PillarStyles): SerializedStyle
 `;
 
 interface LiveblogStandfirstProps {
-    standfirst: string;
-    pillarStyles: PillarStyles;
+    standfirst: DocumentFragment;
+    pillar: Pillar;
 }
 
-const LiveblogStandfirst = ({ standfirst, pillarStyles }: LiveblogStandfirstProps): JSX.Element =>
-    <LeftColumn className={StandfirstStyles(pillarStyles)}>
-        <div>{componentFromHtml(transform(standfirst))}</div>
+const LiveblogStandfirst = ({ standfirst, pillar }: LiveblogStandfirstProps): JSX.Element =>
+    <LeftColumn className={StandfirstStyles(getPillarStyles(pillar))}>
+        <div>{ renderText(standfirst, pillar) }</div>
     </LeftColumn>
 
 export default LiveblogStandfirst;

--- a/src/components/opinion/article.tsx
+++ b/src/components/opinion/article.tsx
@@ -17,7 +17,7 @@ import { darkModeCss, articleWidthStyles, basePx } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { CommentCount } from 'components/shared/commentCount';
 import { getPillarStyles } from 'pillar';
-import { Article } from 'article';
+import { Standard } from 'article';
 
 
 // ----- Styles ----- //
@@ -73,7 +73,7 @@ const topBorder = css`
 
 interface Props {
     imageSalt: string;
-    article: Article;
+    article: Standard;
     children: ReactNode[];
 }
 

--- a/src/components/shared/articleRating.tsx
+++ b/src/components/shared/articleRating.tsx
@@ -36,19 +36,18 @@ const ArticleRatingStyles = css`
 `;
 
 interface ArticleRatingProps {
-   rating: string;
+   rating: number;
 }
 
 const ArticleSeries = ({ rating }: ArticleRatingProps): JSX.Element | null => {
-    const numericalRating = parseInt(rating);
     const acceptedRatings = [0, 1, 2, 3, 4, 5];
-    if (!acceptedRatings.includes(numericalRating)) return null;
+    if (!acceptedRatings.includes(rating)) return null;
 
     return (
         <div css={ArticleRatingStyles}>
             {
                 [...Array(5)].map((_star, index) => {
-                    return index + 1 <= numericalRating
+                    return index + 1 <= rating
                         ? <span key={index} className="filled"></span>
                         : <span key={index}></span>
                 })

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -90,25 +90,32 @@ const WithScript = (props: { src: string; children: ReactNode }): ReactElement =
 
 function ArticleBody({ capi, imageSalt }: BodyProps): React.ReactElement {
     const article = fromCapi(JSDOM.fragment)(capi);
-    const body = partition(article.body).oks;
-    const content = insertAdPlaceholders(renderAll(imageSalt)(article.pillar, body));
+    
     const articleScript = '/assets/article.js';
     const liveblogScript = '/assets/liveblog.js';
 
     switch (article.layout) {
         case Layout.Opinion:
+            const opinionBody = partition(article.body).oks;
+            const opinionContent =
+                insertAdPlaceholders(renderAll(imageSalt)(article.pillar, opinionBody));
+
             return (
                 <WithScript src={articleScript}>
                     <Opinion imageSalt={imageSalt} article={article}>
-                        {content}
+                        {opinionContent}
                     </Opinion>
                 </WithScript>
             );
         case Layout.Immersive:
+            const immersiveBody = partition(article.body).oks;
+            const immersiveContent =
+                insertAdPlaceholders(renderAll(imageSalt)(article.pillar, immersiveBody));
+
             return (
                 <WithScript src={articleScript}>
                     <Immersive imageSalt={imageSalt} article={article}>
-                        {content}
+                        {immersiveContent}
                     </Immersive>
                 </WithScript>
             );
@@ -116,6 +123,9 @@ function ArticleBody({ capi, imageSalt }: BodyProps): React.ReactElement {
         case Layout.Feature:
         case Layout.Analysis:
         case Layout.Review:
+            const body = partition(article.body).oks;
+            const content = insertAdPlaceholders(renderAll(imageSalt)(article.pillar, body));
+
             return (
                 <WithScript src={articleScript}>
                     <Standard imageSalt={imageSalt} article={article}>
@@ -126,7 +136,7 @@ function ArticleBody({ capi, imageSalt }: BodyProps): React.ReactElement {
         case Layout.Liveblog:
             return (
                 <WithScript src={liveblogScript}>
-                    <LiveblogArticle capi={capi} article={article} imageSalt={imageSalt} />
+                    <LiveblogArticle article={article} imageSalt={imageSalt} />
                 </WithScript>
             );
         default:

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -16,7 +16,7 @@ import Tags from 'components/shared/tags';
 import { darkModeCss, articleWidthStyles } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { getPillarStyles } from 'pillar';
-import { Article } from 'article';
+import { Standard, Review } from 'article';
 
 
 // ----- Styles ----- //
@@ -54,7 +54,7 @@ const HeaderImageStyles = css`
 
 interface Props {
     imageSalt: string;
-    article: Article;
+    article: Standard | Review;
     children: ReactNode[];
 }
 
@@ -72,7 +72,6 @@ const Standard = ({ imageSalt, article, children }: Props): JSX.Element =>
                     <Headline
                         headline={article.headline}
                         article={article}
-                        rating={String(article.starRating)}
                     />
                     <Standfirst article={article} className={articleWidthStyles} />
                 </div>

--- a/src/components/standard/headline.tsx
+++ b/src/components/standard/headline.tsx
@@ -58,13 +58,12 @@ const DarkStyles = darkModeCss`
 interface Props {
     headline: string;
     article: Article;
-    rating?: string;
 }
 
-const Headline = ({ headline, article, rating }: Props): JSX.Element =>
+const Headline = ({ headline, article }: Props): JSX.Element =>
     <div css={[Styles(article), DarkStyles]}>
         <h1>{headline}</h1>
-        { rating ? <ArticleRating rating={rating} /> : null }
+        { article.layout === Layout.Review ? <ArticleRating rating={article.starRating} /> : null }
     </div>
 
 


### PR DESCRIPTION
## Why are you doing this?

To bring the liveblog in line with changes made in #138, #145, #147. This should also help to simplify the work @webb04 is doing in #151.

This refactors the `Article` type to narrow it in certain situations:

- Review articles - we *know* that Review articles have a `starRating` field, because the presence of that field is how we define an article as Review. This PR removes the need to pass `starRating` down through the component tree as an optional property: either we're working with a Review article and `starRating` exists, or we're not and we need not include the field.

- Liveblogs - For most article types the blocks API provides a single block for the body, from which we take the `elements` to render the body of the article. However, liveblogs are actually lots of little articles (liveblog "blocks") living within the main liveblog article. This PR adds parsing for the multiple blocks that exist within liveblogs.

## Changes

- Updated the Article type to make it more accurate
- Now different fields for Standard, Liveblog and Review
- Migrated Liveblog components to new Article type
- Added liveblog block parsing
- Simplified Review components by guaranteeing starRating
