### PR TITLE
Opinion styles

### DIFF
--- a/src/components/opinion/headline.tsx
+++ b/src/components/opinion/headline.tsx
@@ -33,7 +33,7 @@ const Styles = css`
         font-weight: 100;
         ${headlineFontStyles}
         color: ${palette.opinion.main};
-        text-decoration: none;
+        background: none;
     }
 `;
 

--- a/src/components/standard/standfirst.tsx
+++ b/src/components/standard/standfirst.tsx
@@ -22,7 +22,9 @@ const FeatureStyles = `
 
 function Styles({ pillar, layout }: Article): SerializedStyles {
     const { kicker } = getPillarStyles(pillar);
-    const includeFeatureStyles = layout === Layout.Feature || layout === Layout.Review;
+    const includeFeatureStyles = layout === Layout.Feature
+        || layout === Layout.Review
+        || layout === Layout.Opinion;
 
     return css`
         padding-bottom: 6px;


### PR DESCRIPTION
## Why are you doing this?
Some changes to closer match the current templates.

## Changes

- Remove underline in opinion headlines
- Use feature font in standfirst

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/72810776-298a3980-3c56-11ea-884a-de40775a915e.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/72810784-327b0b00-3c56-11ea-9dfe-4f61d0bd5eaa.png" width="300px" /> |

