### PR TITLE
handle articles with opinion tags

### DIFF
--- a/src/article.ts
+++ b/src/article.ts
@@ -5,6 +5,7 @@ import { Content, ElementType, BlockElement, Tag, Block } from 'capiThriftModels
 import { isFeature, isAnalysis, isImmersive, isReview, articleMainImage, articleContributors, articleSeries } from 'capi';
 import { Option, fromNullable } from 'types/option';
 import { Err, Ok, Result } from 'types/result';
+import { ITag } from 'mapiThriftModels/Tag';
 
 
 // ----- Types ----- //
@@ -220,11 +221,13 @@ const articleFieldsWithBody = (docParser: DocParser, content: Content): ArticleF
         body: parseElements(docParser)(content.blocks.body[0].elements),
     });
 
+const containsOpinionTags = (tags: Tag[]) =>
+    tags.some(tag => tag.id === 'tone/comment' || tag.id === 'tone/letters')
+
 const fromCapi = (docParser: DocParser) => (content: Content): Article => {
     switch (content.type) {
         case 'article':
-
-            if (pillarFromString(content.pillarId) === Pillar.opinion) {
+            if (pillarFromString(content.pillarId) === Pillar.opinion || containsOpinionTags(content.tags)) {
                 return { layout: Layout.Opinion, ...articleFieldsWithBody(docParser, content) };
 
             } else if (isImmersive(content)) {

--- a/src/article.ts
+++ b/src/article.ts
@@ -5,8 +5,6 @@ import { Content, ElementType, BlockElement, Tag, Block } from 'capiThriftModels
 import { isFeature, isAnalysis, isImmersive, isReview, articleMainImage, articleContributors, articleSeries } from 'capi';
 import { Option, fromNullable } from 'types/option';
 import { Err, Ok, Result } from 'types/result';
-import { ITag } from 'mapiThriftModels/Tag';
-
 
 // ----- Types ----- //
 

--- a/src/article.ts
+++ b/src/article.ts
@@ -223,8 +223,8 @@ const containsOpinionTags = (tags: Tag[]): boolean =>
     tags.some(tag => tag.id === 'tone/comment' || tag.id === 'tone/letters')
 
 const fromCapi = (docParser: DocParser) => (content: Content): Article => {
-    const { type, tags, pillarId, fields, blocks } = content;
-    switch (type) {
+    const { tags, pillarId, fields, blocks } = content;
+    switch (content.type) {
         case 'article':
             if (pillarFromString(pillarId) === Pillar.opinion || containsOpinionTags(tags)) {
                 return { layout: Layout.Opinion, ...articleFieldsWithBody(docParser, content) };

--- a/src/article.ts
+++ b/src/article.ts
@@ -219,13 +219,14 @@ const articleFieldsWithBody = (docParser: DocParser, content: Content): ArticleF
         body: parseElements(docParser)(content.blocks.body[0].elements),
     });
 
-const containsOpinionTags = (tags: Tag[]) =>
+const containsOpinionTags = (tags: Tag[]): boolean =>
     tags.some(tag => tag.id === 'tone/comment' || tag.id === 'tone/letters')
 
 const fromCapi = (docParser: DocParser) => (content: Content): Article => {
-    switch (content.type) {
+    const { type, tags, pillarId, fields, blocks } = content;
+    switch (type) {
         case 'article':
-            if (pillarFromString(content.pillarId) === Pillar.opinion || containsOpinionTags(content.tags)) {
+            if (pillarFromString(pillarId) === Pillar.opinion || containsOpinionTags(tags)) {
                 return { layout: Layout.Opinion, ...articleFieldsWithBody(docParser, content) };
 
             } else if (isImmersive(content)) {
@@ -237,7 +238,7 @@ const fromCapi = (docParser: DocParser) => (content: Content): Article => {
             } else if (isReview(content)) {
                 return {
                     layout: Layout.Review,
-                    starRating: content.fields.starRating,
+                    starRating: fields.starRating,
                     ...articleFieldsWithBody(docParser, content),
                 };
 
@@ -250,7 +251,7 @@ const fromCapi = (docParser: DocParser) => (content: Content): Article => {
         case 'liveblog':
             return {
                 layout: Layout.Liveblog,
-                blocks: parseBlocks(docParser)(content.blocks.body),
+                blocks: parseBlocks(docParser)(blocks.body),
                 ...articleFields(docParser, content),
             };
 

--- a/src/components/shared/Keyline.test.tsx
+++ b/src/components/shared/Keyline.test.tsx
@@ -2,28 +2,27 @@ import React from 'react';
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Keyline } from 'components/shared/keyline';
-import { Pillar } from 'pillar';
 import { Layout } from 'article';
 
 configure({ adapter: new Adapter() });
 
 describe('Keyline component renders as expected', () => {
     it('Renders styles for liveblogs', () => {
-        const article = { pillar: Pillar.opinion, layout: Layout.Liveblog };
+        const article = { layout: Layout.Liveblog };
         const keyline = shallow(<Keyline {...article} />);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
         expect(keyline.props().css.styles).toContain("opacity:.4;")
     })
 
-    it('Renders styles for opinion pillar articles', () => {
-        const article = { pillar: Pillar.opinion, layout: Layout.Standard };
+    it('Renders styles for opinion articles', () => {
+        const article = { layout: Layout.Opinion };
         const keyline = shallow(<Keyline {...article} />);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
         expect(keyline.props().css.styles).toContain("height:24px;")
     })
 
-    it('Renders styles for news pillar articles', () => {
-        const article = { pillar: Pillar.news, layout: Layout.Standard };
+    it('Renders styles for standard articles', () => {
+        const article = { layout: Layout.Standard };
         const keyline = shallow(<Keyline {...article} />);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#dcdcdc,#dcdcdc 1px,transparent 1px,transparent 3px)")
     })

--- a/src/components/shared/keyline.tsx
+++ b/src/components/shared/keyline.tsx
@@ -3,7 +3,6 @@ import { css, SerializedStyles } from '@emotion/core'
 import { darkModeCss, wideContentWidth, wideColumnWidth, baseMultiply } from 'styles';
 import { palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { Pillar } from 'pillar';
 import { Layout } from 'article';
 
 const BaseStyles = css`
@@ -44,19 +43,19 @@ const KeylineDarkStyles = darkModeCss`
 `;
 
 type Props = {
-    pillar: Pillar;
     layout: Layout;
 };
 
-export const Keyline = ({ pillar, layout }: Props): JSX.Element => {
-    const SelectedKeylineStyles = ((pillar, layout): SerializedStyles => {
-        if (layout === Layout.Liveblog) return KeylineLiveblogStyles;
-        switch (pillar) {
-            case Pillar.opinion:
-                return KeylineOpinionStyles;
+export const Keyline = ({ layout }: Props): JSX.Element => {
+    const SelectedKeylineStyles = ((layout): SerializedStyles => {
+        switch(layout) {
+            case Layout.Liveblog:
+                return KeylineLiveblogStyles
+            case Layout.Opinion:
+                return KeylineOpinionStyles
             default:
                 return KeylineNewsStyles;
-        }})(pillar, layout);
+        }})(layout);
     
     return <hr css={[BaseStyles, SelectedKeylineStyles, KeylineDarkStyles]} />
 }

--- a/src/components/shared/shared.stories.tsx
+++ b/src/components/shared/shared.stories.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import Tags from './tags';
 import { Keyline } from './keyline';
-import { Pillar } from 'pillar';
 import { withKnobs } from "@storybook/addon-knobs";
 import { Layout } from 'article';
 export default { title: 'Shared', decorators: [withKnobs] };
 
 export const OpinionKeyline = (): JSX.Element =>
-    <Keyline article={{ pillar: Pillar.opinion, layout: Layout.Opinion }} />
+    <Keyline layout={ Layout.Opinion } />
 
 export const DefaultKeyline = (): JSX.Element =>
-    <Keyline article={{ pillar: Pillar.news, layout: Layout.Standard }} />
+    <Keyline layout={ Layout.Standard } />
 
 export const LiveblogKeyline = (): JSX.Element =>
-    <Keyline article={{ pillar: Pillar.news, layout: Layout.Liveblog }} />
+    <Keyline layout={ Layout.Liveblog } />
 
 const tagsProps = [{
     webTitle: "Tag title",


### PR DESCRIPTION
## Why are you doing this?
Articles with the tags "tone/comment" and "tone/letters" should be rendered as Opinion types (compare dotcom and current app to master with the following article).

http://localhost:8080/australia-news/2020/jan/17/if-the-bushfires-wont-force-climate-policy-change-we-need-to-circumvent-scott-morrison

This logic lives in MAPI: ```def isComment = tagExistsWithId(TagConstants.CommentIsFreeTone) || tagExistsWithId(TagConstants.LettersTone)```

## Changes
- Refactored `Keyline` to determine styles based on `Layout` rather than a combination of layout and pillar
