### PR TITLE
Rename functor map to fmap

### DIFF
--- a/src/article.ts
+++ b/src/article.ts
@@ -135,7 +135,7 @@ const parseImage = (element: BlockElement): Option<Image> => {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return fromNullable(masterAsset).map((asset: any) => ({
+    return fromNullable(masterAsset).fmap((asset: any) => ({
         kind: ElementKind.Image,
         alt,
         caption,
@@ -197,7 +197,7 @@ const parseElement =
                 return new Err('No "html" field on tweetTypeData')
             }
             return tweetContent(id, docParser(h))
-                .map(content => ({ kind: ElementKind.Tweet, content }));
+                .fmap(content => ({ kind: ElementKind.Tweet, content }));
 
         default:
             return new Err(`I'm afraid I don't understand the element I was given: ${element.type}`);
@@ -245,9 +245,9 @@ const articleFields = (docParser: DocParser, content: Content): ArticleFields =>
     ({
         pillar: pillarFromString(content?.pillarId),
         headline: content?.fields?.headline ?? "",
-        standfirst: fromNullable(content?.fields?.standfirst).map(docParser),
+        standfirst: fromNullable(content?.fields?.standfirst).fmap(docParser),
         byline: content?.fields?.byline ?? "",
-        bylineHtml: fromNullable(content?.fields?.bylineHtml).map(docParser),
+        bylineHtml: fromNullable(content?.fields?.bylineHtml).fmap(docParser),
         publishDate: capiDateTimeToDate(content.webPublicationDate),
         mainImage: articleMainImage(content).andThen(parseImage),
         contributors: articleContributors(content),

--- a/src/article.ts
+++ b/src/article.ts
@@ -159,7 +159,7 @@ const parseElement =
 
         case 'image':
             return parseImage(element)
-                .map<Result<string, Image>>(image => new Ok(image))
+                .fmap<Result<string, Image>>(image => new Ok(image))
                 .withDefault(new Err('I couldn\'t find a master asset'));
 
         case 'pullquote':

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -51,7 +51,7 @@ function parseCapiError(capiResponse: string): string {
         const capiError: CapiError = JSON.parse(capiResponse);
 
         return extractErrorMessage(capiError)
-            .map(msg => `It came with this message: ${msg}`)
+            .fmap(msg => `It came with this message: ${msg}`)
             .withDefault('There was no message to explain why.');
     } catch (e) {
         return `I wasn\'t able to parse the error message because: ${e}`;

--- a/src/components/immersive/byline.tsx
+++ b/src/components/immersive/byline.tsx
@@ -65,9 +65,7 @@ function Byline({ pillar, publicationDate, contributors, className }: Props): JS
             <div css={sidePadding}>
                 <div className="author">
                     { publicationDate
-                        // This is not an iterator, ESLint is confused
-                        // eslint-disable-next-line react/jsx-key
-                        .map<JSX.Element | null>(date => <time>{formatDate(date)}</time>)
+                        .fmap<JSX.Element | null>(date => <time>{formatDate(date)}</time>)
                         .withDefault(null) }
                     <Follow contributors={contributors} />
                 </div>

--- a/src/components/immersive/headerImage.tsx
+++ b/src/components/immersive/headerImage.tsx
@@ -43,9 +43,7 @@ interface Props {
 }
 
 const HeaderImage = ({ className, image, imageSalt }: Props): JSX.Element | null =>
-    image.map<JSX.Element | null>(imageData =>
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
+    image.fmap<JSX.Element | null>(imageData =>
         <div css={[className, Styles]}>
             <figure>
                 <ImageElement

--- a/src/components/immersive/standfirst.tsx
+++ b/src/components/immersive/standfirst.tsx
@@ -61,16 +61,14 @@ const Standfirst = ({
 }: Props): JSX.Element => {
     const pillarStyles = getPillarStyles(pillar);
 
-    const standfirstHtml = standfirst.map<ReactNode>(html =>
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
+    const standfirstHtml = standfirst.fmap<ReactNode>(html =>
         renderText(html, pillar)
     ).withDefault(null)
 
     const standfirstIncludesByline = standfirst
-        .map(doc => doc.textContent?.includes(byline)).withDefault(false);
+        .fmap(doc => doc.textContent?.includes(byline)).withDefault(false);
 
-    const content = bylineHtml.map<ReactNode>(html => {
+    const content = bylineHtml.fmap<ReactNode>(html => {
         if (byline !== '' && standfirstIncludesByline) {
             return <div>{standfirstHtml}</div>;
         } else {

--- a/src/components/liveblog/block.tsx
+++ b/src/components/liveblog/block.tsx
@@ -95,15 +95,11 @@ const LiveblogBlock = ({
 }: LiveblogBlockProps): JSX.Element => {
 
     const relativeFirstPublished: JSX.Element | null = firstPublishedDate
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
-        .map<JSX.Element | null>(date => <time>{makeRelativeDate(date)}</time>)
+        .fmap<JSX.Element | null>(date => <time>{makeRelativeDate(date)}</time>)
         .withDefault(null)
 
     const relativeLastModified: JSX.Element | null = lastModifiedDate
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
-        .map<JSX.Element | null>(date => <time>Last updated: {formatDate(date)}</time>)
+        .fmap<JSX.Element | null>(date => <time>Last updated: {formatDate(date)}</time>)
         .withDefault(null)
 
     return (

--- a/src/components/liveblog/byline.tsx
+++ b/src/components/liveblog/byline.tsx
@@ -74,15 +74,11 @@ interface LiveblogBylineProps {
 const LiveblogByline = ({ article, imageSalt}: LiveblogBylineProps): JSX.Element => {
     const pillarStyles = getPillarStyles(article.pillar);
 
-    const byline = article.bylineHtml.map<ReactNode>(html =>
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
+    const byline = article.bylineHtml.fmap<ReactNode>(html =>
         <address>{ renderText(html, article.pillar) }</address>
     ).withDefault(null);
 
-    const date = article.publishDate.map<ReactNode>(date =>
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
+    const date = article.publishDate.fmap<ReactNode>(date =>
         <time>{ formatDate(new Date(date)) }</time>
     ).withDefault(null)
 

--- a/src/components/liveblog/keyEvents.tsx
+++ b/src/components/liveblog/keyEvents.tsx
@@ -148,9 +148,7 @@ const LiveblogKeyEvents = ({ pillar, blocks }: LiveblogKeyEventsProps): JSX.Elem
                 <ul>
                     {keyEvents.map(event => {
                         const relativeDate: JSX.Element | null = event.firstPublished
-                            // This is not an iterator, ESLint is confused
-                            // eslint-disable-next-line react/jsx-key
-                            .map<JSX.Element | null>(date => <time>{makeRelativeDate(date)}</time>)
+                            .fmap<JSX.Element | null>(date => <time>{makeRelativeDate(date)}</time>)
                             .withDefault(null)
 
                         return <li key={event.id}>

--- a/src/components/liveblog/standfirst.tsx
+++ b/src/components/liveblog/standfirst.tsx
@@ -29,9 +29,7 @@ interface LiveblogStandfirstProps {
 }
 
 const LiveblogStandfirst = ({ standfirst, pillar }: LiveblogStandfirstProps): JSX.Element | null =>
-    standfirst.map<JSX.Element | null>(doc =>
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
+    standfirst.fmap<JSX.Element | null>(doc =>
         <LeftColumn className={StandfirstStyles(getPillarStyles(pillar))}>
             <div>{ renderText(doc, pillar) }</div>
         </LeftColumn>

--- a/src/components/opinion/byline.tsx
+++ b/src/components/opinion/byline.tsx
@@ -68,9 +68,7 @@ const Byline = ({ pillar, publicationDate, contributors }: Props): JSX.Element =
             <div css={sidePadding}>
                 <div className="author">
                     { publicationDate
-                        // This is not an iterator, ESLint is confused
-                        // eslint-disable-next-line react/jsx-key
-                        .map<JSX.Element | null>(date => <time>{formatDate(date)}</time>)
+                        .fmap<JSX.Element | null>(date => <time>{formatDate(date)}</time>)
                         .withDefault(null) }
                     <Follow contributors={contributors} />
                 </div>

--- a/src/components/shared/author.tsx
+++ b/src/components/shared/author.tsx
@@ -15,9 +15,7 @@ interface Props {
 }
 
 const Author = (props: Props): JSX.Element | null =>
-    props.byline.map<JSX.Element | null>((bylineHtml: DocumentFragment) =>
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
+    props.byline.fmap<JSX.Element | null>((bylineHtml: DocumentFragment) =>
         h('address', null, renderText(bylineHtml, props.pillar))
     ).withDefault(null);
 

--- a/src/components/shared/headerImage.tsx
+++ b/src/components/shared/headerImage.tsx
@@ -38,9 +38,7 @@ interface HeaderImageProps {
 }
 
 const HeaderImage = ({ className, image, imageSalt }: HeaderImageProps): JSX.Element | null => {
-    const headerImage: Option<JSX.Element | null> = image.map(imageData =>
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
+    const headerImage: Option<JSX.Element | null> = image.fmap(imageData =>
         <div css={[className, Styles(imageData.width, imageData.height)]}>
             <figure aria-labelledby={captionId}>
                 <ImageElement

--- a/src/components/standard/byline.tsx
+++ b/src/components/standard/byline.tsx
@@ -88,9 +88,7 @@ function Byline({ article, imageSalt }: Props): JSX.Element {
                 <div className="author">
                     <Author byline={article.bylineHtml} pillar={article.pillar} />
                     { article.publishDate
-                        // This is not an iterator, ESLint is confused
-                        // eslint-disable-next-line react/jsx-key
-                        .map<JSX.Element | null>(date => <time className="date">{ formatDate(new Date(date)) }</time>)
+                        .fmap<JSX.Element | null>(date => <time className="date">{ formatDate(new Date(date)) }</time>)
                         .withDefault(null) }
                     <Follow contributors={article.contributors} />
                 </div>

--- a/src/components/standard/standfirst.tsx
+++ b/src/components/standard/standfirst.tsx
@@ -60,9 +60,7 @@ interface Props {
 }
 
 const Standfirst = ({ article, className }: Props): JSX.Element | null =>
-    article.standfirst.map<JSX.Element | null>(standfirst =>
-        // This is not an iterator, ESLint is confused
-        // eslint-disable-next-line react/jsx-key
+    article.standfirst.fmap<JSX.Element | null>(standfirst =>
         <div css={[className, Styles(article), DarkStyles(article)]}>
             {renderText(standfirst, article.pillar)}
         </div>

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -23,7 +23,7 @@ const getAttrs = (node: Node): Option<NamedNodeMap> =>
 
 const getAttr = (attr: string) => (node: Node): Option<string> =>
     getAttrs(node).andThen(attrs =>
-        fromNullable(attrs.getNamedItem(attr)).map(attr => attr.value)
+        fromNullable(attrs.getNamedItem(attr)).fmap(attr => attr.value)
     );
 
 const getHref: (node: Node) => Option<string> =

--- a/src/server/ssmConfig.ts
+++ b/src/server/ssmConfig.ts
@@ -39,7 +39,7 @@ async function getState(): Promise<Config> {
 }
 
 async function fetchConfig(): Promise<Config> {
-    return state.map(s => Promise.resolve(s)).withDefault(getState());
+    return state.fmap(s => Promise.resolve(s)).withDefault(getState());
 }
 
 export async function getConfigValue<A>(key: string, defaultValue?: A): Promise<A> {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -164,8 +164,8 @@ export const fontFace = (
 ): SerializedStyles => css`
   @font-face {
     font-family: ${family};
-    ${style.map((s: string) => `font-style: ${s};`).withDefault('')}
-    ${weight.map((w: number | string) => `font-weight: ${w};`).withDefault('')}
+    ${style.fmap((s: string) => `font-style: ${s};`).withDefault('')}
+    ${weight.fmap((w: number | string) => `font-weight: ${w};`).withDefault('')}
     src: url('${url}');
   }
 `;

--- a/src/types/functor.ts
+++ b/src/types/functor.ts
@@ -1,7 +1,7 @@
 // ----- Interface ----- //
 
 interface Functor<A> {
-    map<B>(f: (a: A) => B): Functor<B>;
+    fmap<B>(f: (a: A) => B): Functor<B>;
 }
 
 

--- a/src/types/option.ts
+++ b/src/types/option.ts
@@ -17,7 +17,7 @@ class Some<A> implements OptionInterface<A> {
         return this.value;
     }
 
-    map<B>(f: (a: A) => B): Option<B> {
+    fmap<B>(f: (a: A) => B): Option<B> {
         return new Some(f(this.value));
     }
 
@@ -37,7 +37,7 @@ class None<A> implements OptionInterface<A> {
         return a;
     }
 
-    map<B>(_f: (a: A) => B): Option<B> {
+    fmap<B>(_f: (a: A) => B): Option<B> {
         return new None();
     }
 

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -18,7 +18,7 @@ class Ok<E, B> implements ResultInterface<E, B> {
         return g(this.value);
     }
 
-    map<C>(f: (a: B) => C): Result<E, C> {
+    fmap<C>(f: (a: B) => C): Result<E, C> {
         return new Ok(f(this.value));
     }
 
@@ -44,7 +44,7 @@ class Err<E, B> implements ResultInterface<E, B> {
         return f(this.error);
     }
 
-    map<C>(_f: (a: B) => C): Result<E, C> {
+    fmap<C>(_f: (a: B) => C): Result<E, C> {
         return new Err(this.error);
     }
 


### PR DESCRIPTION
## Why are you doing this?
Rename the functor `map` function to `fmap`. This lets us:
1. Easily distinguish between types, standard JavaScript arrays and `Option`, `Result` etc
2. Remove ESLint warnings and rule suppression comments throughout the codebase

Would be interested in your opinions on this... we're using functor `map` a lot more with the new CAPI types.