### PR TITLE
Mss 1413 more logs

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -211,7 +211,7 @@ Resources:
               - Action:
                   - ssm:GetParametersByPath
                 Effect: Allow
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/apps-rendering/${Stage}/${Stack}
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/apps-rendering/${Stage}/${Stack}/
               - Action:
                   - autoscaling:DescribeAutoScalingInstances
                   - autoscaling:DescribeAutoScalingGroups

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -211,7 +211,7 @@ Resources:
               - Action:
                   - ssm:GetParametersByPath
                 Effect: Allow
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/mobile-apps-rendering/${Stage}/${Stack}
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/apps-rendering/${Stage}/${Stack}
               - Action:
                   - autoscaling:DescribeAutoScalingInstances
                   - autoscaling:DescribeAutoScalingGroups

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -1,10 +1,10 @@
-import {SharedIniFileCredentials, CredentialProviderChain, ECSCredentials} from "aws-sdk/lib/core";
+import {SharedIniFileCredentials, CredentialProviderChain, EC2MetadataCredentials} from "aws-sdk/lib/core";
 import {Region} from "./appIdentity";
 import SSM from "aws-sdk/clients/ssm";
 
 
 const credentialProvider = new CredentialProviderChain([
-    function (): ECSCredentials { return new ECSCredentials(); },
+    function (): EC2MetadataCredentials { return new EC2MetadataCredentials(); },
     function (): SharedIniFileCredentials{ return new SharedIniFileCredentials({
         profile: "mobile"
     }); }                                                                            

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -125,7 +125,17 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
 // ----- App ----- //
 
 const app = express();
-app.use(bodyParser.raw({limit: '50mb'}))
+app.use(bodyParser.raw({limit: '50mb'}));
+
+app.all('*', (request, response, next) => {
+  const start = Date.now();
+  response.once('finish', () => {
+    const duration = Date.now() - start;
+    console.log(`HTTP ${request.method} ${request.path} returned ${response.statusCode} in ${duration}ms`)
+  });
+
+  next();
+});
 
 app.use('/public', express.static(path.resolve(__dirname, '../public')));
 app.use('/assets', express.static(path.resolve(__dirname, '../dist/assets')));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -47,7 +47,11 @@ function checkSupport({ atoms }: Content): Supported {
   return { kind: Support.Supported };
 }
 
-async function serveArticlePost({ body }: Request, res: ExpressResponse, next: NextFunction): Promise<void> {
+async function serveArticlePost(
+    { body }: Request,
+    res: ExpressResponse,
+    next: NextFunction
+): Promise<void> {
   try {
       const transport = new BufferedTransport(body);
       const protocol = new CompactProtocol(transport);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -140,4 +140,4 @@ app.get('/*', bodyParser.raw(), serveArticle);
 app.post('/article', bodyParser.raw(), serveArticlePost);
 
 const port = 3040;
-app.listen(port, () => console.log(`Server listening on port ${port}!\nWebpack dev server listening on port 8080!`));
+app.listen(port, () => console.log(`Server listening on port ${port}!\nIf you're in dev mode, webpack dev server is listening on port 8080`));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import path from 'path';
-import express, { Request, Response as ExpressResponse } from 'express';
+import express, {NextFunction, Request, Response as ExpressResponse} from 'express';
 import compression from 'compression';
 import { createElement as h } from 'react';
 import { renderToString } from 'react-dom/server';
@@ -47,7 +47,7 @@ function checkSupport({ atoms }: Content): Supported {
   return { kind: Support.Supported };
 }
 
-async function serveArticlePost({ body }: Request, res: ExpressResponse): Promise<void> {
+async function serveArticlePost({ body }: Request, res: ExpressResponse, next: NextFunction): Promise<void> {
   try {
       const transport = new BufferedTransport(body);
       const protocol = new CompactProtocol(transport);
@@ -67,7 +67,7 @@ async function serveArticlePost({ body }: Request, res: ExpressResponse): Promis
     }
   } catch (e) {
     console.error(`This error occurred, but I don't know why: ${e}`);
-    res.sendStatus(500);
+    next(e);
   }
 }
 


### PR DESCRIPTION
## Why are you doing this?
Because it wasn't working in CODE

## Changes

- use `i` instead of `I` in the SSM configuration (Not in this PR, fixed in the SSM console)
- missing `/` at the end of the SSM path to authorise the loading of keys
- use `EC2MetadataCredentials` instead of `ECSCredentials`. `ECSCredentials` is for lambdas
- better error handling
- access log

## Screenshots

| Before | After |
| --- | --- |
| <img src="" width="300px" /> | <img src="" width="300px" /> |
