### PR TITLE
Exporting the environment variables

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -307,6 +307,8 @@ Resources:
           chown -R ${App}:mapi /opt/${App}
           mkdir /var/log/${App}
           chown -R ${App}:mapi /var/log/${App}
+          export Stack=${Stack}
+          export Stage=${Stage}
           /usr/local/node/pm2 start --uid ${App} --gid mapi /opt/${App}/server.js
           /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${AWS::Region} mobile-log-aggregation-${Stage} /var/log/${App}/${App}.log
 


### PR DESCRIPTION
## Why are you doing this?
So that the app knows what environment it's in at runtime.

I also created a missing SSM parameter