### PR TITLE
code coverage

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,4 +27,4 @@ jobs:
     - name: lint
       run: npm run lint
     - name: test
-      run: npm run test:run
+      run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules
 
 # Built files
 dist
+
+# Istanbul/Jest code coverage
+coverage

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,4 @@
-const [serverConfig, clientConfig, testConfig] = require('../webpack.config.js');
+const [serverConfig, clientConfig] = require('../webpack.config.js');
 
 module.exports = async ({ config }) => {
 	return {

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ _**Note**: You will need to refresh the page to see any changes you make to the 
 The unit tests are built using Jest. They can be run with the following command:
 
 ```sh
-npm run test:run
+npm run test
 ```
 
 ### Lint

--- a/config/tsconfig.client.json
+++ b/config/tsconfig.client.json
@@ -2,9 +2,11 @@
     "extends": "../tsconfig",
     "compilerOptions": {
         // Output latest features; allow babel to handle browser targeting
-        "target": "es2020"
+        "target": "es2020",
+        // Don't transpile jsx (handled by babel w/ emotion)
+        "jsx": "preserve",
     },
     "include": [
         "../src/client/*"
-    ]
+    ],
 }

--- a/config/tsconfig.test.json
+++ b/config/tsconfig.test.json
@@ -1,9 +1,5 @@
 {
     "extends": "../tsconfig",
-    "compilerOptions": {
-        "target": "es2019",
-        "jsx": "preserve",
-    },
     "files": [
         "../src/server/server.ts"
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,18 +228,28 @@
       }
     },
     "@babel/generator": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.5.5",
+        "@babel/types": "^7.8.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -829,23 +839,49 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-hoist-variables": {
@@ -1005,9 +1041,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
@@ -1354,12 +1390,25 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4"
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-wrap-function": {
@@ -1655,9 +1704,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -1841,6 +1890,15 @@
         }
       }
     },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
@@ -1908,12 +1966,12 @@
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
-      "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -3173,33 +3231,97 @@
       }
     },
     "@babel/template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/traverse": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.5.5",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.5.5",
-        "@babel/types": "^7.5.5",
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.8.4",
+        "@babel/types": "^7.8.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -3226,6 +3348,12 @@
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",
@@ -3651,6 +3779,60 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
       "dev": true
     },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -3869,6 +4051,15 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
     },
     "@storybook/addon-knobs": {
       "version": "5.3.4",
@@ -5049,9 +5240,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
-      "integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -5068,9 +5259,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
-      "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
+      "integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -7349,9 +7540,9 @@
       }
     },
     "bser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
-      "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
@@ -7896,6 +8087,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz",
+      "integrity": "sha512-VKIhJgvk8E1W28m5avZ2Gv2Ruv5YiF56ug2oclvaG9md69BuZImMG2sk9g7QNKLUbtYAKQjXjYxbYZVUlMMKmQ==",
       "dev": true
     },
     "collection-visit": {
@@ -10028,9 +10225,9 @@
       }
     },
     "exec-sh": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
-      "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+      "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
       "dev": true
     },
     "execa": {
@@ -10327,12 +10524,12 @@
       }
     },
     "fb-watchman": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.1.1"
       }
     },
     "fbjs": {
@@ -11690,18 +11887,6 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -11927,6 +12112,12 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
     },
+    "html-escaper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+      "dev": true
+    },
     "html-minifier-terser": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.0.2.tgz",
@@ -12058,6 +12249,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
     "iconv-lite": {
@@ -12887,12 +13084,12 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "isurl": {
@@ -12915,52 +13112,1243 @@
       }
     },
     "jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
-      "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-25.1.0.tgz",
+      "integrity": "sha512-FV6jEruneBhokkt9MQk0WUFoNTwnF76CLXtwNMfsc0um0TlB/LG2yxUd0KqaFjEJ9laQmVWQWS0sG/t2GsuI0w==",
       "dev": true,
       "requires": {
-        "import-local": "^2.0.0",
-        "jest-cli": "^24.9.0"
+        "@jest/core": "^25.1.0",
+        "import-local": "^3.0.2",
+        "jest-cli": "^25.1.0"
       },
       "dependencies": {
-        "jest-cli": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-          "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+        "@jest/console": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.1.0.tgz",
+          "integrity": "sha512-3P1DpqAMK/L07ag/Y9/Jup5iDEG9P4pRAuZiMQnU0JB3UOvCyYCjCoxr7sIA80SeyUCUKrr24fKAxVpmBgQonA==",
           "dev": true,
           "requires": {
-            "@jest/core": "^24.9.0",
-            "@jest/test-result": "^24.9.0",
-            "@jest/types": "^24.9.0",
-            "chalk": "^2.0.1",
+            "@jest/source-map": "^25.1.0",
+            "chalk": "^3.0.0",
+            "jest-util": "^25.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/core": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-25.1.0.tgz",
+          "integrity": "sha512-iz05+NmwCmZRzMXvMo6KFipW7nzhbpEawrKrkkdJzgytavPse0biEnCNr2wRlyCsp3SmKaEY+SGv7YWYQnIdig==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^25.1.0",
+            "@jest/reporters": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^3.0.0",
             "exit": "^0.1.2",
-            "import-local": "^2.0.0",
+            "graceful-fs": "^4.2.3",
+            "jest-changed-files": "^25.1.0",
+            "jest-config": "^25.1.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-resolve-dependencies": "^25.1.0",
+            "jest-runner": "^25.1.0",
+            "jest-runtime": "^25.1.0",
+            "jest-snapshot": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-validate": "^25.1.0",
+            "jest-watcher": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "p-each-series": "^2.1.0",
+            "realpath-native": "^1.1.0",
+            "rimraf": "^3.0.0",
+            "slash": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.1.0.tgz",
+          "integrity": "sha512-cTpUtsjU4cum53VqBDlcW0E4KbQF03Cn0jckGPW/5rrE9tb+porD3+hhLtHAwhthsqfyF+bizyodTlsRA++sHg==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "jest-mock": "^25.1.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.1.0.tgz",
+          "integrity": "sha512-Eu3dysBzSAO1lD7cylZd/CVKdZZ1/43SF35iYBNV1Lvvn2Undp3Grwsv8PrzvbLhqwRzDd4zxrY4gsiHc+wygQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-mock": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "lolex": "^5.0.0"
+          }
+        },
+        "@jest/reporters": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.1.0.tgz",
+          "integrity": "sha512-ORLT7hq2acJQa8N+NKfs68ZtHFnJPxsGqmofxW7v7urVhzJvpKZG9M7FAcgh9Ee1ZbCteMrirHA3m5JfBtAaDg==",
+          "dev": true,
+          "requires": {
+            "@bcoe/v8-coverage": "^0.2.3",
+            "@jest/console": "^25.1.0",
+            "@jest/environment": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "istanbul-lib-instrument": "^4.0.0",
+            "istanbul-lib-report": "^3.0.0",
+            "istanbul-lib-source-maps": "^4.0.0",
+            "istanbul-reports": "^3.0.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-runtime": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-worker": "^25.1.0",
+            "node-notifier": "^6.0.0",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.0",
+            "string-length": "^3.1.0",
+            "terminal-link": "^2.0.0",
+            "v8-to-istanbul": "^4.0.1"
+          }
+        },
+        "@jest/source-map": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.1.0.tgz",
+          "integrity": "sha512-ohf2iKT0xnLWcIUhL6U6QN+CwFWf9XnrM2a6ybL9NXxJjgYijjLSitkYHIdzkd8wFliH73qj/+epIpTiWjRtAA==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.3",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.1.0.tgz",
+          "integrity": "sha512-FZzSo36h++U93vNWZ0KgvlNuZ9pnDnztvaM7P/UcTx87aPDotG18bXifkf1Ji44B7k/eIatmMzkBapnAzjkJkg==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^25.1.0",
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.1.0.tgz",
+          "integrity": "sha512-WgZLRgVr2b4l/7ED1J1RJQBOharxS11EFhmwDqknpknE0Pm87HLZVS2Asuuw+HQdfQvm2aXL2FvvBLxOD1D0iw==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^25.1.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-runner": "^25.1.0",
+            "jest-runtime": "^25.1.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.1.0.tgz",
+          "integrity": "sha512-4ktrQ2TPREVeM+KxB4zskAT84SnmG1vaz4S+51aTefyqn3zocZUnliLLm5Fsl85I3p/kFPN4CRp1RElIfXGegQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^25.1.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "chalk": "^3.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.3",
+            "jest-haste-map": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "pirates": "^4.0.1",
+            "realpath-native": "^1.1.0",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "^3.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
+          "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.3",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.3.tgz",
+          "integrity": "sha512-XCMQRK6kfpNBixHLyHUsGmXrpEmFFxzMrcnSXFMziHd8CoNJo8l16FkHyQq4x+xbM7E2XL83/O78OD8u+iZTdQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-escapes": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "babel-jest": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.1.0.tgz",
+          "integrity": "sha512-tz0VxUhhOE2y+g8R2oFrO/2VtVjA1lkJeavlhExuRBg3LdNJY9gwQ+Vcvqt9+cqy71MCTJhewvTB7Qtnnr9SWg==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/babel__core": "^7.1.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "babel-preset-jest": "^25.1.0",
+            "chalk": "^3.0.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+          "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@istanbuljs/load-nyc-config": "^1.0.0",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-instrument": "^4.0.0",
+            "test-exclude": "^6.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.1.0.tgz",
+          "integrity": "sha512-oIsopO41vW4YFZ9yNYoLQATnnN46lp+MZ6H4VvPKFkcc2/fkl3CfE/NZZSmnEIEsJRmJAgkVEK0R7Zbl50CpTw==",
+          "dev": true,
+          "requires": {
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.1.0.tgz",
+          "integrity": "sha512-eCGn64olaqwUMaugXsTtGAM2I0QTahjEtnRu0ql8Ie+gDWAc1N6wqN0k2NilnyTunM69Pad7gJY7LOtwLimoFQ==",
+          "dev": true,
+          "requires": {
+            "@babel/plugin-syntax-bigint": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "babel-plugin-jest-hoist": "^25.1.0"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          },
+          "dependencies": {
+            "which": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "detect-newline": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+          "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.1.0.tgz",
+          "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "expect": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-25.1.0.tgz",
+          "integrity": "sha512-wqHzuoapQkhc3OKPlrpetsfueuEiMf3iWh0R8+duCu9PIjXoP7HgD5aeypwTnXUAjC8aMsiVDaWwlbJ1RlQ38g==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^25.1.0",
+            "jest-matcher-utils": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-regex-util": "^25.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "dev": true,
+          "optional": true
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "import-local": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+          "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+          "dev": true,
+          "requires": {
+            "pkg-dir": "^4.2.0",
+            "resolve-cwd": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "is-wsl": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+          "dev": true,
+          "optional": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
+          "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.7.5",
+            "@babel/parser": "^7.7.5",
+            "@babel/template": "^7.7.4",
+            "@babel/traverse": "^7.7.4",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+          "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^3.0.0",
+            "make-dir": "^3.0.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+          "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^3.0.0",
+            "source-map": "^0.6.1"
+          }
+        },
+        "istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+          "dev": true,
+          "requires": {
+            "html-escaper": "^2.0.0",
+            "istanbul-lib-report": "^3.0.0"
+          }
+        },
+        "jest-changed-files": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.1.0.tgz",
+          "integrity": "sha512-bdL1aHjIVy3HaBO3eEQeemGttsq1BDlHgWcOjEOIAcga7OOEGWHD2WSu8HhL7I1F0mFFyci8VKU4tRNk+qtwDA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "execa": "^3.2.0",
+            "throat": "^5.0.0"
+          }
+        },
+        "jest-cli": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.1.0.tgz",
+          "integrity": "sha512-p+aOfczzzKdo3AsLJlhs8J5EW6ffVidfSZZxXedJ0mHPBOln1DccqFmGCoO8JWd4xRycfmwy1eoQkMsF8oekPg==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "exit": "^0.1.2",
+            "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^24.9.0",
-            "jest-util": "^24.9.0",
-            "jest-validate": "^24.9.0",
+            "jest-config": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-validate": "^25.1.0",
             "prompts": "^2.0.1",
             "realpath-native": "^1.1.0",
-            "yargs": "^13.3.0"
+            "yargs": "^15.0.0"
+          }
+        },
+        "jest-config": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.1.0.tgz",
+          "integrity": "sha512-tLmsg4SZ5H7tuhBC5bOja0HEblM0coS3Wy5LTCb2C8ZV6eWLewHyK+3qSq9Bi29zmWQ7ojdCd3pxpx4l4d2uGw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/test-sequencer": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "babel-jest": "^25.1.0",
+            "chalk": "^3.0.0",
+            "glob": "^7.1.1",
+            "jest-environment-jsdom": "^25.1.0",
+            "jest-environment-node": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "jest-jasmine2": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-validate": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "pretty-format": "^25.1.0",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-diff": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.1.0.tgz",
+          "integrity": "sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "pretty-format": "^25.1.0"
+          }
+        },
+        "jest-docblock": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.1.0.tgz",
+          "integrity": "sha512-370P/mh1wzoef6hUKiaMcsPtIapY25suP6JqM70V9RJvdKLrV4GaGbfUseUVk4FZJw4oTZ1qSCJNdrClKt5JQA==",
+          "dev": true,
+          "requires": {
+            "detect-newline": "^3.0.0"
+          }
+        },
+        "jest-each": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.1.0.tgz",
+          "integrity": "sha512-R9EL8xWzoPySJ5wa0DXFTj7NrzKpRD40Jy+zQDp3Qr/2QmevJgkN9GqioCGtAJ2bW9P/MQRznQHQQhoeAyra7A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "jest-get-type": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "pretty-format": "^25.1.0"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.1.0.tgz",
+          "integrity": "sha512-ILb4wdrwPAOHX6W82GGDUiaXSSOE274ciuov0lztOIymTChKFtC02ddyicRRCdZlB5YSrv3vzr1Z5xjpEe1OHQ==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^25.1.0",
+            "@jest/fake-timers": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "jest-mock": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jsdom": "^15.1.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.1.0.tgz",
+          "integrity": "sha512-U9kFWTtAPvhgYY5upnH9rq8qZkj6mYLup5l1caAjjx9uNnkLHN2xgZy5mo4SyLdmrh/EtB9UPpKFShvfQHD0Iw==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^25.1.0",
+            "@jest/fake-timers": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "jest-mock": "^25.1.0",
+            "jest-util": "^25.1.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
+          "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.1.0.tgz",
+          "integrity": "sha512-/2oYINIdnQZAqyWSn1GTku571aAfs8NxzSErGek65Iu5o8JYb+113bZysRMcC/pjE5v9w0Yz+ldbj9NxrFyPyw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.3",
+            "jest-serializer": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-worker": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-jasmine2": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.1.0.tgz",
+          "integrity": "sha512-GdncRq7jJ7sNIQ+dnXvpKO2MyP6j3naNK41DTTjEAhLEdpImaDA9zSAZwDhijjSF/D7cf4O5fdyUApGBZleaEg==",
+          "dev": true,
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@jest/environment": "^25.1.0",
+            "@jest/source-map": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "co": "^4.6.0",
+            "expect": "^25.1.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^25.1.0",
+            "jest-matcher-utils": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-runtime": "^25.1.0",
+            "jest-snapshot": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "pretty-format": "^25.1.0",
+            "throat": "^5.0.0"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.1.0.tgz",
+          "integrity": "sha512-3xRI264dnhGaMHRvkFyEKpDeaRzcEBhyNrOG5oT8xPxOyUAblIAQnpiR3QXu4wDor47MDTiHbiFcbypdLcLW5w==",
+          "dev": true,
+          "requires": {
+            "jest-get-type": "^25.1.0",
+            "pretty-format": "^25.1.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz",
+          "integrity": "sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "jest-diff": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "pretty-format": "^25.1.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.1.0.tgz",
+          "integrity": "sha512-Nr/Iwar2COfN22aCqX0kCVbXgn8IBm9nWf4xwGr5Olv/KZh0CZ32RKgZWMVDXGdOahicM10/fgjdimGNX/ttCQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^3.0.0",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-mock": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.1.0.tgz",
+          "integrity": "sha512-28/u0sqS+42vIfcd1mlcg4ZVDmSUYuNvImP4X2lX5hRMLW+CN0BeiKVD4p+ujKKbSPKd3rg/zuhCF+QBLJ4vag==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0"
+          }
+        },
+        "jest-regex-util": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.1.0.tgz",
+          "integrity": "sha512-9lShaDmDpqwg+xAd73zHydKrBbbrIi08Kk9YryBEBybQFg/lBWR/2BDjjiSE7KIppM9C5+c03XiDaZ+m4Pgs1w==",
+          "dev": true
+        },
+        "jest-resolve": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.1.0.tgz",
+          "integrity": "sha512-XkBQaU1SRCHj2Evz2Lu4Czs+uIgJXWypfO57L7JYccmAXv4slXA6hzNblmcRmf7P3cQ1mE7fL3ABV6jAwk4foQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^3.0.0",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.1.0.tgz",
+          "integrity": "sha512-Cu/Je38GSsccNy4I2vL12ZnBlD170x2Oh1devzuM9TLH5rrnLW1x51lN8kpZLYTvzx9j+77Y5pqBaTqfdzVzrw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-snapshot": "^25.1.0"
+          }
+        },
+        "jest-runner": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.1.0.tgz",
+          "integrity": "sha512-su3O5fy0ehwgt+e8Wy7A8CaxxAOCMzL4gUBftSs0Ip32S0epxyZPDov9Znvkl1nhVOJNf4UwAsnqfc3plfQH9w==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^25.1.0",
+            "@jest/environment": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.3",
+            "jest-config": "^25.1.0",
+            "jest-docblock": "^25.1.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-jasmine2": "^25.1.0",
+            "jest-leak-detector": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-runtime": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-worker": "^25.1.0",
+            "source-map-support": "^0.5.6",
+            "throat": "^5.0.0"
+          }
+        },
+        "jest-runtime": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.1.0.tgz",
+          "integrity": "sha512-mpPYYEdbExKBIBB16ryF6FLZTc1Rbk9Nx0ryIpIMiDDkOeGa0jQOKVI/QeGvVGlunKKm62ywcioeFVzIbK03bA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^25.1.0",
+            "@jest/environment": "^25.1.0",
+            "@jest/source-map": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.3",
+            "jest-config": "^25.1.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-mock": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-snapshot": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-validate": "^25.1.0",
+            "realpath-native": "^1.1.0",
+            "slash": "^3.0.0",
+            "strip-bom": "^4.0.0",
+            "yargs": "^15.0.0"
+          }
+        },
+        "jest-serializer": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.1.0.tgz",
+          "integrity": "sha512-20Wkq5j7o84kssBwvyuJ7Xhn7hdPeTXndnwIblKDR2/sy1SUm6rWWiG9kSCgJPIfkDScJCIsTtOKdlzfIHOfKA==",
+          "dev": true
+        },
+        "jest-snapshot": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.1.0.tgz",
+          "integrity": "sha512-xZ73dFYN8b/+X2hKLXz4VpBZGIAn7muD/DAg+pXtDzDGw3iIV10jM7WiHqhCcpDZfGiKEj7/2HXAEPtHTj0P2A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "expect": "^25.1.0",
+            "jest-diff": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "jest-matcher-utils": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^25.1.0",
+            "semver": "^7.1.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.1.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.2.tgz",
+              "integrity": "sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ==",
+              "dev": true
+            }
+          }
+        },
+        "jest-util": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.1.0.tgz",
+          "integrity": "sha512-7did6pLQ++87Qsj26Fs/TIwZMUFBXQ+4XXSodRNy3luch2DnRXsSnmpVtxxQ0Yd6WTipGpbhh2IFP1mq6/fQGw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "is-ci": "^2.0.0",
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "jest-validate": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.1.0.tgz",
+          "integrity": "sha512-kGbZq1f02/zVO2+t1KQGSVoCTERc5XeObLwITqC6BTRH3Adv7NZdYqCpKIZLUgpLXf2yISzQ465qOZpul8abXA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "camelcase": "^5.3.1",
+            "chalk": "^3.0.0",
+            "jest-get-type": "^25.1.0",
+            "leven": "^3.1.0",
+            "pretty-format": "^25.1.0"
+          }
+        },
+        "jest-watcher": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.1.0.tgz",
+          "integrity": "sha512-Q9eZ7pyaIr6xfU24OeTg4z1fUqBF/4MP6J801lyQfg7CsnZ/TCzAPvCfckKdL5dlBBEKBeHV0AdyjFZ5eWj4ig==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^3.0.0",
+            "jest-util": "^25.1.0",
+            "string-length": "^3.1.0"
+          }
+        },
+        "jest-worker": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.1.0.tgz",
+          "integrity": "sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "node-notifier": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+          "integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "growly": "^1.3.0",
+            "is-wsl": "^2.1.1",
+            "semver": "^6.3.0",
+            "shellwords": "^0.1.1",
+            "which": "^1.3.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-each-series": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+          "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+          "dev": true
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "25.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.1.0.tgz",
+          "integrity": "sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "react-is": {
+          "version": "16.12.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+          "dev": true
+        },
+        "resolve-cwd": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+          "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+          "dev": true,
+          "requires": {
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "string-length": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+          "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+          "dev": true,
+          "requires": {
+            "astral-regex": "^1.0.0",
+            "strip-ansi": "^5.2.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+          "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+          "dev": true,
+          "requires": {
+            "@istanbuljs/schema": "^0.1.2",
+            "glob": "^7.1.4",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "throat": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+          "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
           }
         },
         "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
+          "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
           "dev": true,
           "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
             "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
             "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
+            "string-width": "^4.2.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
+            "yargs-parser": "^16.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -13898,6 +15286,15 @@
       "integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
       "dev": true
     },
+    "lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -14716,9 +16113,9 @@
       "dev": true
     },
     "nwsapi": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
-      "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
     "oauth-sign": {
@@ -14938,30 +16335,6 @@
         "is-wsl": "^1.1.0"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -15161,6 +16534,59 @@
         "jest": "^24.9.0",
         "mkdirp": "^0.5.1",
         "npm-run-all": "^4.1.5"
+      },
+      "dependencies": {
+        "jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+          "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+          "dev": true,
+          "requires": {
+            "import-local": "^2.0.0",
+            "jest-cli": "^24.9.0"
+          },
+          "dependencies": {
+            "jest-cli": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+              "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+              "dev": true,
+              "requires": {
+                "@jest/core": "^24.9.0",
+                "@jest/test-result": "^24.9.0",
+                "@jest/types": "^24.9.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "import-local": "^2.0.0",
+                "is-ci": "^2.0.0",
+                "jest-config": "^24.9.0",
+                "jest-util": "^24.9.0",
+                "jest-validate": "^24.9.0",
+                "prompts": "^2.0.1",
+                "realpath-native": "^1.1.0",
+                "yargs": "^13.3.0"
+              }
+            }
+          }
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        }
       }
     },
     "parse-entities": {
@@ -15873,9 +17299,9 @@
       }
     },
     "prompts": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
-      "integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
+      "integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
@@ -17573,9 +18999,9 @@
       }
     },
     "sisteransi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
-      "integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
+      "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
       "dev": true
     },
     "slash": {
@@ -18430,6 +19856,12 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
     "strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -18474,6 +19906,33 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+      "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "svg-parser": {
@@ -18719,6 +20178,27 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.1.1.tgz",
       "integrity": "sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A==",
       "dev": true
+    },
+    "terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        }
+      }
     },
     "terser": {
       "version": "4.4.2",
@@ -19070,12 +20550,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
     "ts-dedent": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.0.tgz",
@@ -19229,6 +20703,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -19256,6 +20736,15 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typescript": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
@@ -19266,26 +20755,6 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
-      "integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "unfetch": {
       "version": "4.1.0",
@@ -19585,6 +21054,25 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
+    },
+    "v8-to-istanbul": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.2.tgz",
+      "integrity": "sha512-G9R+Hpw0ITAmPSr47lSlc5A1uekSYzXxTMlFxso2xoffwo4jQnzbv1p9yXIinO8UMZKfAFewaCHwWvnH4Jb4Ug==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7339,6 +7339,15 @@
         "node-releases": "^1.1.44"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
@@ -13946,6 +13955,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -19066,6 +19081,41 @@
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.0.tgz",
       "integrity": "sha512-CVCvDwMBWZKjDxpN3mU/Dx1v3k+sJgE8nrhXcC9vRopRfoa7vVzilNvHEAUi5jQnmFHpnxDx5jZdI1TpG8ny2g==",
       "dev": true
+    },
+    "ts-jest": {
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.2.0.tgz",
+      "integrity": "sha512-VaRdb0da46eorLfuHEFf0G3d+jeREcV+Wb/SvW71S4y9Oe8SHWU+m1WY/3RaMknrBsnvmVH0/rRjT8dkgeffNQ==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "0.x",
+        "resolve": "1.x",
+        "semver": "^5.5",
+        "yargs-parser": "10.x"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
     },
     "ts-loader": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,24 @@
     "storybook": "start-storybook -s ./",
     "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh"
   },
+  "jest": {
+    "collectCoverage": true,
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "coverageThreshold": {
+      "global": {
+          "branches": 75,
+          "functions": 75,
+          "lines": 75,
+          "statements": 75
+      }
+  },
+  "coverageReporters": ["json", "lcov", "text", "clover"],
+    "collectCoverageFrom": [
+      "<rootDir>/src/renderer.ts"
+    ]
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {
@@ -68,6 +86,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.18.0",
     "jest": "^24.9.0",
+    "ts-jest": "^25.2.0",
     "ts-loader": "^6.2.1",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "upload": "node-riffraff-artifact",
-    "test:build": "webpack --config webpack.config.js --config-name tests",
-    "test:run": "npm run test:build && jest --verbose dist",
+    "test:build": "webpack --config webpack.config.js --config-name server --env.test",
+    "test": "npm run test:build && jest --verbose",
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
     "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "watch:client": "webpack-dev-server --config webpack.config.js --config-name client",
@@ -23,19 +23,28 @@
   "jest": {
     "collectCoverage": true,
     "transform": {
-      "^.+\\.ts$": "ts-jest"
+      "^.+\\.tsx?$": "ts-jest"
     },
     "coverageThreshold": {
       "global": {
-          "branches": 75,
-          "functions": 75,
-          "lines": 75,
-          "statements": 75
+        "branches": 15,
+        "functions": 15,
+        "lines": 15,
+        "statements": 15
       }
-  },
-  "coverageReporters": ["json", "lcov", "text", "clover"],
+    },
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "text",
+      "clover"
+    ],
     "collectCoverageFrom": [
       "<rootDir>/src/renderer.ts"
+    ],
+    "moduleDirectories": [
+      "node_modules",
+      "src"
     ]
   },
   "author": "",
@@ -85,7 +94,7 @@
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.18.0",
-    "jest": "^24.9.0",
+    "jest": "^25.1.0",
     "ts-jest": "^25.2.0",
     "ts-loader": "^6.2.1",
     "webpack": "^4.41.5",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,9 @@
       }
     },
     "coverageReporters": [
-      "json",
-      "lcov",
       "text",
-      "clover",
-      "html"
+      "html",
+      "text-summary"
     ],
     "collectCoverageFrom": [
       "<rootDir>/src/renderer.ts"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "upload": "node-riffraff-artifact",
     "test:build": "webpack --config webpack.config.js --config-name server --env.test",
-    "test": "npm run test:build && jest --verbose && open coverage/index.html",
+    "test": "npm run test:build && jest --verbose",
+    "test:coverage": "npm run test && open coverage/index.html",
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
     "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "watch:client": "webpack-dev-server --config webpack.config.js --config-name client",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "upload": "node-riffraff-artifact",
     "test:build": "webpack --config webpack.config.js --config-name server --env.test",
-    "test": "npm run test:build && jest --verbose",
+    "test": "npm run test:build && jest --verbose && open coverage/index.html",
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
     "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "watch:client": "webpack-dev-server --config webpack.config.js --config-name client",
@@ -37,7 +37,8 @@
       "json",
       "lcov",
       "text",
-      "clover"
+      "clover",
+      "html"
     ],
     "collectCoverageFrom": [
       "<rootDir>/src/renderer.ts"

--- a/src/components/shared/avatar.test.tsx
+++ b/src/components/shared/avatar.test.tsx
@@ -23,7 +23,7 @@ describe('Avatar component renders as expected', () => {
             id: "test"
         }];
         const avatar = shallow(<Avatar contributors={contributors} bgColour="pink" imageSalt="" />);
-        expect(avatar.props().css.styles).toContain("background-color:pink")
+        expect(avatar.props().css.styles).toContain("background-color: pink")
     })
 
     it('Generates correct image url', () => {

--- a/src/components/shared/keyline.test.tsx
+++ b/src/components/shared/keyline.test.tsx
@@ -6,24 +6,28 @@ import { Layout } from 'article';
 
 configure({ adapter: new Adapter() });
 
+const styles = (component: any): string => component.props().css
+    .map(({ styles }: any) => styles)
+    .reduce((a: string, b: string) => a + b, '')
+
 describe('Keyline component renders as expected', () => {
     it('Renders styles for liveblogs', () => {
         const article = { layout: Layout.Liveblog };
         const keyline = shallow(<Keyline {...article} />);
-        expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 3px)")
-        expect(keyline.props().css.styles).toContain("opacity:.4;")
+        expect(styles(keyline)).toContain("background-image: repeating-linear-gradient(#DCDCDC, #DCDCDC 1px, transparent 1px, transparent 3px)")
+        expect(styles(keyline)).toContain("opacity: .4;")
     })
 
     it('Renders styles for opinion articles', () => {
         const article = { layout: Layout.Opinion };
         const keyline = shallow(<Keyline {...article} />);
-        expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 3px)")
-        expect(keyline.props().css.styles).toContain("height:24px;")
+        expect(styles(keyline)).toContain("background-image: repeating-linear-gradient(#DCDCDC, #DCDCDC 1px, transparent 1px, transparent 3px)")
+        expect(styles(keyline)).toContain("height: 24px;")
     })
 
     it('Renders styles for standard articles', () => {
         const article = { layout: Layout.Standard };
         const keyline = shallow(<Keyline {...article} />);
-        expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 3px)")
+        expect(styles(keyline)).toContain("background-image: repeating-linear-gradient(#DCDCDC, #DCDCDC 1px, transparent 1px, transparent 3px)")
     })
 });

--- a/src/components/shared/keyline.test.tsx
+++ b/src/components/shared/keyline.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { configure, shallow } from 'enzyme';
+import { configure, shallow, ShallowWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Keyline } from 'components/shared/keyline';
 import { Layout } from 'article';
 
 configure({ adapter: new Adapter() });
 
-const styles = (component: any): string => component.props().css
-    .map(({ styles }: any) => styles)
+const styles = (component: ShallowWrapper): string => Array.from(component.prop('css'))
+    .flat()
+    .map(({ styles }: { styles: string }) => styles)
     .reduce((a: string, b: string) => a + b, '')
 
 describe('Keyline component renders as expected', () => {

--- a/src/components/shared/tags.test.tsx
+++ b/src/components/shared/tags.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { configure, shallow } from 'enzyme';
+import { configure, shallow, ShallowWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Tags from 'components/shared/tags';
 
@@ -10,8 +10,9 @@ const tagsProps = [{
     webUrl: "https://mapi.co.uk/tag"
 }];
 
-const styles = (component: any): string => component.props().css
-    .map(({ styles }: any) => styles)
+const styles = (component: ShallowWrapper): string => Array.from(component.prop('css'))
+    .flat()
+    .map(({ styles }: { styles: string }) => styles)
     .reduce((a: string, b: string) => a + b, '')
 
 describe('Keyline component renders as expected', () => {

--- a/src/components/shared/tags.test.tsx
+++ b/src/components/shared/tags.test.tsx
@@ -10,6 +10,10 @@ const tagsProps = [{
     webUrl: "https://mapi.co.uk/tag"
 }];
 
+const styles = (component: any): string => component.props().css
+    .map(({ styles }: any) => styles)
+    .reduce((a: string, b: string) => a + b, '')
+
 describe('Keyline component renders as expected', () => {
     it('Renders link to tag', () => {
         const tags = shallow(<Tags tags={tagsProps} />)
@@ -29,6 +33,6 @@ describe('Keyline component renders as expected', () => {
 
     it('Uses background prop in styles', () => {
         const tags = shallow(<Tags tags={tagsProps} background={"pink"}/>)
-        expect(tags.props().css.styles).toContain("background-color:pink;")
+        expect(styles(tags)).toContain("background-color: pink;")
     })
 });

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -1,7 +1,8 @@
-import { renderAll } from './renderer';
+import { makeCaption } from './renderer';
 
-describe('', () => {
-    test('', () => {
-        expect(renderAll("")).toBeDefined();
+describe('renderer returns expected content', () => {
+    test('formats captions', () => {
+        expect(makeCaption("caption", false, "credit")).toBe("caption");
+        expect(makeCaption("caption", true, "credit")).toBe("caption credit");
     });
 });

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -1,8 +1,17 @@
-import { makeCaption } from './renderer';
+import { ImageElement } from './renderer';
 
 describe('renderer returns expected content', () => {
-    test('formats captions', () => {
-        expect(makeCaption("caption", false, "credit")).toBe("caption");
-        expect(makeCaption("caption", true, "credit")).toBe("caption credit");
+    test('ImageElement returns null for no url', () => {
+        const imageProps = {
+            url: '',
+            alt: "alt",
+            salt: "salt",
+            sizes: "sizes",
+            width: 500,
+            height: 500,
+            caption: "caption",
+            credit: "credit"
+        }
+        expect(ImageElement(imageProps)).toBe(null);
     });
 });

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -1,0 +1,7 @@
+import { renderAll } from './renderer';
+
+describe('', () => {
+    test('', () => {
+        expect(renderAll("")).toBeDefined();
+    });
+});

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -415,7 +415,6 @@ const renderAll = (salt: string) => (pillar: Pillar, elements: BodyElement[]): R
 // ----- Exports ----- //
 
 export {
-    makeCaption,
     renderAll,
     text as renderText,
     ImageElement,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -415,6 +415,7 @@ const renderAll = (salt: string) => (pillar: Pillar, elements: BodyElement[]): R
 // ----- Exports ----- //
 
 export {
+    makeCaption,
     renderAll,
     text as renderText,
     ImageElement,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -412,7 +412,6 @@ const render = (salt: string, pillar: Pillar) => (element: BodyElement, key: num
 const renderAll = (salt: string) => (pillar: Pillar, elements: BodyElement[]): ReactNode[] =>
     elements.map(render(salt, pillar));
 
-
 // ----- Exports ----- //
 
 export {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         // Import non-ES modules as default imports.
         "esModuleInterop": true,
         // Don't transpile jsx (handled by babel w/ emotion)
-        "jsx": "preserve",
+        "jsx": "react",
         // Allows discovery of node_modules packages
         "moduleResolution": "node",
         "noUnusedLocals": true,


### PR DESCRIPTION
## Why are you doing this?

It's part of our health OKR to have 75% test coverage on our core parsing logic.

-----

To run: `npm run test`

I've added `renderer.ts` but we can include more files with parsing logic.

The threshold is currently 15% so that the builds don't fail but we should increase this as we add tests.