### PR TITLE
Fix Storybook and Add Standard Stories

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -12,9 +12,9 @@
     @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:"bold"; font-style:"italic"; src:url("./public/fonts/GuardianTextEgyptian-BoldItalic.ttf")}
 
     @font-Face{font-family:"Guardian Text Sans Web"; font-weight:400; src:url("./public/fonts/GuardianTextSans-Regular.ttf")}
-    @font-Face{font-family:"Guardian Text Sans Web"; font-weight:400; font-style:"italic"; src:url(".public/fonts/GuardianTextSans-RegularItalic.ttf")}
+    @font-Face{font-family:"Guardian Text Sans Web"; font-weight:400; font-style:"italic"; src:url("./public/fonts/GuardianTextSans-RegularItalic.ttf")}
     @font-Face{font-family:"Guardian Text Sans Web"; font-weight:700; src:url("./public/fonts/GuardianTextSans-Bold.ttf")}
-    @font-Face{font-family:"Guardian Text Sans Web"; font-weight:700; font-style:"italic"; src:url(".public/fonts/GuardianTextSans-BoldItalic.ttf")}
+    @font-Face{font-family:"Guardian Text Sans Web"; font-weight:700; font-style:"italic"; src:url("./public/fonts/GuardianTextSans-BoldItalic.ttf")}
     
     @font-Face{font-family:"Guardian Headline"; font-weight:300; src:url("/public/fonts/GHGuardianHeadline-Light.ttf")}
     @font-Face{font-family:"Guardian Headline"; font-weight:300; font-style: "italic"; src:url("./public/fonts/GHGuardianHeadline-LightItalic.ttf")}

--- a/src/client/parser.ts
+++ b/src/client/parser.ts
@@ -1,0 +1,27 @@
+// ----- Imports ----- //
+
+import { Result, Err, Ok } from 'types/result';
+
+
+// ----- Functions ----- //
+
+const parse = (domParser: DOMParser) => (s: string): Result<string, DocumentFragment> => {
+
+    try {
+        const frag = new DocumentFragment();
+        const docNodes = domParser.parseFromString(s, 'text/html').body.childNodes;
+
+        Array.from(docNodes).forEach(node => frag.appendChild(node));
+        return new Ok(frag);
+    } catch (e) {
+        return new Err(`I wasn't able to parse the string into a DocumentFragment because: ${e}`);
+    }
+
+}
+
+
+// ----- Exports ----- //
+
+export {
+    parse,
+}

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -69,10 +69,7 @@ const Standard = ({ imageSalt, article, children }: Props): JSX.Element =>
                 />
                 <div css={articleWidthStyles}>
                     <Series series={article.series} pillar={article.pillar} />
-                    <Headline
-                        headline={article.headline}
-                        article={article}
-                    />
+                    <Headline article={article} />
                     <Standfirst article={article} className={articleWidthStyles} />
                 </div>
                 <Keyline {...article} />

--- a/src/components/standard/byline.stories.tsx
+++ b/src/components/standard/byline.stories.tsx
@@ -1,13 +1,14 @@
 // ----- IUmports ----- //
 
 import { withKnobs, text, boolean, date } from '@storybook/addon-knobs';
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
 import Byline from 'components/standard/byline';
 import { Pillar } from 'pillar';
 import { Layout, Article } from 'article';
 import { Option, None, Some } from 'types/option';
 import { parse } from 'client/parser';
+import { ITag as Contributor } from 'mapiThriftModels';
 
 
 // ----- Setup ----- //
@@ -38,7 +39,7 @@ const article: Article = {
     tags: [],
 };
 
-const contributor = () => ({
+const contributor = (): Contributor => ({
     id: 'mock_id',
     type: 2,
     webTitle: text('Byline', 'Jane Smith'),
@@ -47,13 +48,13 @@ const contributor = () => ({
     references: [],
 });
 
-const job = () =>
+const job = (): string =>
     text('Job', 'Editor Of Things');
 
-const profileLink = () =>
+const profileLink = (): string =>
     text('Profile Link', 'https://theguardian.com');
 
-const byline = () =>
+const byline = (): string =>
     text('Byline', 'Jane Smith');
 
 function publishDate(): Option<Date> {

--- a/src/components/standard/byline.stories.tsx
+++ b/src/components/standard/byline.stories.tsx
@@ -1,0 +1,100 @@
+// ----- IUmports ----- //
+
+import { withKnobs, text, boolean, date } from '@storybook/addon-knobs';
+import { ReactNode } from 'react';
+
+import Byline from 'components/standard/byline';
+import { Pillar } from 'pillar';
+import { Layout, Article } from 'article';
+import { Option, None, Some } from 'types/option';
+import { parse } from 'client/parser';
+
+
+// ----- Setup ----- //
+
+const parser = new DOMParser();
+const parseByline = parse(parser);
+
+const article: Article = {
+    pillar: Pillar.news,
+    layout: Layout.Standard,
+    body: [],
+    headline: '',
+    standfirst: new None(),
+    byline: '',
+    bylineHtml: new None(),
+    publishDate: new Some(new Date()),
+    mainImage: new None(),
+    contributors: [],
+    series: {
+        id: '',
+        type: 0,
+        webTitle: '',
+        webUrl: '',
+        apiUrl: '',
+        references: [],
+    },
+    commentable: false,
+    tags: [],
+};
+
+const contributor = () => ({
+    id: 'mock_id',
+    type: 2,
+    webTitle: text('Byline', 'Jane Smith'),
+    webUrl: 'https://theguardian.com',
+    apiUrl: 'https://theguardian.com',
+    references: [],
+});
+
+const job = () =>
+    text('Job', 'Editor Of Things');
+
+const profileLink = () =>
+    text('Profile Link', 'https://theguardian.com');
+
+const byline = () =>
+    text('Byline', 'Jane Smith');
+
+function publishDate(): Option<Date> {
+    const now = new Date(date('Date', new Date()));
+    return boolean('Include Date', true) ? new Some(now) : new None();
+}
+
+const mockBylineHtml = (): Option<DocumentFragment> =>
+    parseByline(`<a href="${profileLink()}">${byline()}</a> ${job()}`).either(
+        _ => new None(),
+        frag => new Some(frag),
+    );
+
+
+// ----- Stories ----- //
+
+export default { title: 'Byline', decorators: [ withKnobs ] };
+
+const News = (): ReactNode =>
+    <Byline imageSalt="mock_salt" article={{
+        ...article,
+        byline: text('Byline', 'Jane Smith'),
+        bylineHtml: mockBylineHtml(),
+        contributors: boolean('Include Follow', false) ? [contributor()] : [],
+        publishDate: publishDate(),
+    }} />
+
+const Sport = (): ReactNode =>
+    <Byline imageSalt="mock_salt" article={{
+        ...article,
+        byline: text('Byline', 'Jane Smith'),
+        pillar: Pillar.sport,
+        bylineHtml: mockBylineHtml(),
+        contributors: boolean('Include Follow', false) ? [contributor()] : [],
+        publishDate: publishDate(),
+    }} />
+
+
+// ----- Exports ----- //
+
+export {
+    News,
+    Sport,
+}

--- a/src/components/standard/headline.stories.tsx
+++ b/src/components/standard/headline.stories.tsx
@@ -5,14 +5,33 @@ import { withKnobs, text } from "@storybook/addon-knobs";
 
 import Headline from 'components/standard/headline';
 import { Pillar } from 'pillar';
-import { Layout } from 'article';
+import { Layout, Article } from 'article';
+import { None } from 'types/option';
 
 
 // ----- Setup ----- //
 
-const article = {
+const article: Article = {
     pillar: Pillar.news,
     layout: Layout.Standard,
+    body: [],
+    headline: '',
+    standfirst: new None(),
+    byline: '',
+    bylineHtml: new None(),
+    publishDate: new None(),
+    mainImage: new None(),
+    contributors: [],
+    series: {
+        id: '',
+        type: 0,
+        webTitle: '',
+        webUrl: '',
+        apiUrl: '',
+        references: [],
+    },
+    commentable: false,
+    tags: [],
 };
 
 const copyKnob = 'Headline Copy';
@@ -24,22 +43,37 @@ const copy = 'Reclaimed lakes and giant airports: how Mexico City might have loo
 export default { title: 'Headline', decorators: [ withKnobs ] };
 
 export const Standard = (): ReactNode =>
-    <Headline headline={text(copyKnob, copy)} article={article} />
+    <Headline article={{
+        ...article,
+        headline: text(copyKnob, copy),
+    }} />
 
 export const Feature = (): ReactNode =>
-    <Headline headline={text(copyKnob, copy)} article={{ ...article, layout: Layout.Feature }} />
+    <Headline article={{
+        ...article,
+        layout: Layout.Feature,
+        headline: text(copyKnob, copy),
+    }} />
 
 export const SportFeature = (): ReactNode =>
-    <Headline
-        headline={text(copyKnob, copy)}
-        article={{ pillar: Pillar.sport, layout: Layout.Feature }}
-    />
+    <Headline article={{
+        ...article,
+        pillar: Pillar.sport,
+        layout: Layout.Feature,
+        headline: text(copyKnob, copy),
+    }} />
 
 export const Analysis = (): ReactNode =>
-    <Headline headline={text(copyKnob, copy)} article={{ ...article, layout: Layout.Analysis }} />
+    <Headline article={{
+        ...article,
+        layout: Layout.Analysis,
+        headline: text(copyKnob, copy),
+    }} />
 
-export const ArtsAnalysis = (): ReactNode =>
-    <Headline
-        headline={text(copyKnob, copy)}
-        article={{ pillar: Pillar.arts, layout: Layout.Analysis }}
-    />
+export const CultureAnalysis = (): ReactNode =>
+    <Headline article={{
+        ...article,
+        pillar: Pillar.arts,
+        layout: Layout.Analysis,
+        headline: text(copyKnob, copy),
+    }} />

--- a/src/components/standard/headline.tsx
+++ b/src/components/standard/headline.tsx
@@ -56,13 +56,12 @@ const DarkStyles = darkModeCss`
 // ----- Component ----- //
 
 interface Props {
-    headline: string;
     article: Article;
 }
 
-const Headline = ({ headline, article }: Props): JSX.Element =>
+const Headline = ({ article }: Props): JSX.Element =>
     <div css={[Styles(article), DarkStyles]}>
-        <h1>{headline}</h1>
+        <h1>{article.headline}</h1>
         { article.layout === Layout.Review ? <ArticleRating rating={article.starRating} /> : null }
     </div>
 


### PR DESCRIPTION
## Why are you doing this?

The headline stories were failing to build because the type of `Article` had changed (I think this happened in the transition from JSON to Thrift for CAPI types, possibly in in #168). This fixes that problem by correctly mocking the new article. It also fixes a problem where storybook was 404ing for some fonts due to an incorrect path.

In addition it adds some stories for the standard byline, and includes a new client-side parser derived from [`DOMParser`](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser), which we may use in the future for pages like liveblogs.

## Changes

- Fix `Article` mocking for headline stories
- Fix font loading for storybook
- Added Byline stories
- Added client-side parser
