### PR TITLE
link prefetch header

### DIFF
--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -82,7 +82,7 @@ interface BodyProps {
     capi: Content;
 }
 
-interface elementWithScript {
+interface ElementWithScript {
     element: JSX.Element;
     script: string;
 }
@@ -93,7 +93,7 @@ const WithScript = (props: { src: string; children: ReactNode }): ReactElement =
         <script src={props.src}></script>
     </>
 
-function ArticleBody({ capi, imageSalt }: BodyProps): elementWithScript {
+function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithScript {
     const article = fromCapi(JSDOM.fragment)(capi);
     
     const articleScript = '/assets/article.js';
@@ -154,7 +154,7 @@ interface Props {
     imageSalt: string;
 }
 
-function Page({ content, imageSalt }: Props): elementWithScript {
+function Page({ content, imageSalt }: Props): ElementWithScript {
     const twitterScript = includesTweets(content)
         ? <script src="https://platform.twitter.com/widgets.js"></script>
         : null

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -84,7 +84,7 @@ interface BodyProps {
 
 interface elementWithScript {
     element: JSX.Element;
-    script?: string;
+    script: string;
 }
 
 const WithScript = (props: { src: string; children: ReactNode }): ReactElement =>
@@ -145,7 +145,7 @@ function ArticleBody({ capi, imageSalt }: BodyProps): elementWithScript {
                 </WithScript>
             ), script: liveblogScript };
         default:
-            return { element: <p>{capi.type} not implemented yet</p> };
+            return { element: <p>{capi.type} not implemented yet</p>, script: articleScript };
     }
 }
 

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -82,9 +82,9 @@ interface BodyProps {
     capi: Content;
 }
 
-interface ElementWithScript {
-    element: JSX.Element;
-    script: string;
+interface ElementWithResources {
+    element: React.ReactElement;
+    resources: string[];
 }
 
 const WithScript = (props: { src: string; children: ReactNode }): ReactElement =>
@@ -93,7 +93,7 @@ const WithScript = (props: { src: string; children: ReactNode }): ReactElement =
         <script src={props.src}></script>
     </>
 
-function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithScript {
+function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithResources {
     const article = fromCapi(JSDOM.fragment)(capi);
     
     const articleScript = '/assets/article.js';
@@ -111,7 +111,7 @@ function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithScript {
                         {opinionContent}
                     </Opinion>
                 </WithScript>
-            ), script: articleScript };
+            ), resources: [articleScript] };
         case Layout.Immersive:
             const immersiveBody = partition(article.body).oks;
             const immersiveContent =
@@ -123,7 +123,7 @@ function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithScript {
                         {immersiveContent}
                     </Immersive>
                 </WithScript>
-            ), script: articleScript };
+            ), resources: [articleScript] };
         case Layout.Standard:
         case Layout.Feature:
         case Layout.Analysis:
@@ -137,15 +137,15 @@ function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithScript {
                         {content}
                     </Standard>
                 </WithScript>
-            ), script: articleScript };;
+            ), resources: [articleScript] };;
         case Layout.Liveblog:
             return { element: (
                 <WithScript src={liveblogScript}>
                     <LiveblogArticle article={article} imageSalt={imageSalt} />
                 </WithScript>
-            ), script: liveblogScript };
+            ), resources: [liveblogScript] };
         default:
-            return { element: <p>{capi.type} not implemented yet</p>, script: articleScript };
+            return { element: <p>{capi.type} not implemented yet</p>, resources: [articleScript] };
     }
 }
 
@@ -154,12 +154,12 @@ interface Props {
     imageSalt: string;
 }
 
-function Page({ content, imageSalt }: Props): ElementWithScript {
+function Page({ content, imageSalt }: Props): ElementWithResources {
     const twitterScript = includesTweets(content)
         ? <script src="https://platform.twitter.com/widgets.js"></script>
         : null
 
-    const { element, script } = ArticleBody({ imageSalt, capi: content})
+    const { element, resources } = ArticleBody({ imageSalt, capi: content})
 
     return { element: (
         <html lang="en" css={PageStyles}>
@@ -174,7 +174,7 @@ function Page({ content, imageSalt }: Props): ElementWithScript {
                 { twitterScript }
             </body>
         </html>
-    ), script };
+    ), resources };
 }
 
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -315,7 +315,7 @@ const richLinkStyles = css`
     background: ${neutral[97]};
     padding: ${basePx(1)};
 
-    h4 {
+    h1 {
         margin: ${basePx(0, 0, 2, 0)};
     }
 
@@ -330,6 +330,7 @@ const richLinkStyles = css`
     a {
         text-decoration: none;
         background: none;
+        font-size: 1.25em;
     }
 
     float: left;
@@ -354,7 +355,7 @@ const richLinkStyles = css`
 
 const RichLink = (props: { url: string; linkText: string; pillar: Pillar }): ReactElement =>
     styledH('aside', { css: richLinkStyles },
-        h('h4', null, props.linkText),
+        h('h1', null, props.linkText),
         h(Anchor, { href: props.url, pillar: props.pillar, text: 'Read more' }),
     );
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -315,7 +315,7 @@ const richLinkStyles = css`
     background: ${neutral[97]};
     padding: ${basePx(1)};
 
-    h1 {
+    h4 {
         margin: ${basePx(0, 0, 2, 0)};
     }
 
@@ -330,7 +330,6 @@ const richLinkStyles = css`
     a {
         text-decoration: none;
         background: none;
-        font-size: 1.25em;
     }
 
     float: left;
@@ -355,7 +354,7 @@ const richLinkStyles = css`
 
 const RichLink = (props: { url: string; linkText: string; pillar: Pillar }): ReactElement =>
     styledH('aside', { css: richLinkStyles },
-        h('h1', null, props.linkText),
+        h('h4', null, props.linkText),
         h(Anchor, { href: props.url, pillar: props.pillar, text: 'Read more' }),
     );
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -38,8 +38,8 @@ type Supported = {
   reason: string;
 }
 
-function getPrefetchHeader(script: string): string {
-  return `<${script}>; rel=prefetch`
+function getPrefetchHeader(resources: string[]): string {
+  return resources.reduce((linkHeader, resource) => linkHeader + `<${resource}>; rel=prefetch,`, '');
 }
 
 function checkSupport({ atoms }: Content): Supported {
@@ -63,9 +63,9 @@ async function serveArticlePost(
       const imageSalt = await getConfigValue<string>('apis.img.salt');
 
     if (support.kind === Support.Supported) {
-      const { script, element } = Page({ content, imageSalt });
+      const { resources, element } = Page({ content, imageSalt });
       const html = renderToString(element);
-      res.set('Link', getPrefetchHeader(script));
+      res.set('Link', getPrefetchHeader(resources));
       res.write('<!DOCTYPE html>');
       res.write(html);
       res.end();
@@ -107,8 +107,8 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
             const support = checkSupport(content);
 
             if (support.kind === Support.Supported) {
-              const { script, element } = Page({ content, imageSalt });
-              res.set('Link', getPrefetchHeader(script));
+              const { resources, element } = Page({ content, imageSalt });
+              res.set('Link', getPrefetchHeader(resources));
               res.write('<!DOCTYPE html>');
               res.write(renderToString(element));
               res.end();

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -38,8 +38,8 @@ type Supported = {
   reason: string;
 }
 
-function getPrefetchScripts(): string {
-  return '<assets/article.js>; rel=prefetch, <assets/liveblog.js>; rel=prefetch'
+function getPrefetchHeader(script: string): string {
+  return `<${script}>; rel=prefetch`
 }
 
 function checkSupport({ atoms }: Content): Supported {
@@ -64,9 +64,8 @@ async function serveArticlePost(
 
     if (support.kind === Support.Supported) {
       const { script, element } = Page({ content, imageSalt });
-      res.set('Link', script);
       const html = renderToString(element);
-      res.set('Link', getPrefetchScripts());
+      res.set('Link', getPrefetchHeader(script));
       res.write('<!DOCTYPE html>');
       res.write(html);
       res.end();
@@ -109,7 +108,7 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
 
             if (support.kind === Support.Supported) {
               const { script, element } = Page({ content, imageSalt });
-              res.set('Link', script);
+              res.set('Link', getPrefetchHeader(script));
               res.write('<!DOCTYPE html>');
               res.write(renderToString(element));
               res.end();


### PR DESCRIPTION
## Why are you doing this?
Added a new `Link` http header to show what scripts and css files the apps need to prefetch. Hopefully the caching layers they use or the webview will do this automatically like browsers do. If not, the http header can still be used to manually fetch the resources so that they're available offline.

### Example:
App requests a standard article and receives the header: 
`Link: <assets/article.js>; rel=prefetch`
We should then assume this JavaScript file is available when the user opens the article (atleast from a home front) and is available offline

- We need to forward these headers in mapi to the apps
- This will change when we serve assets from a more suitable place like s3 (naming of files with hashes and the location)