### PR TITLE
reduce rich link font size

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -315,8 +315,9 @@ const richLinkStyles = css`
     background: ${neutral[97]};
     padding: ${basePx(1)};
 
-    h4 {
+    h1 {
         margin: ${basePx(0, 0, 2, 0)};
+        font-size: 1em;
     }
 
     p {
@@ -354,7 +355,7 @@ const richLinkStyles = css`
 
 const RichLink = (props: { url: string; linkText: string; pillar: Pillar }): ReactElement =>
     styledH('aside', { css: richLinkStyles },
-        h('h4', null, props.linkText),
+        h('h1', null, props.linkText),
         h(Anchor, { href: props.url, pillar: props.pillar, text: 'Read more' }),
     );
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -315,7 +315,7 @@ const richLinkStyles = css`
     background: ${neutral[97]};
     padding: ${basePx(1)};
 
-    h1 {
+    h4 {
         margin: ${basePx(0, 0, 2, 0)};
     }
 
@@ -330,7 +330,6 @@ const richLinkStyles = css`
     a {
         text-decoration: none;
         background: none;
-        font-size: 1.25em;
     }
 
     float: left;
@@ -355,7 +354,7 @@ const richLinkStyles = css`
 
 const RichLink = (props: { url: string; linkText: string; pillar: Pillar }): ReactElement =>
     styledH('aside', { css: richLinkStyles },
-        h('h1', null, props.linkText),
+        h('h4', null, props.linkText),
         h(Anchor, { href: props.url, pillar: props.pillar, text: 'Read more' }),
     );
 


### PR DESCRIPTION
## Why are you doing this?
The Rich link font is too large, use a smaller header and reduce the link font size.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/74332297-59c48400-4d8d-11ea-8511-aacd592161ce.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/74332322-63e68280-4d8d-11ea-983a-cd3e893e6f2e.png" width="300px" /> |
