### PR TITLE
get local times on client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8447,6 +8447,11 @@
         "whatwg-url": "^7.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.8.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.20.tgz",
+      "integrity": "sha512-mH0MCDxw6UCGJYxVN78h8ugWycZAO8thkj3bW6vApL5tS0hQplIDdAQcmbvl7n35H0AKdCJQaArTrIQw2xt4Qg=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -14357,11 +14362,6 @@
       "version": "0.37.0",
       "resolved": "https://registry.npmjs.org/mobile-apps-thrift-typescript/-/mobile-apps-thrift-typescript-0.37.0.tgz",
       "integrity": "sha512-qOy6EFDjzjCZEnF+VWzZK688ut4bBF0K7YLliT0c1Nl0LOUD3HuZG/rrLbS2ymoLaWWogYRLR1oSQ/wnoQan9A=="
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moo": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "express": "^4.17.1",
     "jsdom": "^15.2.1",
     "mobile-apps-thrift-typescript": "^0.37.0",
-    "moment": "^2.24.0",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/uuid": "^3.4.6",
     "aws-sdk": "^2.604.0",
     "compression": "^1.7.4",
+    "dayjs": "^1.8.20",
     "emotion": "^10.0.27",
     "express": "^4.17.1",
     "jsdom": "^15.2.1",

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -129,9 +129,13 @@ function slideshow(): void {
 function formatDates(): void {
     Array.from(document.querySelectorAll('time[data-date]'))
         .forEach(time => {
-            const timestamp = time.getAttribute('data-date');
-            if (timestamp) {
-                time.textContent = formatDate(new Date(timestamp))
+            try {
+                const timestamp = time.getAttribute('data-date');
+                if (timestamp) {
+                    time.textContent = formatDate(new Date(timestamp))
+                }
+            } catch (e) {
+                console.error(e);
             }
         })
 }

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -5,6 +5,7 @@ import { nativeClient } from 'native/nativeApi';
 import { AdSlot } from 'mobile-apps-thrift-typescript/AdSlot'
 import { Topic } from 'mobile-apps-thrift-typescript/Topic';
 import { Image } from 'mobile-apps-thrift-typescript/Image';
+import { formatDate } from 'date';
 
 // ----- Run ----- //
 
@@ -125,7 +126,18 @@ function slideshow(): void {
         }));
 }
 
+function formatDates(): void {
+    Array.from(document.querySelectorAll('time[data-date]'))
+        .forEach(time => {
+            const timestamp = time.getAttribute('data-date');
+            if (timestamp) {
+                time.textContent = formatDate(new Date(timestamp))
+            }
+        })
+}
+
 setup();
 ads();
 topics();
 slideshow();
+formatDates();

--- a/src/components/standard/byline.tsx
+++ b/src/components/standard/byline.tsx
@@ -88,7 +88,7 @@ function Byline({ article, imageSalt }: Props): JSX.Element {
                 <div className="author">
                     <Author byline={article.bylineHtml} pillar={article.pillar} />
                     { article.publishDate
-                        .fmap<JSX.Element | null>(date => <time className="date">{ formatDate(new Date(date)) }</time>)
+                        .fmap<JSX.Element | null>(date => <time data-date={date} className="date">{ formatDate(new Date(date)) }</time>)
                         .withDefault(null) }
                     <Follow contributors={article.contributors} />
                 </div>

--- a/src/date.ts
+++ b/src/date.ts
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 function isToday(date: Date): boolean {
     const today = new Date();
     return (date.toDateString() === today.toDateString());
@@ -63,15 +65,5 @@ export function makeRelativeDate(date: Date): string | null {
 }
 
 export function formatDate(date: Date): string {
-    const options = {
-        weekday: "long", year: "numeric", month: "long",
-        day: "numeric", hour: "numeric", minute: "numeric"
-    }
-    const dateParts = new Date(date)
-        .toLocaleTimeString("en-us", options)
-        .replace(/,/g, '')
-        .split(' ');
-
-    // 7:00 Friday, 13 September 2019
-    return `${dateParts[4]} ${dateParts[0]}, ${dateParts[2]} ${dateParts[1]} ${dateParts[3]}`
+    return dayjs(date).format('HH:mm dddd, D MMMM YYYY');
 }

--- a/src/date.ts
+++ b/src/date.ts
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 function isToday(date: Date): boolean {
     const today = new Date();
     return (date.toDateString() === today.toDateString());
@@ -65,5 +63,15 @@ export function makeRelativeDate(date: Date): string | null {
 }
 
 export function formatDate(date: Date): string {
-    return moment(date).format('HH:mm dddd, D MMMM YYYY');
+    const options = {
+        weekday: "long", year: "numeric", month: "long",
+        day: "numeric", hour: "numeric", minute: "numeric"
+    }
+    const dateParts = new Date(date)
+        .toLocaleTimeString("en-us", options)
+        .replace(/,/g, '')
+        .split(' ');
+
+    // 7:00 Friday, 13 September 2019
+    return `${dateParts[4]} ${dateParts[0]}, ${dateParts[2]} ${dateParts[1]} ${dateParts[3]}`
 }


### PR DESCRIPTION
## Why are you doing this?
Re-render dates client side to change to user's timezone.

## Changes

- Remove moment library
- Added client side code to detect times in the DOM and re-calculate them using `new Date()`. This should reflect their timezone

## More considerations
- We'll need the JavaScript available to avoid a weird change of date (this might be confusing)
- Maybe we should add the user's timezone after the date. A user recently questioned us about this and dotcom show it.

