### PR TITLE
Format and Item Types

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -17,7 +17,12 @@ module.exports =  {
         "@typescript-eslint/no-unused-vars": "off",
         'max-len': [
             "error",
-            { code: 100, ignoreStrings: true, ignoreTemplateLiterals: true },
+            {
+                code: 100,
+                ignoreStrings: true,
+                ignoreTemplateLiterals: true,
+                ignoreUrls: true,
+            },
         ],
         '@typescript-eslint/explicit-function-return-type': 2,
         'eqeqeq': 2,

--- a/src/ads.test.ts
+++ b/src/ads.test.ts
@@ -4,7 +4,7 @@ import { renderAll } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { Pillar } from 'pillar';
 import { compose } from 'lib';
-import { ElementKind, BodyElement } from 'article';
+import { ElementKind, BodyElement } from 'item';
 
 const textElement = (nodes: string[]): BodyElement =>
     ({

--- a/src/capi.test.ts
+++ b/src/capi.test.ts
@@ -6,6 +6,6 @@ describe('server logic runs as expected', () => {
         const key = 'TEST_KEY';
         const capiUrl = capiEndpoint(articleId, key);
 
-        expect(capiUrl).toEqual('https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=all&show-tags=all&show-blocks=all')
+        expect(capiUrl).toEqual('https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=all&show-tags=all&show-blocks=all&show-elements=all');
     });
 });

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -109,6 +109,7 @@ const capiEndpoint = (articleId: string, key: string): string => {
       'show-fields': 'all',
       'show-tags': 'all',
       'show-blocks': 'all',
+      'show-elements': 'all',
     })
   
     return `https://content.guardianapis.com/${articleId}?${params.toString()}`;

--- a/src/components/immersive/article.tsx
+++ b/src/components/immersive/article.tsx
@@ -15,7 +15,7 @@ import Tags from 'components/shared/tags';
 import { articleWidthStyles, basePx, darkModeCss } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { getPillarStyles, Pillar } from 'pillar';
-import { Standard } from 'article';
+import { Standard } from 'item';
 
 
 // ----- Styles ----- //
@@ -77,46 +77,46 @@ const HeaderImageStyles = css`
 
 interface Props {
     imageSalt: string;
-    article: Standard;
+    item: Standard;
     children: ReactNode[];
 }
 
-const Immersive = ({ imageSalt, article, children }: Props): JSX.Element =>
+const Immersive = ({ imageSalt, item, children }: Props): JSX.Element =>
     <main css={DarkStyles}>
         <article css={BorderStyles}>
             <header>
                 <div css={articleWidthStyles}>
                     <HeaderImage
-                        image={article.mainImage}
+                        image={item.mainImage}
                         imageSalt={imageSalt}
                         className={HeaderImageStyles}
                     />
-                    <Series series={article.series} pillar={article.pillar}/>
-                    <Headline headline={article.headline}/>
+                    <Series series={item.series} pillar={item.pillar}/>
+                    <Headline headline={item.headline}/>
                     <Standfirst
-                        standfirst={article.standfirst}
-                        pillar={article.pillar}
+                        standfirst={item.standfirst}
+                        pillar={item.pillar}
                         className={articleWidthStyles}
-                        bylineHtml={article.bylineHtml}
-                        byline={article.byline}
+                        bylineHtml={item.bylineHtml}
+                        byline={item.byline}
                     />
                 </div>
-                <Keyline {...article} />
+                <Keyline {...item} />
                 <Byline
-                    pillar={article.pillar}
-                    publicationDate={article.publishDate}
-                    contributors={article.contributors}
+                    pillar={item.pillar}
+                    publicationDate={item.publishDate}
+                    contributors={item.contributors}
                     className={articleWidthStyles}
                 />
             </header>
             <ArticleBody
-                pillar={article.pillar}
-                className={[articleWidthStyles, DropCapStyles(article.pillar), HeaderStyles]}
+                pillar={item.pillar}
+                className={[articleWidthStyles, DropCapStyles(item.pillar), HeaderStyles]}
             >
                 {children}
             </ArticleBody>
             <footer css={articleWidthStyles}>
-                <Tags tags={article.tags}/>
+                <Tags tags={item.tags}/>
             </footer>
         </article>
     </main>

--- a/src/components/immersive/article.tsx
+++ b/src/components/immersive/article.tsx
@@ -15,7 +15,7 @@ import Tags from 'components/shared/tags';
 import { articleWidthStyles, basePx, darkModeCss } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { getPillarStyles, Pillar } from 'pillar';
-import { Standard } from 'item';
+import { Item } from 'item';
 
 
 // ----- Styles ----- //
@@ -77,7 +77,7 @@ const HeaderImageStyles = css`
 
 interface Props {
     imageSalt: string;
-    item: Standard;
+    item: Item;
     children: ReactNode[];
 }
 

--- a/src/components/immersive/headerImage.tsx
+++ b/src/components/immersive/headerImage.tsx
@@ -6,7 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 
 import { wideContentWidth } from 'styles';
 import { Option } from 'types/option';
-import { Image } from 'article';
+import { Image } from 'item';
 import { ImageElement } from 'renderer';
 
 

--- a/src/components/liveblog/article.tsx
+++ b/src/components/liveblog/article.tsx
@@ -13,7 +13,7 @@ import { css, SerializedStyles } from '@emotion/core'
 import { neutral, background } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { PillarStyles, getPillarStyles } from 'pillar';
-import { Liveblog } from 'article';
+import { Liveblog } from 'item';
 
 const LiveblogArticleStyles: SerializedStyles = css`
     background: ${neutral[97]};
@@ -45,31 +45,31 @@ const HeaderImageStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
 `;
 
 interface LiveblogArticleProps {
-    article: Liveblog;
+    item: Liveblog;
     imageSalt: string;
 }
 
-const LiveblogArticle = ({ article, imageSalt }: LiveblogArticleProps): JSX.Element => {
+const LiveblogArticle = ({ item, imageSalt }: LiveblogArticleProps): JSX.Element => {
 
     return (
         <main css={LiveblogArticleStyles}>
             <div css={BorderStyles}>
-                <LiveblogSeries series={article.series} pillar={article.pillar} />
-                <LiveblogHeadline headline={article.headline} pillar={article.pillar} />
-                <LiveblogStandfirst standfirst={article.standfirst} pillar={article.pillar} />
-                <LiveblogByline article={article} imageSalt={imageSalt} />
+                <LiveblogSeries series={item.series} pillar={item.pillar} />
+                <LiveblogHeadline headline={item.headline} pillar={item.pillar} />
+                <LiveblogStandfirst standfirst={item.standfirst} pillar={item.pillar} />
+                <LiveblogByline item={item} imageSalt={imageSalt} />
                 <HeaderImage
-                    image={article.mainImage}
+                    image={item.mainImage}
                     imageSalt={imageSalt}
-                    className={HeaderImageStyles(getPillarStyles(article.pillar))}
+                    className={HeaderImageStyles(getPillarStyles(item.pillar))}
                 />
-                <LiveblogKeyEvents blocks={article.blocks} pillar={article.pillar} />
+                <LiveblogKeyEvents blocks={item.blocks} pillar={item.pillar} />
                 <LiveblogBody
-                    blocks={article.blocks}
-                    pillar={article.pillar}
+                    blocks={item.blocks}
+                    pillar={item.pillar}
                     imageSalt={imageSalt}
                 />
-                <Tags tags={article.tags} background={neutral[93]} />
+                <Tags tags={item.tags} background={neutral[93]} />
             </div>
         </main>
     );

--- a/src/components/liveblog/body.tsx
+++ b/src/components/liveblog/body.tsx
@@ -3,7 +3,7 @@ import LiveblogBlock from './block';
 import LiveblogLoadMore from './loadMore';
 import { css, SerializedStyles } from '@emotion/core'
 import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
-import { LiveBlock } from 'article';
+import { LiveBlock } from 'item';
 import { renderAll } from 'renderer';
 import { partition } from 'types/result';
 

--- a/src/components/liveblog/byline.tsx
+++ b/src/components/liveblog/byline.tsx
@@ -8,7 +8,7 @@ import Avatar from 'components/shared/avatar';
 import LeftColumn from 'components/shared/leftColumn';
 import { PillarStyles, getPillarStyles } from 'pillar';
 import { CommentCount } from 'components/shared/commentCount';
-import { Article } from 'article';
+import { Liveblog } from 'item';
 import { renderText } from 'renderer';
 
 const LiveblogBylineStyles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
@@ -67,29 +67,29 @@ const commentCount = ({ liveblogBackground }: PillarStyles): SerializedStyles =>
 `
 
 interface LiveblogBylineProps {
-    article: Article;
+    item: Liveblog;
     imageSalt: string;
 }
 
-const LiveblogByline = ({ article, imageSalt}: LiveblogBylineProps): JSX.Element => {
-    const pillarStyles = getPillarStyles(article.pillar);
+const LiveblogByline = ({ item, imageSalt}: LiveblogBylineProps): JSX.Element => {
+    const pillarStyles = getPillarStyles(item.pillar);
 
-    const byline = article.bylineHtml.fmap<ReactNode>(html =>
-        <address>{ renderText(html, article.pillar) }</address>
+    const byline = item.bylineHtml.fmap<ReactNode>(html =>
+        <address>{ renderText(html, item.pillar) }</address>
     ).withDefault(null);
 
-    const date = article.publishDate.fmap<ReactNode>(date =>
+    const date = item.publishDate.fmap<ReactNode>(date =>
         <time>{ formatDate(new Date(date)) }</time>
     ).withDefault(null)
 
     return (
         <div css={[LiveblogBylineStyles(pillarStyles)]}>
-            <Keyline {...article} />
+            <Keyline {...item} />
             <LeftColumn>
                 <section>
                     <div className="byline">
                         <Avatar
-                            contributors={article.contributors}
+                            contributors={item.contributors}
                             bgColour={pillarStyles.featureHeadline}
                             imageSalt={imageSalt}
                         />
@@ -100,7 +100,7 @@ const LiveblogByline = ({ article, imageSalt}: LiveblogBylineProps): JSX.Element
                         </div>
                     </div>
 
-                    {article.commentable
+                    {item.commentable
                         ? <CommentCount
                             count={0}
                             colour={neutral[100]}

--- a/src/components/liveblog/keyEvents.tsx
+++ b/src/components/liveblog/keyEvents.tsx
@@ -4,7 +4,7 @@ import { css, SerializedStyles } from '@emotion/core'
 import { neutral } from '@guardian/src-foundations/palette';
 import { makeRelativeDate } from 'date';
 import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
-import { LiveBlock } from 'article';
+import { LiveBlock } from 'item';
 
 const LiveblogKeyEventsStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     background: ${neutral[100]};

--- a/src/components/opinion/article.tsx
+++ b/src/components/opinion/article.tsx
@@ -17,7 +17,7 @@ import { darkModeCss, articleWidthStyles, basePx } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { CommentCount } from 'components/shared/commentCount';
 import { getPillarStyles } from 'pillar';
-import { Standard } from 'article';
+import { Comment } from 'item';
 
 
 // ----- Styles ----- //
@@ -73,59 +73,59 @@ const topBorder = css`
 
 interface Props {
     imageSalt: string;
-    article: Standard;
+    item: Comment;
     children: ReactNode[];
 }
 
-const Opinion = ({ imageSalt, article, children }: Props): JSX.Element =>
+const Opinion = ({ imageSalt, item, children }: Props): JSX.Element =>
     <main css={[Styles, DarkStyles]}>
         <article css={BorderStyles}>
             <header>
                 <div css={articleWidthStyles}>
-                    <ArticleSeries series={article.series} pillar={article.pillar}/>
+                    <ArticleSeries series={item.series} pillar={item.pillar}/>
                     <Headline
-                        byline={article.bylineHtml}
-                        headline={article.headline}
-                        pillar={article.pillar}
+                        byline={item.bylineHtml}
+                        headline={item.headline}
+                        pillar={item.pillar}
                     />
                 </div>
                 <Cutout 
-                    contributors={article.contributors}
+                    contributors={item.contributors}
                     imageSalt={imageSalt}
                     className={articleWidthStyles}
                 />
-                <Keyline {...article} />
+                <Keyline {...item} />
                 <ArticleStandfirst
-                    article={article}
+                    item={item}
                     className={articleWidthStyles}
                 />
 
                 <section css={[articleWidthStyles, topBorder]}>
                     <Byline
-                        pillar={article.pillar}
-                        publicationDate={article.publishDate}
-                        contributors={article.contributors}
+                        pillar={item.pillar}
+                        publicationDate={item.publishDate}
+                        contributors={item.contributors}
                     />
-                    {article.commentable
+                    {item.commentable
                         ? <CommentCount
                             count={0}
-                            colour={getPillarStyles(article.pillar).kicker}
+                            colour={getPillarStyles(item.pillar).kicker}
                             className={CommentCountStyles}
                             />
                         : null}
                 </section>
 
                 <HeaderImage
-                    image={article.mainImage}
+                    image={item.mainImage}
                     imageSalt={imageSalt}
                     className={HeaderImageStyles}
                 />
             </header>
-            <ArticleBody pillar={article.pillar} className={[articleWidthStyles]}>
+            <ArticleBody pillar={item.pillar} className={[articleWidthStyles]}>
                 {children}
             </ArticleBody>
             <footer css={articleWidthStyles}>
-                <Tags tags={article.tags}/>
+                <Tags tags={item.tags}/>
             </footer>
         </article>
     </main>

--- a/src/components/shared/headerImage.test.tsx
+++ b/src/components/shared/headerImage.test.tsx
@@ -3,7 +3,7 @@ import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { None, Option } from 'types/option';
 import HeaderImage from 'components/shared/headerImage';
-import { Image } from 'article';
+import { Image } from 'item';
 
 configure({ adapter: new Adapter() });
 

--- a/src/components/shared/headerImage.tsx
+++ b/src/components/shared/headerImage.tsx
@@ -5,7 +5,7 @@ import HeaderImageCaption, { captionId } from './headerImageCaption';
 import { from, breakpoints } from '@guardian/src-foundations/mq';
 import { wideContentWidth, basePx } from 'styles';
 import { Option } from 'types/option';
-import { Image } from 'article';
+import { Image } from 'item';
 import { ImageElement } from 'renderer';
 
 const Styles = (width: number, height: number): SerializedStyles => css`

--- a/src/components/shared/keyline.test.tsx
+++ b/src/components/shared/keyline.test.tsx
@@ -2,27 +2,27 @@ import React from 'react';
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Keyline } from 'components/shared/keyline';
-import { Layout } from 'article';
+import { Design } from 'item';
 
 configure({ adapter: new Adapter() });
 
 describe('Keyline component renders as expected', () => {
     it('Renders styles for liveblogs', () => {
-        const article = { layout: Layout.Liveblog };
+        const article = { design: Design.Live };
         const keyline = shallow(<Keyline {...article} />);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 3px)")
         expect(keyline.props().css.styles).toContain("opacity:.4;")
     })
 
-    it('Renders styles for opinion articles', () => {
-        const article = { layout: Layout.Opinion };
+    it('Renders styles for comment articles', () => {
+        const article = { design: Design.Comment };
         const keyline = shallow(<Keyline {...article} />);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 3px)")
         expect(keyline.props().css.styles).toContain("height:24px;")
     })
 
     it('Renders styles for standard articles', () => {
-        const article = { layout: Layout.Standard };
+        const article = { design: Design.Article };
         const keyline = shallow(<Keyline {...article} />);
         expect(keyline.props().css.styles).toContain("background-image:repeating-linear-gradient(#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 3px)")
     })

--- a/src/components/shared/keyline.tsx
+++ b/src/components/shared/keyline.tsx
@@ -3,7 +3,7 @@ import { css, SerializedStyles } from '@emotion/core'
 import { darkModeCss, wideContentWidth, wideColumnWidth, baseMultiply } from 'styles';
 import { neutral } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
-import { Layout } from 'article';
+import { Design } from 'item';
 
 const BaseStyles = css`
     height: 12px;
@@ -43,19 +43,19 @@ const KeylineDarkStyles = darkModeCss`
 `;
 
 type Props = {
-    layout: Layout;
+    design: Design;
 };
 
-export const Keyline = ({ layout }: Props): JSX.Element => {
-    const SelectedKeylineStyles = ((layout): SerializedStyles => {
-        switch(layout) {
-            case Layout.Liveblog:
+export const Keyline = ({ design }: Props): JSX.Element => {
+    const SelectedKeylineStyles = ((design): SerializedStyles => {
+        switch(design) {
+            case Design.Live:
                 return KeylineLiveblogStyles
-            case Layout.Opinion:
+            case Design.Comment:
                 return KeylineOpinionStyles
             default:
                 return KeylineNewsStyles;
-        }})(layout);
+        }})(design);
     
     return <hr css={[BaseStyles, SelectedKeylineStyles, KeylineDarkStyles]} />
 }

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -121,6 +121,20 @@ function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithResources {
         ), resources: [liveblogScript] };
     }
 
+    if (item.display === Display.Immersive) {
+        const immersiveBody = partition(item.body).oks;
+        const immersiveContent =
+            insertAdPlaceholders(renderAll(imageSalt)(item.pillar, immersiveBody));
+
+        return { element: (
+            <WithScript src={articleScript}>
+                <Immersive imageSalt={imageSalt} item={item}>
+                    {immersiveContent}
+                </Immersive>
+            </WithScript>
+        ), resources: [articleScript] };
+    }
+
     if (
         item.design === Design.Feature ||
         item.design === Design.Analysis ||
@@ -135,20 +149,6 @@ function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithResources {
                 <Standard imageSalt={imageSalt} item={item}>
                     {content}
                 </Standard>
-            </WithScript>
-        ), resources: [articleScript] };
-    }
-
-    if (item.display === Display.Immersive) {
-        const immersiveBody = partition(item.body).oks;
-        const immersiveContent =
-            insertAdPlaceholders(renderAll(imageSalt)(item.pillar, immersiveBody));
-
-        return { element: (
-            <WithScript src={articleScript}>
-                <Immersive imageSalt={imageSalt} item={item}>
-                    {immersiveContent}
-                </Immersive>
             </WithScript>
         ), resources: [articleScript] };
     }

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -16,7 +16,7 @@ import { renderAll } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { partition } from 'types/result';
 import { insertAdPlaceholders } from 'ads';
-import { fromCapi, Layout } from 'article';
+import { fromCapi, Design, Display } from 'item';
 
 
 // ----- Components ----- //
@@ -94,59 +94,66 @@ const WithScript = (props: { src: string; children: ReactNode }): ReactElement =
     </>
 
 function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithResources {
-    const article = fromCapi(JSDOM.fragment)(capi);
+    const item = fromCapi(JSDOM.fragment)(capi);
     
     const articleScript = '/assets/article.js';
     const liveblogScript = '/assets/liveblog.js';
 
-    switch (article.layout) {
-        case Layout.Opinion:
-            const opinionBody = partition(article.body).oks;
-            const opinionContent =
-                insertAdPlaceholders(renderAll(imageSalt)(article.pillar, opinionBody));
+    if (item.design === Design.Comment) {
+        const commentBody = partition(item.body).oks;
+        const commentContent =
+            insertAdPlaceholders(renderAll(imageSalt)(item.pillar, commentBody));
 
-            return { element: (
-                <WithScript src={articleScript}>
-                    <Opinion imageSalt={imageSalt} article={article}>
-                        {opinionContent}
-                    </Opinion>
-                </WithScript>
-            ), resources: [articleScript] };
-        case Layout.Immersive:
-            const immersiveBody = partition(article.body).oks;
-            const immersiveContent =
-                insertAdPlaceholders(renderAll(imageSalt)(article.pillar, immersiveBody));
-
-            return { element: (
-                <WithScript src={articleScript}>
-                    <Immersive imageSalt={imageSalt} article={article}>
-                        {immersiveContent}
-                    </Immersive>
-                </WithScript>
-            ), resources: [articleScript] };
-        case Layout.Standard:
-        case Layout.Feature:
-        case Layout.Analysis:
-        case Layout.Review:
-            const body = partition(article.body).oks;
-            const content = insertAdPlaceholders(renderAll(imageSalt)(article.pillar, body));
-
-            return { element: (
-                <WithScript src={articleScript}>
-                    <Standard imageSalt={imageSalt} article={article}>
-                        {content}
-                    </Standard>
-                </WithScript>
-            ), resources: [articleScript] };;
-        case Layout.Liveblog:
-            return { element: (
-                <WithScript src={liveblogScript}>
-                    <LiveblogArticle article={article} imageSalt={imageSalt} />
-                </WithScript>
-            ), resources: [liveblogScript] };
-        default:
-            return { element: <p>{capi.type} not implemented yet</p>, resources: [articleScript] };
+        return { element: (
+            <WithScript src={articleScript}>
+                <Opinion imageSalt={imageSalt} item={item}>
+                    {commentContent}
+                </Opinion>
+            </WithScript>
+        ), resources: [articleScript] };
     }
+
+    if (item.design === Design.Live) {
+        return { element: (
+            <WithScript src={liveblogScript}>
+                <LiveblogArticle item={item} imageSalt={imageSalt} />
+            </WithScript>
+        ), resources: [liveblogScript] };
+    }
+
+    if (
+        item.design === Design.Feature ||
+        item.design === Design.Analysis ||
+        item.design === Design.Review ||
+        item.design === Design.Article
+    ) {
+        const body = partition(item.body).oks;
+        const content = insertAdPlaceholders(renderAll(imageSalt)(item.pillar, body));
+
+        return { element: (
+            <WithScript src={articleScript}>
+                <Standard imageSalt={imageSalt} item={item}>
+                    {content}
+                </Standard>
+            </WithScript>
+        ), resources: [articleScript] };
+    }
+
+    if (item.display === Display.Immersive) {
+        const immersiveBody = partition(item.body).oks;
+        const immersiveContent =
+            insertAdPlaceholders(renderAll(imageSalt)(item.pillar, immersiveBody));
+
+        return { element: (
+            <WithScript src={articleScript}>
+                <Immersive imageSalt={imageSalt} item={item}>
+                    {immersiveContent}
+                </Immersive>
+            </WithScript>
+        ), resources: [articleScript] };
+    }
+
+    return { element: <p>Content format not implemented yet</p>, resources: [] };
 }
 
 interface Props {

--- a/src/components/shared/shared.stories.tsx
+++ b/src/components/shared/shared.stories.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import Tags from './tags';
 import { Keyline } from './keyline';
 import { withKnobs } from "@storybook/addon-knobs";
-import { Layout } from 'article';
+import { Design } from 'item';
 export default { title: 'Shared', decorators: [withKnobs] };
 
 export const OpinionKeyline = (): JSX.Element =>
-    <Keyline layout={ Layout.Opinion } />
+    <Keyline design={ Design.Comment } />
 
 export const DefaultKeyline = (): JSX.Element =>
-    <Keyline layout={ Layout.Standard } />
+    <Keyline design={ Design.Article } />
 
 export const LiveblogKeyline = (): JSX.Element =>
-    <Keyline layout={ Layout.Liveblog } />
+    <Keyline design={ Design.Live } />
 
 const tagsProps = [{
     webTitle: "Tag title",

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -16,7 +16,7 @@ import Tags from 'components/shared/tags';
 import { darkModeCss, articleWidthStyles } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { getPillarStyles } from 'pillar';
-import { Standard, Review } from 'article';
+import { Standard, Review } from 'item';
 
 
 // ----- Styles ----- //
@@ -54,37 +54,38 @@ const HeaderImageStyles = css`
 
 interface Props {
     imageSalt: string;
-    article: Standard | Review;
+    item: Standard | Review;
     children: ReactNode[];
 }
 
-const Standard = ({ imageSalt, article, children }: Props): JSX.Element =>
+const Standard = ({ imageSalt, item, children }: Props): JSX.Element =>
     <main css={[Styles, DarkStyles]}>
         <article css={BorderStyles}>
             <header>
                 <HeaderImage
-                    image={article.mainImage}
+                    image={item.mainImage}
                     imageSalt={imageSalt}
                     className={HeaderImageStyles}
                 />
                 <div css={articleWidthStyles}>
-                    <Series series={article.series} pillar={article.pillar} />
-                    <Headline article={article} />
-                    <Standfirst article={article} className={articleWidthStyles} />
+                    <Series series={item.series} pillar={item.pillar} />
+                    <Headline item={item} />
+                    <Standfirst item={item} className={articleWidthStyles} />
+
                 </div>
-                <Keyline {...article} />
+                <Keyline {...item} />
                 <section css={articleWidthStyles}>
-                    <Byline article={article} imageSalt={imageSalt} />
-                    {article.commentable
-                        ? <CommentCount count={0} colour={getPillarStyles(article.pillar).kicker}/>
+                    <Byline item={item} imageSalt={imageSalt} />
+                    {item.commentable
+                        ? <CommentCount count={0} colour={getPillarStyles(item.pillar).kicker}/>
                         : null}
                 </section>
             </header>
-            <Body pillar={article.pillar} className={[articleWidthStyles]}>
+            <Body pillar={item.pillar} className={[articleWidthStyles]}>
                 {children}
             </Body>
             <footer css={articleWidthStyles}>
-                <Tags tags={article.tags}/>
+                <Tags tags={item.tags}/>
             </footer>
         </article>
     </main>

--- a/src/components/standard/byline.tsx
+++ b/src/components/standard/byline.tsx
@@ -9,7 +9,7 @@ import { formatDate } from 'date';
 import Avatar from 'components/shared/avatar';
 import Follow from 'components/shared/follow';
 import { PillarStyles, getPillarStyles } from 'pillar';
-import { Article } from 'article';
+import { Standard, Review } from 'item';
 import Author from 'components/shared/author';
 
 
@@ -68,12 +68,12 @@ const DarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss
 // ----- Component ----- //
 
 interface Props {
-    article: Article;
+    item: Standard | Review;
     imageSalt: string;
 }
 
-function Byline({ article, imageSalt }: Props): JSX.Element {
-    const pillarStyles = getPillarStyles(article.pillar);
+function Byline({ item, imageSalt }: Props): JSX.Element {
+    const pillarStyles = getPillarStyles(item.pillar);
 
     return (
         <div
@@ -81,16 +81,16 @@ function Byline({ article, imageSalt }: Props): JSX.Element {
         >
             <div css={sidePadding}>
                 <Avatar
-                    contributors={article.contributors}
+                    contributors={item.contributors}
                     bgColour={pillarStyles.inverted}
                     imageSalt={imageSalt}
                 />
                 <div className="author">
-                    <Author byline={article.bylineHtml} pillar={article.pillar} />
-                    { article.publishDate
+                    <Author byline={item.bylineHtml} pillar={item.pillar} />
+                    { item.publishDate
                         .fmap<JSX.Element | null>(date => <time data-date={date} className="date">{ formatDate(new Date(date)) }</time>)
                         .withDefault(null) }
-                    <Follow contributors={article.contributors} />
+                    <Follow contributors={item.contributors} />
                 </div>
             </div>
         </div>

--- a/src/components/standard/headline.tsx
+++ b/src/components/standard/headline.tsx
@@ -8,7 +8,7 @@ import { until } from '@guardian/src-foundations/mq';
 import ArticleRating from 'components/shared/articleRating';
 import { basePx, sidePadding, headlineFont, darkModeCss, headlineFontStyles } from 'styles';
 import { getPillarStyles } from 'pillar';
-import { Layout, Article } from 'article';
+import { Item, Design } from 'item';
 
 
 // ----- Styles ----- //
@@ -24,10 +24,10 @@ const AnalysisStyles = (kicker: string): SerializedStyles => css`
     }
 `;
 
-function Styles({ layout, pillar }: Article): SerializedStyles {
+function Styles({ design, pillar }: Item): SerializedStyles {
 
-    const isFeature = layout === Layout.Feature;
-    const isAnalysis = layout === Layout.Analysis;
+    const isFeature = design === Design.Feature;
+    const isAnalysis = design === Design.Analysis;
     const { featureHeadline, kicker } = getPillarStyles(pillar);
 
     return css`
@@ -56,13 +56,13 @@ const DarkStyles = darkModeCss`
 // ----- Component ----- //
 
 interface Props {
-    article: Article;
+    item: Item;
 }
 
-const Headline = ({ article }: Props): JSX.Element =>
-    <div css={[Styles(article), DarkStyles]}>
-        <h1>{article.headline}</h1>
-        { article.layout === Layout.Review ? <ArticleRating rating={article.starRating} /> : null }
+const Headline = ({ item }: Props): JSX.Element =>
+    <div css={[Styles(item), DarkStyles]}>
+        <h1>{item.headline}</h1>
+        { item.design === Design.Review ? <ArticleRating rating={item.starRating} /> : null }
     </div>
 
 

--- a/src/components/standard/standfirst.tsx
+++ b/src/components/standard/standfirst.tsx
@@ -7,7 +7,7 @@ import { neutral, background } from '@guardian/src-foundations/palette';
 import { sidePadding, headlineFont, darkModeCss } from 'styles';
 import { getPillarStyles } from 'pillar';
 import { renderText } from 'renderer';
-import { Article, Layout } from 'article';
+import { Design, Item } from 'item';
 
 
 // ----- Styles ----- //
@@ -20,10 +20,10 @@ const FeatureStyles = `
     line-height: 2.4rem;
 `;
 
-function Styles({ layout }: Article): SerializedStyles {
-    const includeFeatureStyles = layout === Layout.Feature
-        || layout === Layout.Review
-        || layout === Layout.Opinion;
+function Styles({ design }: Item): SerializedStyles {
+    const includeFeatureStyles = design === Design.Feature
+        || design === Design.Review
+        || design === Design.Comment;
 
     return css`
         padding-bottom: 6px;
@@ -40,7 +40,7 @@ function Styles({ layout }: Article): SerializedStyles {
     `;
 }
 
-const DarkStyles = ({ pillar }: Article): SerializedStyles => darkModeCss`
+const DarkStyles = ({ pillar }: Item): SerializedStyles => darkModeCss`
     background: ${background.inverse};
     color: ${neutral[86]};
 
@@ -53,14 +53,14 @@ const DarkStyles = ({ pillar }: Article): SerializedStyles => darkModeCss`
 // ----- Component ----- //
 
 interface Props {
-    article: Article;
+    item: Item;
     className: SerializedStyles;
 }
 
-const Standfirst = ({ article, className }: Props): JSX.Element | null =>
-    article.standfirst.fmap<JSX.Element | null>(standfirst =>
-        <div css={[className, Styles(article), DarkStyles(article)]}>
-            {renderText(standfirst, article.pillar)}
+const Standfirst = ({ item, className }: Props): JSX.Element | null =>
+    item.standfirst.fmap<JSX.Element | null>(standfirst =>
+        <div css={[className, Styles(item), DarkStyles(item)]}>
+            {renderText(standfirst, item.pillar)}
         </div>
     ).withDefault(null);
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -9,7 +9,7 @@ import { Option, fromNullable, Some, None } from 'types/option';
 import { srcset, src } from 'image';
 import { basePx, icons, headlineFont, darkModeCss, textSans } from 'styles';
 import { getPillarStyles, Pillar } from 'pillar';
-import { ElementKind, BodyElement } from 'article';
+import { ElementKind, BodyElement } from 'item';
 
 
 // ----- Renderer ----- //


### PR DESCRIPTION
## Why are you doing this?

Part of the motivation for this work is to standardise how we define the design of content. The concept of a [`DesignType`](https://github.com/guardian/content-api-scala-client/blob/9e249bcef47cc048da483b3453c10dd7d2e9565d/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala) has existed for a while, and is used in frontend. We're using a [`Layout`](https://github.com/guardian/apps-rendering/blob/66f93cf1832e7cb1d6f26d8af4579edcb653216b/src/article.ts#L14) type in apps-rendering. These both attempt to solve a similar problem, but are incomplete and are not compatible with one another.

Therefore dotcom-rendering and apps-rendering are attempting to co-ordinate their approaches by introducing a new type (terminology may change):

```ts
interface Format {
    pillar: Pillar;
    design: Design;
    display: Display;
}
```

The idea is that this type *should* cover all possible rendering formats that a piece of content can have. Some related work has [recently been merged](https://github.com/guardian/dotcom-rendering/pull/1160) on dotcom-rendering with this goal in mind.

This PR adopts some of the techniques for identifying content that are used by [frontend](https://github.com/guardian/frontend/blob/e25e3f1bad2750c5fd45933a6b4e6ff34deffdd8/common/app/model/meta.scala#L580) and the [CAPI Scala Client](https://github.com/guardian/content-api-scala-client/blob/9e249bcef47cc048da483b3453c10dd7d2e9565d/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala), such as identifying `Design` based on tags, and showcase based on the main media `role`.

With these changes I have also renamed the `Article` type to `Item` because

1. the name "article" was becoming somewhat overloaded (for example, it clashed with `Design.Article`), and
2. this is better correlated with MAPI's `mobile-item` service.

**Note:** I haven't made many changes to components and the general file structure to bring them in line with the new `Format` type (hence, for example, why we still have the term `opinion` in a few places where we really mean `Comment`). Updating this will require further thought and will likely come about in future PRs.

## Changes

- Renamed the `Article` type to `Item`
- Created new `Format` type, comprised of `Design`, `Pillar` and `Display`
- Brings apps-rendering more in line with frontend and dotcom-rendering
- Updated some naming across codebase to use `item` over `article`
- Split `Layout` into `Design` and `Display`
- Derived `Design` from tags
- Based decision for "showcase" on main media roles
- Turned off max line length for URLs
- Added `elements` to CAPI request (needed for showcase embeds)
