### PR TITLE
captions can be html

### DIFF
--- a/src/components/immersive/article.tsx
+++ b/src/components/immersive/article.tsx
@@ -90,6 +90,7 @@ const Immersive = ({ imageSalt, item, children }: Props): JSX.Element =>
                         image={item.mainImage}
                         imageSalt={imageSalt}
                         className={HeaderImageStyles}
+                        pillar={item.pillar}
                     />
                     <Series series={item.series} pillar={item.pillar}/>
                     <Headline headline={item.headline}/>

--- a/src/components/immersive/headerImage.tsx
+++ b/src/components/immersive/headerImage.tsx
@@ -8,6 +8,7 @@ import { wideContentWidth } from 'styles';
 import { Option } from 'types/option';
 import { Image } from 'item';
 import { ImageElement } from 'renderer';
+import { Pillar } from 'pillar';
 
 
 // ----- Styles ----- //
@@ -40,9 +41,10 @@ interface Props {
     image: Option<Image>;
     imageSalt: string;
     className?: SerializedStyles | null;
+    pillar: Pillar;
 }
 
-const HeaderImage = ({ className, image, imageSalt }: Props): JSX.Element | null =>
+const HeaderImage = ({ className, image, imageSalt, pillar }: Props): JSX.Element | null =>
     image.fmap<JSX.Element | null>(imageData =>
         <div css={[className, Styles]}>
             <figure>
@@ -54,7 +56,9 @@ const HeaderImage = ({ className, image, imageSalt }: Props): JSX.Element | null
                     sizes={`calc(80vh * ${imageData.width/imageData.height})`}
                     salt={imageSalt}
                     caption={imageData.caption}
+                    captionString={imageData.captionString}
                     credit={imageData.credit}
+                    pillar={pillar}
                 />
             </figure>
         </div>

--- a/src/components/liveblog/article.tsx
+++ b/src/components/liveblog/article.tsx
@@ -62,6 +62,7 @@ const LiveblogArticle = ({ item, imageSalt }: LiveblogArticleProps): JSX.Element
                     image={item.mainImage}
                     imageSalt={imageSalt}
                     className={HeaderImageStyles(getPillarStyles(item.pillar))}
+                    pillar={item.pillar}
                 />
                 <LiveblogKeyEvents blocks={item.blocks} pillar={item.pillar} />
                 <LiveblogBody

--- a/src/components/opinion/article.tsx
+++ b/src/components/opinion/article.tsx
@@ -119,6 +119,7 @@ const Opinion = ({ imageSalt, item, children }: Props): JSX.Element =>
                     image={item.mainImage}
                     imageSalt={imageSalt}
                     className={HeaderImageStyles}
+                    pillar={item.pillar}
                 />
             </header>
             <ArticleBody pillar={item.pillar} className={[articleWidthStyles]}>

--- a/src/components/shared/headerImage.test.tsx
+++ b/src/components/shared/headerImage.test.tsx
@@ -4,13 +4,14 @@ import Adapter from 'enzyme-adapter-react-16';
 import { None, Option } from 'types/option';
 import HeaderImage from 'components/shared/headerImage';
 import { Image } from 'item';
+import { Pillar } from 'pillar';
 
 configure({ adapter: new Adapter() });
 
 describe('HeaderImage component renders as expected', () => {
     it('Renders null if no block element', () => {
         const image: Option<Image> = new None;
-        const headerImage = shallow(<HeaderImage image={image} imageSalt=""/>)
+        const headerImage = shallow(<HeaderImage image={image} imageSalt="" pillar={Pillar.news}/>)
         expect(headerImage.html()).toBe(null);
     })
 });

--- a/src/components/shared/headerImage.tsx
+++ b/src/components/shared/headerImage.tsx
@@ -39,7 +39,8 @@ interface HeaderImageProps {
     pillar: Pillar;
 }
 
-const HeaderImage = ({ className, image, imageSalt, pillar }: HeaderImageProps): JSX.Element | null => {
+const HeaderImage = (props: HeaderImageProps): JSX.Element | null => {
+    const { className, image, imageSalt, pillar } = props;
     const headerImage: Option<JSX.Element | null> = image.fmap(imageData =>
         <div css={[className, Styles(imageData.width, imageData.height)]}>
             <figure aria-labelledby={captionId}>

--- a/src/components/shared/headerImage.tsx
+++ b/src/components/shared/headerImage.tsx
@@ -7,6 +7,7 @@ import { wideContentWidth, basePx } from 'styles';
 import { Option } from 'types/option';
 import { Image } from 'item';
 import { ImageElement } from 'renderer';
+import { Pillar } from 'pillar';
 
 const Styles = (width: number, height: number): SerializedStyles => css`
     figure {
@@ -35,9 +36,10 @@ interface HeaderImageProps {
     image: Option<Image>;
     imageSalt: string;
     className?: SerializedStyles | null;
+    pillar: Pillar;
 }
 
-const HeaderImage = ({ className, image, imageSalt }: HeaderImageProps): JSX.Element | null => {
+const HeaderImage = ({ className, image, imageSalt, pillar }: HeaderImageProps): JSX.Element | null => {
     const headerImage: Option<JSX.Element | null> = image.fmap(imageData =>
         <div css={[className, Styles(imageData.width, imageData.height)]}>
             <figure aria-labelledby={captionId}>
@@ -49,9 +51,11 @@ const HeaderImage = ({ className, image, imageSalt }: HeaderImageProps): JSX.Ele
                     sizes={`(min-width: ${breakpoints.wide}px) 620px, 100vw`}
                     salt={imageSalt}
                     caption={imageData.caption}
+                    captionString={imageData.captionString}
                     credit={imageData.credit}
+                    pillar={pillar}
                 />
-                <HeaderImageCaption caption={imageData.caption} credit={imageData.credit}/>
+                <HeaderImageCaption caption={imageData.captionString} credit={imageData.credit}/>
             </figure>
         </div>
     );

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -66,6 +66,7 @@ const Standard = ({ imageSalt, item, children }: Props): JSX.Element =>
                     image={item.mainImage}
                     imageSalt={imageSalt}
                     className={HeaderImageStyles}
+                    pillar={item.pillar}
                 />
                 <div css={articleWidthStyles}>
                     <Series series={item.series} pillar={item.pillar} />

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -1,4 +1,6 @@
 import { ImageElement } from './renderer';
+import { JSDOM } from 'jsdom';
+import { Pillar } from 'pillar';
 
 describe('renderer returns expected content', () => {
     test('ImageElement returns null for no url', () => {
@@ -9,8 +11,11 @@ describe('renderer returns expected content', () => {
             sizes: "sizes",
             width: 500,
             height: 500,
-            caption: "caption",
-            credit: "credit"
+            captionString: "caption",
+            caption: JSDOM.fragment('this caption contains <em>html</em>'),
+            credit: "credit",
+            pillar: Pillar.news
+
         }
         expect(ImageElement(imageProps)).toBe(null);
     });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -4,6 +4,7 @@ import { ReactNode, createElement as h, ReactElement } from 'react';
 import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { from, until } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
+import { JSDOM } from 'jsdom';
 
 import { Option, fromNullable, Some, None } from 'types/option';
 import { srcset, src } from 'image';
@@ -174,8 +175,11 @@ const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => 
 const text = (doc: DocumentFragment, pillar: Pillar): ReactNode[] =>
     Array.from(doc.childNodes).map(textElement(pillar));
 
-const makeCaption = (caption: string, displayCredit: boolean, credit: string): string =>
-    displayCredit ? `${caption} ${credit}` : caption;
+const makeCaption = (props: FigureElement): ReactNode[] => {
+    const { caption, credit, displayCredit, pillar } = props;
+    const fullCaption = displayCredit ? `${caption} ${credit}` : caption;
+    return text(JSDOM.fragment(fullCaption), pillar);
+}
 
 interface ImageProps {
     url: string;
@@ -193,6 +197,7 @@ type FigureElement = ImageProps & {
     displayCredit: boolean;
     credit: string;
     className?: SerializedStyles;
+    pillar: Pillar;
 }
 
 const imageStyles = (width: number, height: number): SerializedStyles => css`
@@ -226,7 +231,7 @@ const ImageElement = (props: ImageProps): ReactElement | null => {
 const FigureElement = (props: FigureElement): ReactElement =>
     styledH('figure', { css: props.className },
         h(ImageElement, props),
-        h('figcaption', null, makeCaption(props.caption, props.displayCredit, props.credit)),
+        h('figcaption', null, makeCaption(props)),
     );
 
 const bodyImageStyles = css`
@@ -387,6 +392,7 @@ const render = (salt: string, pillar: Pillar) => (element: BodyElement, key: num
                 key,
                 width,
                 height,
+                pillar
             });
 
         case ElementKind.Pullquote:


### PR DESCRIPTION
## Why are you doing this?


http://localhost:8080/food/2020/jan/31/bong-bongs-manila-kanteen-london-e2-grace-dent-restaurant-review

It's possible to receive html in image captions. Instead of always returning a string, we should parse the content and render the correct tags.

| Before | After |
| --- | --- |
| <img src="" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/74652874-e781e400-517e-11ea-96ad-c0d5d90f3fbf.png" width="300px" /> |
