### PR TITLE
Storybook Italic/Bold Bug

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,27 +5,27 @@
     }
     
     @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:400; src:url("./public/fonts/GuardianTextEgyptian-Reg.ttf");}
-    @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:400; font-style:"italic"; src:url("./public/fonts/GuardianTextEgyptian-RegItalic.ttf")}
+    @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:400; font-style:italic; src:url("./public/fonts/GuardianTextEgyptian-RegItalic.ttf")}
     @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:700; src:url("./public/fonts/GuardianTextEgyptian-Bold.ttf")}
-    @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:700; font-style:"italic"; src:url("./public/fonts/GuardianTextEgyptian-BoldItalic.ttf")}
-    @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:"bold"; src:url("./public/fonts/GuardianTextEgyptian-Bold.ttf")}
-    @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:"bold"; font-style:"italic"; src:url("./public/fonts/GuardianTextEgyptian-BoldItalic.ttf")}
+    @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:700; font-style:italic; src:url("./public/fonts/GuardianTextEgyptian-BoldItalic.ttf")}
+    @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:bold; src:url("./public/fonts/GuardianTextEgyptian-Bold.ttf")}
+    @font-Face{font-family:"Guardian Text Egyptian Web"; font-weight:bold; font-style:italic; src:url("./public/fonts/GuardianTextEgyptian-BoldItalic.ttf")}
 
     @font-Face{font-family:"Guardian Text Sans Web"; font-weight:400; src:url("./public/fonts/GuardianTextSans-Regular.ttf")}
-    @font-Face{font-family:"Guardian Text Sans Web"; font-weight:400; font-style:"italic"; src:url("./public/fonts/GuardianTextSans-RegularItalic.ttf")}
+    @font-Face{font-family:"Guardian Text Sans Web"; font-weight:400; font-style:italic; src:url("./public/fonts/GuardianTextSans-RegularItalic.ttf")}
     @font-Face{font-family:"Guardian Text Sans Web"; font-weight:700; src:url("./public/fonts/GuardianTextSans-Bold.ttf")}
-    @font-Face{font-family:"Guardian Text Sans Web"; font-weight:700; font-style:"italic"; src:url("./public/fonts/GuardianTextSans-BoldItalic.ttf")}
+    @font-Face{font-family:"Guardian Text Sans Web"; font-weight:700; font-style:italic; src:url("./public/fonts/GuardianTextSans-BoldItalic.ttf")}
     
     @font-Face{font-family:"Guardian Headline"; font-weight:300; src:url("/public/fonts/GHGuardianHeadline-Light.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:300; font-style: "italic"; src:url("./public/fonts/GHGuardianHeadline-LightItalic.ttf")}
+    @font-Face{font-family:"Guardian Headline"; font-weight:300; font-style: italic; src:url("./public/fonts/GHGuardianHeadline-LightItalic.ttf")}
     @font-Face{font-family:"Guardian Headline"; font-weight:400; src:url("/public/fonts/GHGuardianHeadline-Regular.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:400; font-style: "italic"; src:url("./public/fonts/GHGuardianHeadline-RegularItalic.ttf")}
+    @font-Face{font-family:"Guardian Headline"; font-weight:400; font-style: italic; src:url("./public/fonts/GHGuardianHeadline-RegularItalic.ttf")}
     @font-Face{font-family:"Guardian Headline"; font-weight:500; src:url("/public/fonts/GHGuardianHeadline-Medium.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:500; font-style: "italic"; src:url( "./public/fonts/GHGuardianHeadline-MediumItalic.ttf")}
+    @font-Face{font-family:"Guardian Headline"; font-weight:500; font-style: italic; src:url( "./public/fonts/GHGuardianHeadline-MediumItalic.ttf")}
     @font-Face{font-family:"Guardian Headline"; font-weight:600; src:url("/public/fonts/GHGuardianHeadline-Semibold.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:600; font-style: "italic"; src:url( "./public/fonts/GHGuardianHeadline-SemiboldItalic.ttf")}
+    @font-Face{font-family:"Guardian Headline"; font-weight:600; font-style: italic; src:url( "./public/fonts/GHGuardianHeadline-SemiboldItalic.ttf")}
     @font-Face{font-family:"Guardian Headline"; font-weight:700; src:url("/public/fonts/GHGuardianHeadline-Bold.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:700; font-style: "italic"; src:url("./public/fonts/GHGuardianHeadline-BoldItalic.ttf")}
+    @font-Face{font-family:"Guardian Headline"; font-weight:700; font-style: italic; src:url("./public/fonts/GHGuardianHeadline-BoldItalic.ttf")}
 
     @font-Face{font-family:"Guardian Icons"; src:url("/public/fonts/icons.otf")}
 


### PR DESCRIPTION
## Why are you doing this?

Storybook was loading italic and/or bold versions of fonts regardless of whether they were specified or not. This meant components were appearing with italic or bold text even when neither of these properties were set.

The problem was that `font-style` and `font-weight` declarations were being given string values inside `font-face` rules, which are not valid. This resulted in the browser picking the incorrect fonts to download.

## Changes

- Removed quotes from font-style and font-weight
