### PR TITLE
Fix the application name, and the cloudformation

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -211,7 +211,7 @@ Resources:
               - Action:
                   - ssm:GetParametersByPath
                 Effect: Allow
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/apps-rendering/${Stage}/${Stack}/
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/mobile-apps-rendering/${Stage}/${Stack}/
               - Action:
                   - autoscaling:DescribeAutoScalingInstances
                   - autoscaling:DescribeAutoScalingGroups

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -211,7 +211,7 @@ Resources:
               - Action:
                   - ssm:GetParametersByPath
                 Effect: Allow
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/mobile-apps-rendering/${Stage}/${Stack}/
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}/${Stage}/${Stack}/
               - Action:
                   - autoscaling:DescribeAutoScalingInstances
                   - autoscaling:DescribeAutoScalingGroups

--- a/src/server/appIdentity.ts
+++ b/src/server/appIdentity.ts
@@ -1,4 +1,4 @@
-export const App = process.env.App || "apps-rendering";
+export const App = process.env.App || "mobile-apps-rendering";
 export const Stack = process.env.Stack || "mobile";
 export const Stage = process.env.Stage || "CODE";
 export const Region = process.env.AWS_REGION || "eu-west-1";


### PR DESCRIPTION
The application name was defaulting to "apps-rendering" when the `App` tag of the ec2 instance is "mobile-apps-rendering".

This misalignment prevented the app from loading the configuration.

This fixes it.