### PR TITLE
Fix slow start

### DIFF
--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -1,13 +1,11 @@
-import {SharedIniFileCredentials, CredentialProviderChain, EC2MetadataCredentials} from "aws-sdk/lib/core";
+import {SharedIniFileCredentials, CredentialProviderChain, EC2MetadataCredentials, Credentials} from "aws-sdk/lib/core";
 import {Region} from "./appIdentity";
 import SSM from "aws-sdk/clients/ssm";
 
 
 const credentialProvider = new CredentialProviderChain([
-    function (): EC2MetadataCredentials { return new EC2MetadataCredentials(); },
-    function (): SharedIniFileCredentials{ return new SharedIniFileCredentials({
-        profile: "mobile"
-    }); }                                                                            
+    (): Credentials => new SharedIniFileCredentials({profile: "mobile"}),
+    (): Credentials => new EC2MetadataCredentials()
 ]);
 
 export const ssm: SSM  = new SSM({


### PR DESCRIPTION
After having a chat with @JamieB-gu we realised the slow start was due to the AWS credentials testing if the code is running within EC2, and timing out.

Now we're looking at if the service is running locally, and if so, directly using the local credentials rather than waiting for the EC2 on to timeout.