### PR TITLE
Fix Liveblog Highlights

### DIFF
--- a/src/components/liveblog/block.tsx
+++ b/src/components/liveblog/block.tsx
@@ -79,7 +79,7 @@ interface TitleProps {
 
 const Title = ({ title, highlighted }: TitleProps): JSX.Element | null => {
     const TitleStyles = css`
-        padding: 0.5rem 0.125rem;
+        padding: 0.1rem 0.125rem;
         background-color: ${brandAlt[400]};
     `
     return title ? <h3><span css={highlighted ? TitleStyles : null}>{title}</span></h3> : null;


### PR DESCRIPTION
## Why are you doing this?

Highlights on liveblogs were cutting off descenders.

## Changes

- Tweaked padding on highlight

## Screenshots

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/53781962/74864437-78a3b700-5347-11ea-8499-7da47d14c339.png) | ![after](https://user-images.githubusercontent.com/53781962/74864449-7f322e80-5347-11ea-9df9-8c85cc87ee6d.png) |
