### PR TITLE
Change name of the Android bridge function

### DIFF
--- a/src/native/thrift/nativeConnection.ts
+++ b/src/native/thrift/nativeConnection.ts
@@ -17,8 +17,10 @@ import * as uuid from 'uuid';
 declare global {
     interface Window {
         nativeConnections: { [id: string]: NativeConnection };
-        AndroidWebViewMessage?: (nativeMessage: NativeMessage) => {};
-        webkit: {
+        android?: {
+            postMessage: (data: string, connectionId: string) => {};
+        };
+        webkit?: {
             messageHandlers: {
                 iOSWebViewMessage: {
                     postMessage: (nativeMessage: NativeMessage) => {};
@@ -42,9 +44,10 @@ interface PromiseResponse {
 const ACTION_TIMEOUT_MS = 30000;
 
 function sendNativeMessage(nativeMessage: NativeMessage): void {
-    if (window.AndroidWebViewMessage) {
-        window.AndroidWebViewMessage(nativeMessage)
-    } else if (window?.webkit?.messageHandlers?.iOSWebViewMessage?.postMessage) {
+    if (window.android) {
+        // Arguments are supplied separately when posting to Android:
+        window.android.postMessage(nativeMessage.data, nativeMessage.connectionId)
+    } else if (window.webkit) {
         window.webkit.messageHandlers.iOSWebViewMessage.postMessage(nativeMessage)
     } else {
         console.warn('No native APIs available');

--- a/src/native/thrift/nativeConnection.ts
+++ b/src/native/thrift/nativeConnection.ts
@@ -45,7 +45,6 @@ const ACTION_TIMEOUT_MS = 30000;
 
 function sendNativeMessage(nativeMessage: NativeMessage): void {
     if (window.android) {
-        // Arguments are supplied separately when posting to Android:
         window.android.postMessage(nativeMessage.data, nativeMessage.connectionId)
     } else if (window.webkit) {
         window.webkit.messageHandlers.iOSWebViewMessage.postMessage(nativeMessage)


### PR DESCRIPTION
## Why are you doing this?

To make the Thrift native communication work on Android (in conjunction with this Android PR: https://github.com/guardian/android-news-app/pull/5856

## Changes

- Changed the definition/names of the bridge functions
- Called the android bridge function with separate params