### PR TITLE
Use multiplexed thrift

### DIFF
--- a/src/native/thrift/nativeConnection.ts
+++ b/src/native/thrift/nativeConnection.ts
@@ -132,5 +132,6 @@ export function createAppClient<TClient extends ThriftClient<void>>(
             super(new Protocol(transport), ServiceClient.serviceName ?? "")
         }
     }
-    return new ServiceClient(new NativeConnection(getTransport(transport), NamedMultiplexedProtocol));
+    const connection = new NativeConnection(getTransport(transport), NamedMultiplexedProtocol)
+    return new ServiceClient(connection)
 }

--- a/src/native/thrift/nativeConnection.ts
+++ b/src/native/thrift/nativeConnection.ts
@@ -6,6 +6,7 @@ import {
     getProtocol,
     TransportType,
     ProtocolType,
+    TTransport,
     ITransportConstructor,
     IProtocolConstructor,
     TApplicationException,
@@ -13,6 +14,8 @@ import {
 } from '@creditkarma/thrift-server-core'
 
 import * as uuid from 'uuid';
+
+import { TMultiplexedProtocol } from './protocols'
 
 declare global {
     interface Window {
@@ -123,5 +126,11 @@ export function createAppClient<TClient extends ThriftClient<void>>(
     transport: TransportType = 'buffered', 
     protocol: ProtocolType = 'compact'
 ): TClient {
-    return new ServiceClient(new NativeConnection(getTransport(transport), getProtocol(protocol)));
+    class NamedMultiplexedProtocol extends TMultiplexedProtocol {
+        constructor(transport: TTransport) {
+            const Protocol = getProtocol(protocol)
+            super(new Protocol(transport), ServiceClient.serviceName ?? "")
+        }
+    }
+    return new ServiceClient(new NativeConnection(getTransport(transport), NamedMultiplexedProtocol));
 }

--- a/src/native/thrift/protocols.ts
+++ b/src/native/thrift/protocols.ts
@@ -165,7 +165,7 @@ export class TMultiplexedProtocol extends TProtocolDecorator {
     }
   
     writeMessageBegin(name: string, type: MessageType, seqid: number): void {
-        if (type == MessageType.CALL || type == MessageType.ONEWAY) {
+        if (type === MessageType.CALL || type === MessageType.ONEWAY) {
             super.writeMessageBegin(
                     this.serviceName + TMultiplexedProtocol.separator + name,
                     type,

--- a/src/native/thrift/protocols.ts
+++ b/src/native/thrift/protocols.ts
@@ -1,0 +1,178 @@
+import { 
+    TProtocol,
+    TTransport,
+    IThriftSet,
+    Int64,
+    TType,
+    MessageType,
+    IThriftMessage,
+    IThriftStruct,
+    IThriftMap,
+    IThriftField,
+    IThriftList
+} from '@creditkarma/thrift-server-core'
+
+export abstract class TProtocolDecorator extends TProtocol {
+
+    private concreteProtocol: TProtocol;
+
+    constructor(protocol: TProtocol) {
+        super(protocol.getTransport());
+        this.concreteProtocol = protocol;
+    }
+
+    getTransport(): TTransport {
+        return this.concreteProtocol.getTransport();
+    }
+    flush(): Buffer {
+        return this.concreteProtocol.flush();
+    }
+    writeMessageBegin(name: string, type: MessageType, seqid: number): void {
+        return this.concreteProtocol.writeMessageBegin(name, type, seqid);
+    }
+    writeMessageEnd(): void {
+        return this.concreteProtocol.writeMessageEnd();
+    }
+    writeStructBegin(name: string): void {
+        return this.concreteProtocol.writeStructBegin(name);
+    }
+    writeStructEnd(): void {
+        return this.concreteProtocol.writeStructEnd();
+    }
+    writeFieldBegin(name: string, type: TType, id: number): void {
+        return this.concreteProtocol.writeFieldBegin(name, type, id);
+    }
+    writeFieldEnd(): void {
+        return this.concreteProtocol.writeFieldEnd();
+    }
+    writeFieldStop(): void {
+        return this.concreteProtocol.writeFieldStop();
+    }
+    writeMapBegin(keyType: TType, valueType: TType, size: number): void {
+        return this.concreteProtocol.writeMapBegin(keyType, valueType, size);
+    }
+    writeMapEnd(): void {
+        return this.concreteProtocol.writeMapEnd();
+    }
+    writeListBegin(elementType: TType, size: number): void {
+        return this.concreteProtocol.writeListBegin(elementType, size);
+    }
+    writeListEnd(): void {
+        return this.concreteProtocol.writeListEnd();
+    }
+    writeSetBegin(elementType: TType, size: number): void {
+        return this.concreteProtocol.writeSetBegin(elementType, size);
+    }
+    writeSetEnd(): void {
+        return this.concreteProtocol.writeSetEnd();
+    }
+    writeBool(bool: boolean): void {
+        return this.concreteProtocol.writeBool(bool);
+    }
+    writeByte(b: number): void {
+        return this.concreteProtocol.writeByte(b);
+    }
+    writeI16(i16: number): void {
+        return this.concreteProtocol.writeI16(i16);
+    }
+    writeI32(i32: number): void {
+        return this.concreteProtocol.writeI32(i32);
+    }
+    writeI64(i64: number | Int64): void {
+        return this.concreteProtocol.writeI64(i64);
+    }
+    writeDouble(dbl: number): void {
+        return this.concreteProtocol.writeDouble(dbl);
+    }
+    writeString(arg: string): void {
+        return this.concreteProtocol.writeString(arg);
+    }
+    writeBinary(arg: string | Buffer): void {
+        return this.concreteProtocol.writeBinary(arg);
+    }
+    readMessageBegin(): IThriftMessage {
+        return this.concreteProtocol.readMessageBegin();
+    }
+    readMessageEnd(): void {
+        return this.concreteProtocol.readMessageEnd();
+    }
+    readStructBegin(): IThriftStruct {
+        return this.concreteProtocol.readStructBegin();
+    }
+    readStructEnd(): void {
+        return this.concreteProtocol.readStructEnd();
+    }
+    readFieldBegin(): IThriftField {
+        return this.concreteProtocol.readFieldBegin();
+    }
+    readFieldEnd(): void {
+        return this.concreteProtocol.readFieldEnd();
+    }
+    readMapBegin(): IThriftMap {
+        return this.concreteProtocol.readMapBegin();
+    }
+    readMapEnd(): void {
+        return this.concreteProtocol.readMapEnd();
+    }
+    readListBegin(): IThriftList {
+        return this.concreteProtocol.readListBegin();
+    }
+    readListEnd(): void {
+        return this.concreteProtocol.readListEnd();
+    }
+    readSetBegin(): IThriftSet {
+        return this.concreteProtocol.readSetBegin();
+    }
+    readSetEnd(): void {
+        return this.concreteProtocol.readSetEnd();
+    }
+    readBool(): boolean {
+        return this.concreteProtocol.readBool();
+    }
+    readByte(): number {
+        return this.concreteProtocol.readByte();
+    }
+    readI16(): number {
+        return this.concreteProtocol.readI16();
+    }
+    readI32(): number {
+        return this.concreteProtocol.readI32();
+    }
+    readI64(): Int64 {
+        return this.concreteProtocol.readI64();
+    }
+    readDouble(): number {
+        return this.concreteProtocol.readDouble();
+    }
+    readBinary(): Buffer {
+        return this.concreteProtocol.readBinary();
+    }
+    readString(): string {
+        return this.concreteProtocol.readString();
+    }
+    skip(type: TType): void {
+        return this.concreteProtocol.skip(type);
+    }
+}
+
+export class TMultiplexedProtocol extends TProtocolDecorator {
+    static readonly separator = ":"
+    readonly serviceName: string
+    
+    constructor(protocol: TProtocol, serviceName: string) {
+        super(protocol);
+        this.serviceName = serviceName;
+    }
+  
+    writeMessageBegin(name: string, type: MessageType, seqid: number): void {
+        if (type == MessageType.CALL || type == MessageType.ONEWAY) {
+            super.writeMessageBegin(
+                    this.serviceName + TMultiplexedProtocol.separator + name,
+                    type,
+                    seqid
+            );
+        } else {
+            super.writeMessageBegin(name, type, seqid);
+        }
+    }
+}


### PR DESCRIPTION
With service name to identify the desired service

## Why are you doing this?

Thrift has a meta-protocol that supports serving multiple services across a single link.  Adding support for it will allow us to split the interface that the native layer provide into logically separate services without needing to create a different webview<->native postMessage connection.  

The Thrift spec allows an arbitrary string to identify a service, but we are choosing to use the service name as defined in the `thrift` file.
