### PR TITLE
Hashed JavaScript bundles

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,12 +22,12 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: install
       run: npm install
-    - name: compile server
-      run: npm run build:server
     - name: lint
       run: npm run lint
     - name: test
       run: npm run test
     - name: check client bundle size
       run: npm run build:client:prod
+    - name: compile server
+      run: npm run prod
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,5 +29,5 @@ jobs:
     - name: check client bundle size
       run: npm run build:client:prod
     - name: compile server
-      run: npm run prod
+      run: npm run build:server:prod
 

--- a/artifact.json
+++ b/artifact.json
@@ -4,7 +4,7 @@
   "actions": [
     {
       "action": "mobile-apps-rendering",
-      "path": "dist/server.js",
+      "path": "dist/server",
       "compress": "zip"
     },
     {

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -316,7 +316,9 @@ Resources:
           chown -R ${App}:mapi /usr/share/${App}
           ln -s /usr/share/${App}/logs /var/log/${App}
           chown -R ${App}:mapi /var/log/${App}
+
           export PM2_HOME="/usr/share/${App}"
+          export ASSETS_MANIFEST="/opt/${App}/manifest.json"
 
           /usr/local/node/pm2 start --name ${App} --uid ${App} --gid mapi /opt/${App}/server.js
           /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${AWS::Region} mobile-log-aggregation-${Stage} '/var/log/${App}/*'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15255,6 +15255,12 @@
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
+    "json-loader": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4516,6 +4516,20 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "html-webpack-plugin": {
+          "version": "4.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz",
+          "integrity": "sha512-4Xzepf0qWxf8CGg7/WQM5qBB2Lc/NFI7MhU59eUDTkuQp3skZczH4UA1d6oQyDEIoMDgERVhRyTdtUPZ5s5HBg==",
+          "dev": true,
+          "requires": {
+            "html-minifier-terser": "^5.0.1",
+            "loader-utils": "^1.2.3",
+            "lodash": "^4.17.15",
+            "pretty-error": "^2.1.1",
+            "tapable": "^1.1.3",
+            "util.promisify": "1.0.0"
+          }
+        },
         "import-fresh": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -7725,16 +7739,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
-    "camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true,
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
-      }
-    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -7937,9 +7941,9 @@
       "dev": true
     },
     "clean-css": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
       "dev": true,
       "requires": {
         "source-map": "~0.6.0"
@@ -9194,6 +9198,37 @@
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
+      }
+    },
+    "dot-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        }
       }
     },
     "dotenv": {
@@ -12355,40 +12390,65 @@
       "dev": true
     },
     "html-minifier-terser": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.0.2.tgz",
-      "integrity": "sha512-VAaitmbBuHaPKv9bj47XKypRhgDxT/cDLvsPiiF7w+omrN3K0eQhpigV9Z1ilrmHa9e0rOYcD6R/+LCDADGcnQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.0.4.tgz",
+      "integrity": "sha512-fHwmKQ+GzhlqdxEtwrqLT7MSuheiA+rif5/dZgbz3GjoMXJzcRzy1L9NXoiiyxrnap+q5guSiv8Tz5lrh9g42g==",
       "dev": true,
       "requires": {
-        "camel-case": "^3.0.0",
-        "clean-css": "^4.2.1",
-        "commander": "^4.0.0",
+        "camel-case": "^4.1.1",
+        "clean-css": "^4.2.3",
+        "commander": "^4.1.1",
         "he": "^1.2.0",
-        "param-case": "^2.1.1",
+        "param-case": "^3.0.3",
         "relateurl": "^0.2.7",
-        "terser": "^4.3.9"
+        "terser": "^4.6.3"
       },
       "dependencies": {
+        "camel-case": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.1",
+            "tslib": "^1.10.0"
+          }
+        },
         "commander": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-          "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
           "dev": true
+        },
+        "param-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+          "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+          "dev": true,
+          "requires": {
+            "dot-case": "^3.0.3",
+            "tslib": "^1.10.0"
+          }
+        },
+        "terser": {
+          "version": "4.6.4",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.4.tgz",
+          "integrity": "sha512-5fqgBPLgVHZ/fVvqRhhUp9YUiGXhFJ9ZkrZWD9vQtFBR4QIGTnbsb+/kKqSqfgp3WnBwGWAFnedGTtmX1YTn0w==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+              "dev": true
+            }
+          }
         }
-      }
-    },
-    "html-webpack-plugin": {
-      "version": "4.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz",
-      "integrity": "sha512-4Xzepf0qWxf8CGg7/WQM5qBB2Lc/NFI7MhU59eUDTkuQp3skZczH4UA1d6oQyDEIoMDgERVhRyTdtUPZ5s5HBg==",
-      "dev": true,
-      "requires": {
-        "html-minifier-terser": "^5.0.1",
-        "loader-utils": "^1.2.3",
-        "lodash": "^4.17.15",
-        "pretty-error": "^2.1.1",
-        "tapable": "^1.1.3",
-        "util.promisify": "1.0.0"
       }
     },
     "htmlparser2": {
@@ -15493,6 +15553,18 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
+      "dev": true
+    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -15568,12 +15640,6 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
-    },
-    "lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-      "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -16150,15 +16216,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "dev": true,
-      "requires": {
-        "lower-case": "^1.1.1"
-      }
     },
     "node-dir": {
       "version": "0.1.17",
@@ -16763,15 +16820,6 @@
         "readable-stream": "^2.1.5"
       }
     },
-    "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true,
-      "requires": {
-        "no-case": "^2.2.0"
-      }
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -16934,6 +16982,37 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "pascal-case": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        }
+      }
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -21203,12 +21282,6 @@
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
     },
-    "upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-      "dev": true
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -21548,6 +21621,21 @@
             "worker-farm": "^1.7.0"
           }
         }
+      }
+    },
+    "webpack-assets-manifest": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-3.1.1.tgz",
+      "integrity": "sha512-JV9V2QKc5wEWQptdIjvXDUL1ucbPLH2f27toAY3SNdGZp+xSaStAgpoMcvMZmqtFrBc9a5pTS1058vxyMPOzRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0",
+        "lodash.get": "^4.0",
+        "lodash.has": "^4.0",
+        "mkdirp": "^0.5",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.0.0",
+        "webpack-sources": "^1.0.0"
       }
     },
     "webpack-cli": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15255,12 +15255,6 @@
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
-    "json-loader": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
-      "dev": true
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15553,18 +15553,6 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
-      "dev": true
-    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -21623,21 +21611,6 @@
         }
       }
     },
-    "webpack-assets-manifest": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-3.1.1.tgz",
-      "integrity": "sha512-JV9V2QKc5wEWQptdIjvXDUL1ucbPLH2f27toAY3SNdGZp+xSaStAgpoMcvMZmqtFrBc9a5pTS1058vxyMPOzRQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0",
-        "lodash.get": "^4.0",
-        "lodash.has": "^4.0",
-        "mkdirp": "^0.5",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.0.0",
-        "webpack-sources": "^1.0.0"
-      }
-    },
     "webpack-cli": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz",
@@ -22005,6 +21978,40 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "webpack-manifest-plugin": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz",
+      "integrity": "sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "lodash": ">=3.5 <5",
+        "object.entries": "^1.1.0",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
     "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "watch:client": "webpack-dev-server --config webpack.config.js --config-name client",
-    "watch": "npm run watch:server & npm run watch:client",
+    "watch": "npm run build:client; npm run watch:server; npm run watch:client",
     "build:server": "webpack --config webpack.config.js --config-name server --env.production",
     "build:client": "webpack --config webpack.config.js --config-name client",
     "build:client:prod": "webpack --config webpack.config.js --config-name clientProduction",
     "storybook": "start-storybook -s ./",
-    "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh"
+    "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh",
+    "prod": "npm run build:client:prod; npm run build:server"
   },
   "jest": {
     "collectCoverage": true,

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "watch:client": "webpack-dev-server --config webpack.config.js --config-name client",
     "watch": "npm run watch:client & npm run watch:server",
-    "build:server": "webpack --config webpack.config.js --config-name server --env.production",
+    "build:server": "webpack --config webpack.config.js --config-name server",
     "build:client": "webpack --config webpack.config.js --config-name client",
+    "build:server:prod": "npm run build:client:prod; webpack --config webpack.config.js --config-name server --env.production",
     "build:client:prod": "webpack --config webpack.config.js --config-name clientProduction",
     "storybook": "start-storybook -s ./",
-    "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh",
-    "prod": "npm run build:client:prod; npm run build:server"
+    "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh"
   },
   "jest": {
     "collectCoverage": true,

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "ts-jest": "^25.2.0",
     "ts-loader": "^6.2.1",
     "webpack": "^4.41.5",
+    "webpack-assets-manifest": "^3.1.1",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.10.1",
     "winston": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
     "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "watch:client": "webpack-dev-server --config webpack.config.js --config-name client",
-    "watch": "npm run build:client; npm run watch:server; npm run watch:client",
+    "watch": "npm run build:client; npm run watch:server & npm run watch:client",
     "build:server": "webpack --config webpack.config.js --config-name server --env.production",
     "build:client": "webpack --config webpack.config.js --config-name client",
     "build:client:prod": "webpack --config webpack.config.js --config-name clientProduction",
@@ -101,9 +101,9 @@
     "ts-jest": "^25.2.0",
     "ts-loader": "^6.2.1",
     "webpack": "^4.41.5",
-    "webpack-assets-manifest": "^3.1.1",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.10.1",
+    "webpack-manifest-plugin": "^2.2.0",
     "winston": "^3.2.1",
     "winston-daily-rotate-file": "^4.4.2"
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
     "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "watch:client": "webpack-dev-server --config webpack.config.js --config-name client",
-    "watch": "npm run watch:client & npm run watch:server",
+    "watch": "npm run watch:server & npm run watch:client",
     "build:server": "webpack --config webpack.config.js --config-name server",
     "build:client": "webpack --config webpack.config.js --config-name client",
     "build:server:prod": "webpack --config webpack.config.js --config-name server --env.production",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
     "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "watch:client": "webpack-dev-server --config webpack.config.js --config-name client",
-    "watch": "npm run build:client; npm run watch:server & npm run watch:client",
+    "watch": "npm run watch:client & npm run watch:server",
     "build:server": "webpack --config webpack.config.js --config-name server --env.production",
     "build:client": "webpack --config webpack.config.js --config-name client",
     "build:client:prod": "webpack --config webpack.config.js --config-name clientProduction",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "upload": "node-riffraff-artifact",
+    "copy-manifest": "cp dist/assets/manifest.json dist/server/manifest.json",
     "test:build": "webpack --config webpack.config.js --config-name server --env.test",
     "test": "npm run test:build && jest --verbose",
     "test:coverage": "npm run test && open coverage/index.html",
@@ -18,7 +19,7 @@
     "watch": "npm run watch:client & npm run watch:server",
     "build:server": "webpack --config webpack.config.js --config-name server",
     "build:client": "webpack --config webpack.config.js --config-name client",
-    "build:server:prod": "npm run build:client:prod; webpack --config webpack.config.js --config-name server --env.production",
+    "build:server:prod": "webpack --config webpack.config.js --config-name server --env.production",
     "build:client:prod": "webpack --config webpack.config.js --config-name clientProduction",
     "storybook": "start-storybook -s ./",
     "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "upload": "node-riffraff-artifact",
-    "test:build": "webpack --config webpack.config.js --config-name server --env.test",
+    "test:build": "npm run build:client:prod; webpack --config webpack.config.js --config-name server --env.test",
     "test": "npm run test:build && jest --verbose",
     "test:coverage": "npm run test && open coverage/index.html",
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "upload": "node-riffraff-artifact",
-    "test:build": "npm run build:client:prod; webpack --config webpack.config.js --config-name server --env.test",
+    "test:build": "webpack --config webpack.config.js --config-name server --env.test",
     "test": "npm run test:build && jest --verbose",
     "test:coverage": "npm run test && open coverage/index.html",
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -80,7 +80,7 @@ const PageStyles = css`
 interface BodyProps {
     imageSalt: string;
     capi: Content;
-    scriptMappings: { [key: string]: string } | null;
+    getAssetLocation: (assetName: string) => string;
 }
 
 interface ElementWithResources {
@@ -94,18 +94,14 @@ const WithScript = (props: { src: string; children: ReactNode }): ReactElement =
         <script src={props.src}></script>
     </>
 
-function ArticleBody({ capi, imageSalt, scriptMappings }: BodyProps): ElementWithResources {
+function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementWithResources {
 
     const insertAdPlaceholders = getAdPlaceholderInserter(capi.fields?.shouldHideAdverts ?? false);
 
     const item = fromCapi(JSDOM.fragment)(capi);
 
-    const getHashedScript = (scriptName: string): string => scriptMappings
-        ? `/assets/${scriptMappings[scriptName]}`
-        : scriptName
-
-    const articleScript = getHashedScript('article.js');
-    const liveblogScript = getHashedScript('liveblog.js');
+    const articleScript = getAssetLocation('article.js');
+    const liveblogScript = getAssetLocation('liveblog.js');
 
     if (item.design === Design.Comment) {
         const commentBody = partition(item.body).oks;
@@ -167,15 +163,15 @@ function ArticleBody({ capi, imageSalt, scriptMappings }: BodyProps): ElementWit
 interface Props {
     content: Content;
     imageSalt: string;
-    scriptMappings: { [key: string]: string } | null;
+    getAssetLocation: (assetName: string) => string;
 }
 
-function Page({ content, imageSalt, scriptMappings }: Props): ElementWithResources {
+function Page({ content, imageSalt, getAssetLocation }: Props): ElementWithResources {
     const twitterScript = includesTweets(content)
         ? <script src="https://platform.twitter.com/widgets.js"></script>
         : null
 
-    const { element, resources } = ArticleBody({ imageSalt, capi: content, scriptMappings })
+    const { element, resources } = ArticleBody({ imageSalt, capi: content, getAssetLocation })
 
     return { element: (
         <html lang="en" css={PageStyles}>

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -80,7 +80,7 @@ const PageStyles = css`
 interface BodyProps {
     imageSalt: string;
     capi: Content;
-    scriptMappings: { [key: string]: string; };
+    scriptMappings: { [key: string]: string };
 }
 
 interface ElementWithResources {
@@ -100,7 +100,7 @@ function ArticleBody({ capi, imageSalt, scriptMappings }: BodyProps): ElementWit
 
     const item = fromCapi(JSDOM.fragment)(capi);
 
-    const getHashedScript = (scriptName: string) =>
+    const getHashedScript = (scriptName: string): string =>
         `/assets/${scriptMappings[scriptName]}`
 
     const articleScript = getHashedScript('article.js');
@@ -166,7 +166,7 @@ function ArticleBody({ capi, imageSalt, scriptMappings }: BodyProps): ElementWit
 interface Props {
     content: Content;
     imageSalt: string;
-    scriptMappings: { [key: string]: string; }
+    scriptMappings: { [key: string]: string };
 }
 
 function Page({ content, imageSalt, scriptMappings }: Props): ElementWithResources {

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -80,6 +80,7 @@ const PageStyles = css`
 interface BodyProps {
     imageSalt: string;
     capi: Content;
+    scriptMappings: { [key: string]: string; };
 }
 
 interface ElementWithResources {
@@ -93,14 +94,17 @@ const WithScript = (props: { src: string; children: ReactNode }): ReactElement =
         <script src={props.src}></script>
     </>
 
-function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithResources {
+function ArticleBody({ capi, imageSalt, scriptMappings }: BodyProps): ElementWithResources {
 
     const insertAdPlaceholders = getAdPlaceholderInserter(capi.fields?.shouldHideAdverts ?? false);
 
     const item = fromCapi(JSDOM.fragment)(capi);
-    
-    const articleScript = '/assets/article.js';
-    const liveblogScript = '/assets/liveblog.js';
+
+    const getHashedScript = (scriptName: string) =>
+        `/assets/${scriptMappings[scriptName]}`
+
+    const articleScript = getHashedScript('article.js');
+    const liveblogScript = getHashedScript('liveblog.js');
 
     if (item.design === Design.Comment) {
         const commentBody = partition(item.body).oks;
@@ -162,14 +166,15 @@ function ArticleBody({ capi, imageSalt }: BodyProps): ElementWithResources {
 interface Props {
     content: Content;
     imageSalt: string;
+    scriptMappings: { [key: string]: string; }
 }
 
-function Page({ content, imageSalt }: Props): ElementWithResources {
+function Page({ content, imageSalt, scriptMappings }: Props): ElementWithResources {
     const twitterScript = includesTweets(content)
         ? <script src="https://platform.twitter.com/widgets.js"></script>
         : null
 
-    const { element, resources } = ArticleBody({ imageSalt, capi: content})
+    const { element, resources } = ArticleBody({ imageSalt, capi: content, scriptMappings })
 
     return { element: (
         <html lang="en" css={PageStyles}>

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -80,7 +80,7 @@ const PageStyles = css`
 interface BodyProps {
     imageSalt: string;
     capi: Content;
-    scriptMappings: { [key: string]: string };
+    scriptMappings: { [key: string]: string } | null;
 }
 
 interface ElementWithResources {
@@ -100,8 +100,9 @@ function ArticleBody({ capi, imageSalt, scriptMappings }: BodyProps): ElementWit
 
     const item = fromCapi(JSDOM.fragment)(capi);
 
-    const getHashedScript = (scriptName: string): string =>
-        `/assets/${scriptMappings[scriptName]}`
+    const getHashedScript = (scriptName: string): string => scriptMappings
+        ? `/assets/${scriptMappings[scriptName]}`
+        : scriptName
 
     const articleScript = getHashedScript('article.js');
     const liveblogScript = getHashedScript('liveblog.js');
@@ -166,7 +167,7 @@ function ArticleBody({ capi, imageSalt, scriptMappings }: BodyProps): ElementWit
 interface Props {
     content: Content;
     imageSalt: string;
-    scriptMappings: { [key: string]: string };
+    scriptMappings: { [key: string]: string } | null;
 }
 
 function Page({ content, imageSalt, scriptMappings }: Props): ElementWithResources {

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -12,6 +12,6 @@ export const getMappings = (): AssetMapping => {
         return JSON.parse(fs.readFileSync('./manifest.json').toString());
     } catch(e) {
         logger.error(`Unable to load asset mapping: ${e}`)
-        process.exit(1);
+        throw e;
     }
 }

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -9,7 +9,7 @@ export const getMappings = (): AssetMapping => {
     }
 
     try {
-        return JSON.parse(fs.readFileSync('./dist/assets/manifest.json').toString());
+        return JSON.parse(fs.readFileSync('./manifest.json').toString());
     } catch(e) {
         logger.error(`Unable to load asset mapping: ${e}`)
         process.exit(1);

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -3,7 +3,7 @@ import { logger } from 'logger';
 
 type AssetMapping = { [key: string]: string } | null;
 
-export function getAssetMappings(): AssetMapping {
+function getAssetMappings(): AssetMapping {
     if (process.env.NODE_ENV !== "production") {
         return null;
     }
@@ -21,4 +21,11 @@ export function getAssetMappings(): AssetMapping {
         logger.error(`Unable to load asset mapping`, e);
         throw e;
     }
+}
+
+export const getMappedAssetLocation = (): (scriptName: string) => string => {
+    const scriptMappings = getAssetMappings();
+    return scriptMappings
+        ? (scriptName: string) => `/assets/${scriptMappings[scriptName]}`
+        : (scriptName: string) => `/assets/${scriptName}`
 }

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -3,15 +3,22 @@ import { logger } from 'logger';
 
 type AssetMapping = { [key: string]: string } | null;
 
-export const getMappings = (): AssetMapping => {
+export function getAssetMappings(): AssetMapping {
     if (process.env.NODE_ENV !== "production") {
         return null;
     }
 
+    const manifestLocation = process.env.ASSETS_MANIFEST;
+
+    if (!manifestLocation) {
+        logger.error("Environment variable ASSETS_MANIFEST not set");
+        throw new Error("Environment variable ASSETS_MANIFEST not set");
+    }
+
     try {
-        return JSON.parse(fs.readFileSync('./manifest.json').toString());
+        return JSON.parse(fs.readFileSync(manifestLocation).toString());
     } catch(e) {
-        logger.error(`Unable to load asset mapping: ${e}`)
+        logger.error(`Unable to load asset mapping`, e);
         throw e;
     }
 }

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -23,9 +23,14 @@ function getAssetMappings(): AssetMapping {
     }
 }
 
-export const getMappedAssetLocation = (): (scriptName: string) => string => {
+export function getMappedAssetLocation(): (assetName: string) => string {
     const scriptMappings = getAssetMappings();
-    return scriptMappings
-        ? (scriptName: string): string => `/assets/${scriptMappings[scriptName]}`
-        : (scriptName: string): string => `/assets/${scriptName}`
+    if (scriptMappings) {
+        return (assetName: string): string => {
+            const mappedAsset = scriptMappings[assetName] ?? assetName;
+            return `/assets/${mappedAsset}`;
+        }
+    } else {
+        return (assetName: string): string => `/assets/${assetName}`
+    }
 }

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -26,6 +26,6 @@ function getAssetMappings(): AssetMapping {
 export const getMappedAssetLocation = (): (scriptName: string) => string => {
     const scriptMappings = getAssetMappings();
     return scriptMappings
-        ? (scriptName: string) => `/assets/${scriptMappings[scriptName]}`
-        : (scriptName: string) => `/assets/${scriptName}`
+        ? (scriptName: string): string => `/assets/${scriptMappings[scriptName]}`
+        : (scriptName: string): string => `/assets/${scriptName}`
 }

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import { logger } from 'logger';
+
+type AssetMapping = { [key: string]: string } | null;
+
+export const getMappings = (): AssetMapping => {
+    if (process.env.NODE_ENV !== "production") {
+        return null;
+    }
+
+    try {
+        return JSON.parse(fs.readFileSync('./dist/assets/manifest.json').toString());
+    } catch(e) {
+        logger.error(`Unable to load asset mapping: ${e}`)
+        process.exit(1);
+    }
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 
 import path from 'path';
-import fs from 'fs';
 import express, {NextFunction, Request, Response as ExpressResponse} from 'express';
 import compression from 'compression';
 import { renderToString } from 'react-dom/server';
@@ -20,10 +19,11 @@ import Page from 'components/shared/page';
 import { ErrorResponse } from 'mapiThriftModels';
 import { logger } from 'logger';
 import { App, Stack, Stage } from './appIdentity';
+import { getMappings } from './assets';
 
 // ----- Setup ----- //
 
-let scriptMappings: { [key: string]: string } | null = null;
+const scriptMappings = getMappings();
 const defaultId =
   'cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked';
 
@@ -134,16 +134,10 @@ app.post('/article', bodyParser.raw(), serveArticlePost);
 
 const port = 3040;
 
-fs.readFile('./dist/assets/manifest.json', function (err, data) {
-  if (!err) {
-    scriptMappings = JSON.parse(data.toString());
+app.listen(port, () => {
+  if (process.env.NODE_ENV === "production") {
+    logger.info(`Server listening on port ${port}!`);
+  } else {
+    logger.info(`Webpack dev server is listening on port 8080`);
   }
-
-  app.listen(port, () => {
-    if (process.env.NODE_ENV === "production") {
-      logger.info(`Server listening on port ${port}!`);
-    } else {
-      logger.info(`Webpack dev server is listening on port 8080`);
-    }
-  });
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -23,7 +23,7 @@ import { getMappedAssetLocation } from './assets';
 
 // ----- Setup ----- //
 
-const getAssetLocation = getMappedAssetLocation();
+const getAssetLocation: (assetName: string) => string = getMappedAssetLocation();
 const defaultId =
   'cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked';
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import path from 'path';
+import fs from 'fs';
 import express, {NextFunction, Request, Response as ExpressResponse} from 'express';
 import compression from 'compression';
 import { renderToString } from 'react-dom/server';
@@ -19,10 +20,10 @@ import Page from 'components/shared/page';
 import { ErrorResponse } from 'mapiThriftModels';
 import { logger } from 'logger';
 import { App, Stack, Stage } from './appIdentity';
-import scriptMappings from 'assets/manifest.json';
 
 // ----- Setup ----- //
 
+let scriptMappings: { [key: string]: string } | null = null;
 const defaultId =
   'cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked';
 
@@ -132,9 +133,17 @@ app.get('/*', bodyParser.raw(), serveArticle);
 app.post('/article', bodyParser.raw(), serveArticlePost);
 
 const port = 3040;
-app.listen(port, () => {
-  logger.info(`Server listening on port ${port}!`);
-  if (process.env.NODE_ENV !== "production") {
-    logger.info(`Webpack dev server is listening on port 8080`);
+
+fs.readFile('./dist/assets/manifest.json', function (err, data) {
+  if (!err) {
+    scriptMappings = JSON.parse(data.toString());
   }
+
+  app.listen(port, () => {
+    if (process.env.NODE_ENV === "production") {
+      logger.info(`Server listening on port ${port}!`);
+    } else {
+      logger.info(`Webpack dev server is listening on port 8080`);
+    }
+  });
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 
 import path from 'path';
-import fs from 'fs';
 import express, {NextFunction, Request, Response as ExpressResponse} from 'express';
 import compression from 'compression';
 import { renderToString } from 'react-dom/server';
@@ -19,11 +18,11 @@ import { CapiError, capiEndpoint, getContent } from 'capi';
 import Page from 'components/shared/page';
 import { ErrorResponse } from 'mapiThriftModels';
 import { logger } from 'logger';
-import {App, Stack, Stage} from "./appIdentity";
+import { App, Stack, Stage } from './appIdentity';
+import scriptMappings from '../../dist/assets/manifest.json';
 
 // ----- Setup ----- //
 
-let scriptMappings: { [key: string]: string };
 const defaultId =
   'cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked';
 
@@ -133,15 +132,9 @@ app.get('/*', bodyParser.raw(), serveArticle);
 app.post('/article', bodyParser.raw(), serveArticlePost);
 
 const port = 3040;
-
-fs.readFile('dist/assets/manifest.json', function(err, data) {
-  if (err) throw err;
-  scriptMappings = JSON.parse(data.toString());
-
-  app.listen(port, () => {
-    logger.info(`Server listening on port ${port}!`);
-    if (process.env.NODE_ENV !== "production") {
-      logger.info(`Webpack dev server is listening on port 8080`);
-    }
-  });
+app.listen(port, () => {
+  logger.info(`Server listening on port ${port}!`);
+  if (process.env.NODE_ENV !== "production") {
+    logger.info(`Webpack dev server is listening on port 8080`);
+  }
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -19,11 +19,11 @@ import Page from 'components/shared/page';
 import { ErrorResponse } from 'mapiThriftModels';
 import { logger } from 'logger';
 import { App, Stack, Stage } from './appIdentity';
-import { getAssetMappings } from './assets';
+import { getMappedAssetLocation } from './assets';
 
 // ----- Setup ----- //
 
-const scriptMappings = getAssetMappings();
+const getAssetLocation = getMappedAssetLocation();
 const defaultId =
   'cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked';
 
@@ -46,7 +46,7 @@ async function serveArticlePost(
     const content: MapiContent = MapiContent.read(protocol);
     const imageSalt = await getConfigValue<string>('apis.img.salt');
 
-    const { resources, element } = Page({ content, imageSalt, scriptMappings });
+    const { resources, element } = Page({ content, imageSalt, getAssetLocation });
     const html = renderToString(element);
     res.set('Link', getPrefetchHeader(resources));
     res.write('<!DOCTYPE html>');
@@ -83,7 +83,7 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
             }
           },
           content => {
-            const { resources, element } = Page({ content, imageSalt, scriptMappings });
+            const { resources, element } = Page({ content, imageSalt, getAssetLocation });
             res.set('Link', getPrefetchHeader(resources));
             res.write('<!DOCTYPE html>');
             res.write(renderToString(element));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -19,7 +19,7 @@ import Page from 'components/shared/page';
 import { ErrorResponse } from 'mapiThriftModels';
 import { logger } from 'logger';
 import { App, Stack, Stage } from './appIdentity';
-import scriptMappings from '../../dist/assets/manifest.json';
+import scriptMappings from 'assets/manifest.json';
 
 // ----- Setup ----- //
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -19,11 +19,11 @@ import Page from 'components/shared/page';
 import { ErrorResponse } from 'mapiThriftModels';
 import { logger } from 'logger';
 import { App, Stack, Stage } from './appIdentity';
-import { getMappings } from './assets';
+import { getAssetMappings } from './assets';
 
 // ----- Setup ----- //
 
-const scriptMappings = getMappings();
+const scriptMappings = getAssetMappings();
 const defaultId =
   'cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked';
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -23,7 +23,7 @@ import {App, Stack, Stage} from "./appIdentity";
 
 // ----- Setup ----- //
 
-let scriptMappings: { [key: string]: string; };
+let scriptMappings: { [key: string]: string };
 const defaultId =
   'cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "moduleResolution": "node",
         "noUnusedLocals": true,
         "noUnusedParameters": false,
-        "baseUrl": "src/"
+        "baseUrl": "src/",
+        "resolveJsonModule": true,
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,6 @@
         "moduleResolution": "node",
         "noUnusedLocals": true,
         "noUnusedParameters": false,
-        "baseUrl": ".",
-        "paths": {
-            "*": ["src/*", "dist/*"]
-        },
-        "resolveJsonModule": true,
+        "baseUrl": "src/"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,10 @@
         "moduleResolution": "node",
         "noUnusedLocals": true,
         "noUnusedParameters": false,
-        "baseUrl": "src/",
+        "baseUrl": ".",
+        "paths": {
+            "*": ["src/*", "dist/*"]
+        },
         "resolveJsonModule": true,
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,8 +29,9 @@ class LaunchServerPlugin {
 
 function resolve(loggerName) {
     return {
-        extensions: ['.ts', '.tsx', '.js'],
+        extensions: ['.json', '.ts', '.tsx', '.js'],
         modules: [
+            path.resolve(__dirname, 'dist'),
             path.resolve(__dirname, 'src'),
             'node_modules',
         ],
@@ -109,7 +110,7 @@ const clientConfig = {
         filename: '[name].js',
     },
     plugins: [
-        new ManifestPlugin(),
+        new ManifestPlugin({ writeToFileEmit: true }),
     ],
     resolve: resolve("clientDev"),
     devServer: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ const serverConfig = env => {
             __dirname: false,
         },
         output: {
-            filename: 'server.js',
+            filename: 'server/server.js',
         },
         watch: env && env.watch,
         watchOptions: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,14 +24,12 @@ class LaunchServerPlugin {
     }
 }
 
-
 // ----- Shared Config ----- //
 
 function resolve(loggerName) {
     return {
-        extensions: ['.json', '.ts', '.tsx', '.js'],
+        extensions: ['.ts', '.tsx', '.js'],
         modules: [
-            path.resolve(__dirname, 'dist'),
             path.resolve(__dirname, 'src'),
             'node_modules',
         ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const { fork } = require('child_process');
 const webpack = require('webpack');
 const path = require('path');
 const CompressionPlugin = require('compression-webpack-plugin');
+const WebpackAssetsManifest = require('webpack-assets-manifest');
 
 // ----- Plugins ----- //
 
@@ -105,8 +106,11 @@ const clientConfig = {
     target: 'web',
     output: {
         path: path.resolve(__dirname, 'dist/assets'),
-        filename: '[name].js',
+        filename: '[name].[contenthash].js',
     },
+    plugins: [
+        new WebpackAssetsManifest(),
+    ],
     resolve: resolve("clientDev"),
     devServer: {
         publicPath: '/assets/',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ const serverConfig = env => {
                             options: { configFile: isTest ? 'config/tsconfig.test.json' : 'config/tsconfig.server.json' }
                         }
                     ],
-                },
+                }
             ]
         },
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,15 +43,16 @@ function resolve(loggerName) {
 
 const serverConfig = env => {
     const isTest = env && env.test;
-
+    const isProd = env && env.production;
+    const isWatch = env && env.watch;
     // Does not try to require the 'canvas' package,
     // an optional dependency of jsdom that we aren't using.
     const plugins = [ new webpack.IgnorePlugin(/^canvas$/) ];
-    if (env && env.watch) {
+    if (isWatch) {
         plugins.push(new LaunchServerPlugin());
     }
 
-    const mode = (env && env.production) ? "production" : "development";
+    const mode = isProd ? "production" : "development";
 
     return {
         name: 'server',
@@ -62,7 +63,7 @@ const serverConfig = env => {
             __dirname: false,
         },
         output: {
-            filename: 'server/server.js',
+            filename: isProd ? 'server/server.js': 'server.js',
         },
         watch: env && env.watch,
         watchOptions: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,7 +106,7 @@ const clientConfig = {
     target: 'web',
     output: {
         path: path.resolve(__dirname, 'dist/assets'),
-        filename: '[name].[contenthash].js',
+        filename: '[name].js',
     },
     plugins: [
         new WebpackAssetsManifest(),
@@ -158,6 +158,7 @@ const clientConfigProduction = {
             threshold: 10240,
             minRatio: 0.8,
         }),
+        new WebpackAssetsManifest(),
     ],
     performance: {
         hints: 'error',
@@ -165,6 +166,10 @@ const clientConfigProduction = {
         assetFilter: function(assetFilename) {
             return assetFilename.endsWith('.js');
         }
+    },
+    output: {
+        path: path.resolve(__dirname, 'dist/assets'),
+        filename: '[name].[contenthash].js',
     },
     resolve: resolve("clientProd")
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const { fork } = require('child_process');
 const webpack = require('webpack');
 const path = require('path');
 const CompressionPlugin = require('compression-webpack-plugin');
-const WebpackAssetsManifest = require('webpack-assets-manifest');
+const ManifestPlugin = require('webpack-manifest-plugin');
 
 // ----- Plugins ----- //
 
@@ -109,7 +109,7 @@ const clientConfig = {
         filename: '[name].js',
     },
     plugins: [
-        new WebpackAssetsManifest(),
+        new ManifestPlugin(),
     ],
     resolve: resolve("clientDev"),
     devServer: {
@@ -158,7 +158,7 @@ const clientConfigProduction = {
             threshold: 10240,
             minRatio: 0.8,
         }),
-        new WebpackAssetsManifest(),
+        new ManifestPlugin(),
     ],
     performance: {
         hints: 'error',


### PR DESCRIPTION
## Why are you doing this?

Use `contenthash` to be able to invalidate cached JavaScript bundles on device.
This does require client content being built before the server is started...

## Changes

- Adds content hash to generated JavaScript files
- Creates json mapping from script to hashed script name
- Reads mapping on server launch and passes it into the rendering logic

<img src="https://user-images.githubusercontent.com/11618797/75172270-e58ec680-5724-11ea-9f40-7d12c6d4e35a.png" width="900" />
