### PR TITLE
Reset Root Font Size

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,5 @@
 <style>
     html {
-        font-size: 62.5%;
         background: white;
     }
     
@@ -29,7 +28,7 @@
 
     @font-Face{font-family:"Guardian Icons"; src:url("/public/fonts/icons.otf")}
 
-    body{margin:0;font-family:'Guardian Text Egyptian Web';font-size:1.6em;line-height:1.5em;overflow-x:hidden;}
+    body{margin:0;font-family:'Guardian Text Egyptian Web';overflow-x:hidden;}
     figure{margin:1em 0;}
     figure.element-embed{margin:2em 0;}
     .js-email-sub__iframe{width:100%;}

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -23,7 +23,7 @@ const darkStyles = darkMode`
 `;
 
 const styles = css`
-    ${headline.large()}
+    ${headline.medium()}
     ${textPadding}
     padding-bottom: ${spaceToRem(9)};
     color: ${text.primary};
@@ -33,7 +33,7 @@ const styles = css`
 `;
 
 const immersiveStyles = css`
-    ${headline.large({ fontWeight: 'bold' })}
+    ${headline.medium({ fontWeight: 'bold' })}
     background-color: ${neutral[7]};
     color: ${neutral[100]};
     font-weight: 700;
@@ -45,7 +45,7 @@ const immersiveStyles = css`
 
 const analysisStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     ${styles}
-    ${headline.large({ lineHeight: 'regular', fontWeight: 'light' })}
+    ${headline.medium({ lineHeight: 'regular', fontWeight: 'light' })}
 
     span {
         box-shadow: inset 0 -0.1rem ${kicker};
@@ -55,7 +55,7 @@ const analysisStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
 
 const featureStyles = ({ featureHeadline }: PillarStyles): SerializedStyles => css`
     ${styles}
-    ${headline.large({ fontWeight: 'bold' })}
+    ${headline.medium({ fontWeight: 'bold' })}
     color: ${featureHeadline};
 `;
 

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -47,14 +47,11 @@ const PageStyles = css`
 
     ${fontFace("Guardian Icons", new None, new None, "/public/fonts/icons.otf")}
 
-    font-size: 62.5%;
     background: white;
 
     body {
         margin: 0;
         font-family: 'Guardian Text Egyptian Web';
-        font-size: 1.6em;
-        line-height: 1.5em;
         overflow-x: hidden;
     }
 


### PR DESCRIPTION
## Why are you doing this?

Previously we set the root font size to `62.5%`. This undoes that to allow the font size to revert to the browser default. This should make it easier to integrate with designs and the design system, and possibly simplify work being done to adjust the font size in the native layers.

This also removes font size rules that were being applied globally to the body. We would like to make our CSS more granular and apply this at the component level.

I've also updated the universal headline component introduced in #202 to use the correct design system sizes, which now work correctly with our root font size.

**Note:** This will break some of the scaling on articles until I can migrate the remainder of our components across to the design system scaling.

FYI @SiAdcock @jeanlauliac 

## Changes

- Removed font sizes being set on the `html` and `body` elements.
- Applied correct design system font sizes to headline.
