### PR TITLE
Fix Storybook Crash

### DIFF
--- a/src/components/headline.stories.tsx
+++ b/src/components/headline.stories.tsx
@@ -33,6 +33,7 @@ const item: Item = {
     },
     commentable: false,
     tags: [],
+    shouldHideReaderRevenue: false,
 };
 
 const pillarOptions = {

--- a/src/components/standard/byline.stories.tsx
+++ b/src/components/standard/byline.stories.tsx
@@ -38,6 +38,7 @@ const item: Item = {
     },
     commentable: false,
     tags: [],
+    shouldHideReaderRevenue: false,
 };
 
 const contributor = (): Contributor => ({

--- a/src/components/standfirst.stories.tsx
+++ b/src/components/standfirst.stories.tsx
@@ -42,6 +42,7 @@ const item: Item = {
     },
     commentable: false,
     tags: [],
+    shouldHideReaderRevenue: false,
 };
 
 const pillarOptions = {

--- a/src/components/starRating.stories.tsx
+++ b/src/components/starRating.stories.tsx
@@ -33,6 +33,7 @@ const item: Item = {
     },
     commentable: false,
     tags: [],
+    shouldHideReaderRevenue: false,
 };
 
 const starRating: Record<number, number> = [0, 1, 2, 3, 4, 5];


### PR DESCRIPTION
## Why are you doing this?

A missing field in the mock item was causing storybook to crash.

**Note:** I'm aware that this mock is repeated a lot. Will be extracting it out soon 🙂

## Changes

- Added mock for `shouldHideReaderRevenue` field
