### PR TITLE
Paragraph Component

### DIFF
--- a/src/components/paragraph.stories.tsx
+++ b/src/components/paragraph.stories.tsx
@@ -9,7 +9,8 @@ import Paragraph from './paragraph';
 
 const Default: FC = () =>
     <Paragraph>
-        Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have dreamed of water: containing it, draining it and now retaining it.
+        Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have
+        dreamed of water: containing it, draining it and now retaining it.
     </Paragraph>
 
 

--- a/src/components/paragraph.stories.tsx
+++ b/src/components/paragraph.stories.tsx
@@ -1,0 +1,25 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+
+import Paragraph from './paragraph';
+
+
+// ----- Stories ----- //
+
+const Default: FC = () =>
+    <Paragraph>
+        Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have dreamed of water: containing it, draining it and now retaining it.
+    </Paragraph>
+
+
+// ----- Exports ----- //
+
+export default {
+    component: Paragraph,
+    title: 'Paragraph',
+}
+
+export {
+    Default,
+}

--- a/src/components/paragraph.tsx
+++ b/src/components/paragraph.tsx
@@ -19,7 +19,7 @@ const styles = css`
     margin: 0 0 ${spaceToRem(3)};
 `;
 
-const Paragraph: FC<Props> = ({ children }) =>
+const Paragraph: FC<Props> = ({ children }: Props) =>
     <p css={styles}>{children}</p>;
 
 

--- a/src/components/paragraph.tsx
+++ b/src/components/paragraph.tsx
@@ -3,8 +3,7 @@
 import { FC, ReactNode } from 'react';
 import React, { css } from '@emotion/core';
 import { body } from '@guardian/src-foundations/typography';
-
-import { spaceToRem } from 'styles';
+import { remSpace } from '@guardian/src-foundations';
 
 
 // ----- Component ----- //
@@ -16,7 +15,7 @@ interface Props {
 const styles = css`
     ${body.medium()}
     overflow-wrap: break-word;
-    margin: 0 0 ${spaceToRem(3)};
+    margin: 0 0 ${remSpace[3]};
 `;
 
 const Paragraph: FC<Props> = ({ children }: Props) =>

--- a/src/components/paragraph.tsx
+++ b/src/components/paragraph.tsx
@@ -1,0 +1,28 @@
+// ----- Imports ----- //
+
+import { FC, ReactNode } from 'react';
+import React, { css } from '@emotion/core';
+import { body } from '@guardian/src-foundations/typography';
+
+import { spaceToRem } from 'styles';
+
+
+// ----- Component ----- //
+
+interface Props {
+    children?: ReactNode;
+}
+
+const styles = css`
+    ${body.medium()}
+    overflow-wrap: break-word;
+    margin: 0 0 ${spaceToRem(3)};
+`;
+
+const Paragraph: FC<Props> = ({ children }) =>
+    <p css={styles}>{children}</p>;
+
+
+// ----- Exports ----- //
+
+export default Paragraph;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -10,6 +10,7 @@ import { srcset, src } from 'image';
 import { basePx, icons, headlineFont, darkModeCss, textSans } from 'styles';
 import { getPillarStyles, Pillar } from 'pillar';
 import { ElementKind, BodyElement } from 'item';
+import Paragraph from 'components/paragraph';
 
 
 // ----- Renderer ----- //
@@ -29,9 +30,6 @@ const getAttr = (attr: string) => (node: Node): Option<string> =>
 
 const getHref: (node: Node) => Option<string> =
     getAttr('href');
-
-const Paragraph = (props: { children?: ReactNode }): ReactElement =>
-    styledH('p', { css: css`overflow-wrap: break-word` }, props.children);
 
 const anchorStyles = (colour: string): SerializedStyles => css`
     color: ${colour};


### PR DESCRIPTION
## Why are you doing this?

Give the `Paragraph` component its own file. This helps to scope styles directly on the component, and fits in with our other component conventions, including storybook.

## Changes

- New file for Paragraph
- Added styles directly to para component, w/ design system fonts
- Updated pxToRem to use 16px as root font size
- Added stories for Paragraph
