### PR TITLE
Migrate To REM Space 🌌

### DIFF
--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -4,9 +4,10 @@ import React, { ReactElement } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { headline } from '@guardian/src-foundations/typography';
 import { background, neutral, text } from '@guardian/src-foundations/palette';
+import { remSpace } from '@guardian/src-foundations';
 
 import { Item, Design, Display } from 'item';
-import { textPadding, darkModeCss as darkMode, spaceToRem } from 'styles';
+import { textPadding, darkModeCss as darkMode } from 'styles';
 import { getPillarStyles, PillarStyles } from 'pillar';
 import StarRating from './starRating';
 
@@ -25,7 +26,7 @@ const darkStyles = darkMode`
 const styles = css`
     ${headline.medium()}
     ${textPadding}
-    padding-bottom: ${spaceToRem(9)};
+    padding-bottom: ${remSpace[9]};
     color: ${text.primary};
     margin: 0;
 
@@ -37,7 +38,7 @@ const immersiveStyles = css`
     background-color: ${neutral[7]};
     color: ${neutral[100]};
     font-weight: 700;
-    padding: ${spaceToRem(1)} ${spaceToRem(2)} ${spaceToRem(6)} ${spaceToRem(2)};
+    padding: ${remSpace[1]} ${remSpace[2]} ${remSpace[6]} ${remSpace[2]};
     margin: 0;
 
     ${darkStyles}
@@ -62,7 +63,7 @@ const featureStyles = ({ featureHeadline }: PillarStyles): SerializedStyles => c
 const commentStyles = css`
     ${styles}
     ${headline.medium({ fontWeight: 'light' })}
-    padding-bottom: ${spaceToRem(1)};
+    padding-bottom: ${remSpace[1]};
 `;
 
 const getStyles = (item: Item): SerializedStyles => {

--- a/src/components/shared/epic.tsx
+++ b/src/components/shared/epic.tsx
@@ -1,31 +1,33 @@
 // ----- Imports ----- //
-import { css, SerializedStyles } from '@emotion/core';
-import { spaceToRem } from 'styles';
-import { from } from '@guardian/src-foundations/mq';
-import { palette } from '@guardian/src-foundations';
-import { brandAltBackground } from '@guardian/src-foundations/palette';
+
 import React, { useState, useEffect, useRef } from 'react';
-import { nativeClient } from 'native/nativeApi';
-import { SvgArrowRightStraight } from "@guardian/src-svgs"
+import { css, SerializedStyles } from '@emotion/core';
 import { ThemeProvider } from 'emotion-theming'
+import { from } from '@guardian/src-foundations/mq';
+import palette, { brandAltBackground } from '@guardian/src-foundations/palette';
+import { remSpace } from '@guardian/src-foundations';
+import { SvgArrowRightStraight } from "@guardian/src-svgs"
 import { Button, buttonReaderRevenue } from '@guardian/src-button';
 import { body, headline } from '@guardian/src-foundations/typography';
+
+import { nativeClient } from 'native/nativeApi';
+
 
 // ----- Styles ----- //
 
 const EpicStyles = (): SerializedStyles => css`
-        width: calc(100% - ${spaceToRem(2)} - ${spaceToRem(2)} - ${spaceToRem(2)} - ${spaceToRem(2)});
-        margin: ${spaceToRem(2)};
+        width: calc(100% - ${remSpace[2]} - ${remSpace[2]} - ${remSpace[2]} - ${remSpace[2]});
+        margin: ${remSpace[2]};
 
         ${from.wide} {
-            margin: ${spaceToRem(2)} 0;
+            margin: ${remSpace[2]} 0;
         }
 
         clear: both;
 
         border-top: 1px solid ${brandAltBackground.primary};
         background: ${palette.neutral[97]};
-        padding: ${spaceToRem(2)};
+        padding: ${remSpace[2]};
         ${body.medium()}
         clear: left;
 
@@ -34,16 +36,16 @@ const EpicStyles = (): SerializedStyles => css`
         }
 
         button {
-            margin: 0 ${spaceToRem(2)} ${spaceToRem(2)} 0;
+            margin: 0 ${remSpace[2]} ${remSpace[2]} 0;
         }
 
         .button-container {
-            margin-top: ${spaceToRem(9)};
+            margin-top: ${remSpace[9]};
         }
 
         svg {
-            margin-left: ${spaceToRem(2)};
-            margin-top: -${spaceToRem(1)};
+            margin-left: ${remSpace[2]};
+            margin-top: -${remSpace[1]};
             vertical-align: middle;
         }
 

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -5,10 +5,11 @@ import { css, SerializedStyles } from '@emotion/core';
 import { headline } from '@guardian/src-foundations/typography';
 import { background, neutral, text } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
+import { remSpace } from '@guardian/src-foundations';
 
 import { Item, Design, Display } from 'item';
 import { renderText } from 'renderer';
-import { spaceToRem, textPadding, darkModeCss as darkMode } from 'styles';
+import { textPadding, darkModeCss as darkMode } from 'styles';
 import { PillarStyles, getPillarStyles } from 'pillar';
 
 
@@ -28,7 +29,7 @@ const darkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkMode`
 `;
 
 const styles = (pillarStyles: PillarStyles): SerializedStyles => css`
-    margin-bottom: ${spaceToRem(2)};
+    margin-bottom: ${remSpace[2]};
     ${textPadding}
     color: ${text.primary};
 
@@ -58,7 +59,7 @@ const thinHeadline = css`
 const immersive = (pillarStyles: PillarStyles): SerializedStyles => css`
     ${styles(pillarStyles)}
     ${headline.xsmall({ fontWeight: 'light' })}
-    margin-top: ${spaceToRem(3)};
+    margin-top: ${remSpace[3]};
 
     a {
         box-shadow: inset 0 -0.1rem ${pillarStyles.kicker};

--- a/src/components/starRating.tsx
+++ b/src/components/starRating.tsx
@@ -3,9 +3,10 @@
 import React, { ReactNode, ReactElement } from 'react';
 import { css } from '@emotion/core';
 import { brandAltBackground, text } from '@guardian/src-foundations/palette';
+import { remSpace } from '@guardian/src-foundations';
 
 import { Item, Design } from 'item';
-import { icons, spaceToRem } from 'styles';
+import { icons } from 'styles';
 
 
 // ----- Subcomponents ----- //
@@ -13,18 +14,18 @@ import { icons, spaceToRem } from 'styles';
 const starStyles = css`
     ${icons}
     background-color: ${brandAltBackground.primary};
-    font-size: ${spaceToRem(5)};
+    font-size: ${remSpace[5]};
     line-height: 1;
     display: inline-block;
-    padding: 0 0.2rem ${spaceToRem(1)};
+    padding: 0 0.2rem ${remSpace[1]};
     color: ${text.primary};
 
     &:nth-of-type(1) {
-        padding-left: ${spaceToRem(1)};
+        padding-left: ${remSpace[1]};
     }
 
     &:nth-of-type(5) {
-        padding-right: ${spaceToRem(1)};
+        padding-right: ${remSpace[1]};
     }
 `;
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,19 +1,12 @@
 import { neutral } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
+import { remSpace } from '@guardian/src-foundations';
 import { css, SerializedStyles } from '@emotion/core'
 import { Option } from 'types/option';
 
 const BASE_PADDING = 8;
 
 export const baseMultiply = (value: number): number => value * BASE_PADDING;
-
-// We've changed the root font size to 62.5%, which equates to 10px.
-const pxToRem = (px: number): string =>
-    `${px/10}rem`;
-
-export const spaceToRem = (size: keyof (typeof space)): string =>
-    pxToRem(space[size]);
 
 export const basePx = (...values: Array<number>): string => values.map(baseMultiply).join("px ") + "px";
 
@@ -24,8 +17,8 @@ export const headlineFontStyles = css`
 `;
 
 export const textPadding = css`
-    padding-left: ${spaceToRem(2)};
-    padding-right: ${spaceToRem(2)};
+    padding-left: ${remSpace[2]};
+    padding-right: ${remSpace[2]};
 
     ${from.wide} {
         padding-left: 0;


### PR DESCRIPTION
## Why are you doing this?

For a while we've been using a couple of functions to convert design system spaces (in px) to rems. We recently [pushed this upstream](https://github.com/guardian/source/pull/236) to the design system. Now we can use the design system implementation.

**Note:** This is reliant on #218.

## Changes

- Deleted `pxToRem` and `spaceToRem`
- Updated all uses of `spaceToRem` to `remSpace`
- Tidied up epic imports
