### PR TITLE
toOption Method On Result

### DIFF
--- a/src/components/author.stories.tsx
+++ b/src/components/author.stories.tsx
@@ -6,7 +6,7 @@ import { text, withKnobs, select } from '@storybook/addon-knobs';
 import Author from './author';
 import { Item, Design, Display } from 'item';
 import { Pillar } from 'pillar';
-import { Option, None, Some } from 'types/option';
+import { Option, None } from 'types/option';
 import { parse } from 'client/parser';
 
 
@@ -47,10 +47,7 @@ const byline = (): string =>
     text('Byline', 'Jane Smith');
 
 const mockBylineHtml = (): Option<DocumentFragment> =>
-    parseByline(`<a href="${profileLink()}">${byline()}</a>`).either(
-        _ => new None(),
-        frag => new Some(frag),
-    );
+    parseByline(`<a href="${profileLink()}">${byline()}</a>`).toOption();
 
 const pillarOptions = {
     News: Pillar.news,

--- a/src/components/standard/byline.stories.tsx
+++ b/src/components/standard/byline.stories.tsx
@@ -65,10 +65,7 @@ function publishDate(): Option<Date> {
 }
 
 const mockBylineHtml = (): Option<DocumentFragment> =>
-    parseByline(`<a href="${profileLink()}">${byline()}</a> ${job()}`).either(
-        _ => new None(),
-        frag => new Some(frag),
-    );
+    parseByline(`<a href="${profileLink()}">${byline()}</a> ${job()}`).toOption();
 
 
 // ----- Stories ----- //

--- a/src/components/standfirst.stories.tsx
+++ b/src/components/standfirst.stories.tsx
@@ -6,7 +6,7 @@ import React, { ReactElement } from 'react';
 import Standfirst from './standfirst';
 import { Item, Design, Display } from 'item';
 import { Pillar } from 'pillar';
-import { Option, None, Some } from 'types/option';
+import { Option, None } from 'types/option';
 import { parse } from 'client/parser';
 
 
@@ -15,10 +15,9 @@ import { parse } from 'client/parser';
 const parser = new DOMParser();
 const parseStandfirst = parse(parser);
 
-const standfirst: Option<DocumentFragment> = parseStandfirst('<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>').either(
-    _ => new None(),
-    frag => new Some(frag),
-);
+const standfirst: Option<DocumentFragment> =
+    parseStandfirst('<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>')
+        .toOption();
 
 const item: Item = {
     pillar: Pillar.news,

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,0 +1,16 @@
+// ----- Imports ----- //
+
+import { identity } from './lib';
+
+
+// ----- Tests ----- //
+
+describe('identity', () => {
+    it('returns the same value that it was given', () => {
+
+        expect(identity(2)).toBe(2);
+        expect(identity('hello world')).toBe('hello world');
+        expect(identity({ foo: 'bar' })).toEqual({ foo: 'bar' });
+
+    });
+});

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -2,8 +2,12 @@
 
 const compose = <A, B, C>(f: (_b: B) => C, g: (_a: A) => B) => (a: A): C => f(g(a));
 
+const identity = <A>(a: A): A => a;
+
+
 // ----- Exports ----- //
 
 export {
     compose,
+    identity,
 };

--- a/src/types/result.test.ts
+++ b/src/types/result.test.ts
@@ -1,0 +1,85 @@
+// ----- Imports ----- //
+
+import { Result, Ok, Err } from './result';
+import { identity } from 'lib';
+
+
+// ----- Setup ----- //
+
+const ok: Result<string, number> = new Ok(4);
+const err: Result<string, number> = new Err('message');
+
+const onOk = (a: number): number => a + 2;
+const onError = (e: string): string => `Output: ${e}`;
+
+
+// ----- Tests ----- //
+
+describe('either', () => {
+    it('runs the correct function when Result is Ok', () => {
+        expect(ok.either<number | string>(onError, onOk)).toBe(6);
+    });
+
+    it('runs the correct function when Result is Err', () => {
+        expect(err.either<number | string>(onError, onOk)).toBe('Output: message');
+    });
+});
+
+describe('fmap', () => {
+    it('runs the function when Result is Ok', () => {
+        expect(ok.fmap(onOk).either<number | string>(identity, identity)).toBe(6);
+    });
+
+    it('passes the error through when Result is Err', () => {
+        expect(err.fmap(a => `Output: ${a}`).either<number | string>(identity, identity))
+            .toBe('message');
+    });
+});
+
+describe('andThen', () => {
+    it('runs the function and unwraps the result when both Results are Ok', () => {
+        const f = (a: number): Result<string, number> => new Ok(a + 2);
+
+        expect(ok.andThen(f).either<string | number>(identity, identity)).toBe(6);
+    });
+
+    it('passes through the Err when the first Result is Err', () => {
+        const f = (a: number): Result<string, number> => new Ok(a + 2);
+
+        expect(err.andThen(f).either<string | number>(identity, identity)).toBe('message');
+    });
+
+    it('passes through the Err when the second Result is Err', () => {
+        const f = (_: number): Result<string, number> => new Err('message');
+
+        expect(ok.andThen(f).either<string | number>(identity, identity)).toBe('message');
+    });
+
+    it('passes through the first Err when the first Result is Err', () => {
+        const f = (_: number): Result<string, number> => new Err('secondMessage');
+
+        expect(err.andThen(f).either<string | number>(identity, identity)).toBe('message');
+    });
+});
+
+describe('mapError', () => {
+    it('passes through the result when Result is Ok', () => {
+        expect(ok.mapError(onError).either<string | number>(identity, identity))
+            .toBe(4);
+    });
+
+    it('runs the function when Result is Err', () => {
+        expect(err.mapError(onError).either<string | number>(identity, identity))
+            .toBe('Output: message');
+    });
+});
+
+describe('toOption', () => {
+    it('produces Some when Result is Ok', () => {
+        expect(ok.toOption().withDefault(6)).toBe(4);
+    });
+
+    it('produces None when Result is Err', () => {
+        expect(err.toOption().withDefault(6)).toBe(6);
+    });
+});

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { Monad } from './monad';
+import { Option, Some, None } from './option';
 
 
 // ----- Classes ----- //
@@ -8,6 +9,7 @@ import { Monad } from './monad';
 interface ResultInterface<E, B> extends Monad<B> {
     either<C>(f: (e: E) => C, g: (b: B) => C): C;
     mapError<F>(g: (e: E) => F): Result<F, B>;
+    toOption(): Option<B>;
 }
 
 class Ok<E, B> implements ResultInterface<E, B> {
@@ -28,6 +30,10 @@ class Ok<E, B> implements ResultInterface<E, B> {
 
     mapError<F>(_g: (e: E) => F): Result<F, B> {
         return new Ok(this.value);
+    }
+
+    toOption(): Option<B> {
+        return new Some(this.value);
     }
 
     constructor(value: B) {
@@ -54,6 +60,10 @@ class Err<E, B> implements ResultInterface<E, B> {
 
     mapError<F>(g: (e: E) => F): Result<F, B> {
         return new Err(g(this.error));
+    }
+
+    toOption(): Option<B> {
+        return new None();
     }
 
     constructor(error: E) {


### PR DESCRIPTION
## Why are you doing this?

I've written conversions from `Result` to `Option` using `either` at least three times. Therefore I've decided to create a `toOption` method on `Result` to handle this.

I've also written out a test file to cover `Result`. In writing these tests I found a use for the `identity` function, so I've added that to `lib` and included some tests there too.

cc @gtrufitt 

## Changes

- Added a `toOption` method to `Result`
- Migrated some usages of `either` to `Option`
- Added `identity` function and corresponding tests
- Added tests for `Result`
