### PR TITLE
Add a local font URL for iOS

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -181,6 +181,6 @@ export const fontFace = (
     font-family: ${family};
     ${style.fmap((s: string) => `font-style: ${s};`).withDefault('')}
     ${weight.fmap((w: number | string) => `font-weight: ${w};`).withDefault('')}
-    src: url('${url}');
+    src: url('font://${url)}'), url('${url}');
   }
 `;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -181,6 +181,6 @@ export const fontFace = (
     font-family: ${family};
     ${style.fmap((s: string) => `font-style: ${s};`).withDefault('')}
     ${weight.fmap((w: number | string) => `font-weight: ${w};`).withDefault('')}
-    src: url('font://${url)}'), url('${url}');
+    src: url('font://${url}'), url('${url}');
   }
 `;


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

This adds an additional URL with a custom URL scheme, `font://`, to the `font-face` element. This allows iOS to handle the custom URL scheme and return a local font. See https://theguardian.atlassian.net/browse/GLA-1776.

## Changes

- Added the new `font://` URL before the relative URL
