### PR TITLE
Don't insert ads until after checking premium status

### DIFF
--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -57,7 +57,6 @@ function insertAds(): void {
 }
 
 function ads(): void {
-    insertAds();
     nativeClient.isPremiumUser().then(premiumUser => {
         if (!premiumUser) {
             Array.from(document.querySelectorAll('.ad-placeholder'))


### PR DESCRIPTION
## Why are you doing this?

We're inserting ads before checking if the user is premium. This PR stops that happening.

## Changes

- Removed a call to insert ads before checking if a user is premium
