### PR TITLE
update ads when fonts loaded

### DIFF
--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -14,6 +14,16 @@ import ReactDOM from 'react-dom';
 
 // ----- Run ----- //
 
+interface FontFaceSet {
+    readonly ready: Promise<FontFaceSet>;
+}
+
+declare global {
+    interface Document {
+        fonts: FontFaceSet;
+    }
+}
+
 function getAdSlots(): AdSlot[] {
     const advertSlots = document.getElementsByClassName('ad-slot');
 
@@ -55,7 +65,7 @@ function insertAds(): void {
         observer.observe(targetNode, config);
 
         try {
-            (document as any).fonts.ready.then(() => nativeClient.updateAdverts(getAdSlots()))
+            document.fonts.ready.then(() => nativeClient.updateAdverts(getAdSlots()))
         } catch (e) {
             logger.error(`font loading API not supported: ${e}`)
         }

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -53,6 +53,9 @@ function insertAds(): void {
 
         const observer = new MutationObserver(callback);
         observer.observe(targetNode, config);
+
+        // handle font loading and changes that do not mutate DOM
+        setTimeout(() => nativeClient.updateAdverts(getAdSlots()), 200);
     }
 }
 
@@ -60,7 +63,7 @@ function ads(): void {
     nativeClient.isPremiumUser().then(premiumUser => {
         if (!premiumUser) {
             Array.from(document.querySelectorAll('.ad-placeholder'))
-                 .map(placeholder => placeholder.classList.remove('hidden'))
+                 .forEach(placeholder => placeholder.classList.remove('hidden'))
             insertAds();
         }
     })

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -54,8 +54,11 @@ function insertAds(): void {
         const observer = new MutationObserver(callback);
         observer.observe(targetNode, config);
 
-        // handle font loading and changes that do not mutate DOM
-        setTimeout(() => nativeClient.updateAdverts(getAdSlots()), 200);
+        try {
+            (document as any).fonts.ready.then(() => nativeClient.updateAdverts(getAdSlots()))
+        } catch (e) {
+            logger.error(`font loading API not supported: ${e}`)
+        }
     }
 }
 


### PR DESCRIPTION
## Why are you doing this?
Sometimes the ad positions change without a DOM mutation e.g. fonts loading. This should correctly reposition ads.