### PR TITLE
rename npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7447,6 +7447,11 @@
         }
       }
     },
+    "bridget-typescript": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/bridget-typescript/-/bridget-typescript-0.46.0.tgz",
+      "integrity": "sha512-MnrRlCPlhR+qXqcJrQrW8ZZBhfFK5TaeumxI+9RbYzhz9aJ6RnZPWYOZoNsC08dMsBhXutcsr8o5ASbvoc24Qg=="
+    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -15948,11 +15953,6 @@
           "dev": true
         }
       }
-    },
-    "mobile-apps-thrift-typescript": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/mobile-apps-thrift-typescript/-/mobile-apps-thrift-typescript-0.44.0.tgz",
-      "integrity": "sha512-8/h+U3e1VnKV6Me161Pg95fyfE71OTtRYEsbVCLj25ZjDDL5y9R6mU6x9fN9o9OPS7U1gITX/s5gjbLxOOCQgw=="
     },
     "moment": {
       "version": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "emotion": "^10.0.27",
     "express": "^4.17.1",
     "jsdom": "^15.2.1",
-    "mobile-apps-thrift-typescript": "^0.44.0",
+    "bridget-typescript": "^0.46.0",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -1,10 +1,10 @@
 // ----- Imports ----- //
 
 import { nativeClient } from 'native/nativeApi';
-import { AdSlot } from 'mobile-apps-thrift-typescript/AdSlot'
-import { Topic } from 'mobile-apps-thrift-typescript/Topic';
-import { Image } from 'mobile-apps-thrift-typescript/Image';
-import { IMaybeEpic as MaybeEpic } from 'mobile-apps-thrift-typescript/MaybeEpic';
+import { AdSlot } from 'bridget-typescript/AdSlot'
+import { Topic } from 'bridget-typescript/Topic';
+import { Image } from 'bridget-typescript/Image';
+import { IMaybeEpic as MaybeEpic } from 'bridget-typescript/MaybeEpic';
 import { formatDate } from 'date';
 import { logger } from "../logger";
 import { createElement as h } from 'react';

--- a/src/native/nativeApi.ts
+++ b/src/native/nativeApi.ts
@@ -1,5 +1,5 @@
 import { createAppClient } from './thrift/nativeConnection';
-import * as Native from 'mobile-apps-thrift-typescript/Native';
+import * as Native from 'bridget-typescript/Native';
 
 const nativeClient: Native.Client<void> = createAppClient<Native.Client>(Native.Client, 'buffered', 'compact');
 


### PR DESCRIPTION
## Why are you doing this?
Create new npm package with a more consistent name to other repos (bridget and bridget-swift)

I've made the changes to publish the TypeScript files to `bridget-typescript` inside the `bridget` repo.