### PR TITLE
Image and BodyImage Components

### DIFF
--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -117,8 +117,8 @@ function launchSlideshow(src: string | null): void {
     const images = Array.from(document.querySelectorAll('.js-launch-slideshow'));
     const imagesWithCaptions: Image[] = images.flatMap((image: Element) => {
         const url = image.getAttribute('src');
-        const caption =  image.getAttribute('caption') ?? undefined;
-        const credit = image.getAttribute('credit') ?? undefined;
+        const caption =  image.getAttribute('data-caption') ?? undefined;
+        const credit = image.getAttribute('data-credit') ?? undefined;
         return url ? new Image({ url, caption, credit }) : [];
     });
     const clickedImageIndex = images.findIndex((image: Element) => image.getAttribute('src') === src);

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -55,7 +55,7 @@ const captionStyles = css`
     color: ${text.supporting};
 `;
 
-const BodyImage: FC<Props> = ({ figcaption, image, pillar }) =>
+const BodyImage: FC<Props> = ({ figcaption, image, pillar }: Props) =>
     <figure css={styles}>
         <Image {...image} sizes={sizes} />
         <figcaption css={captionStyles}>

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -1,0 +1,76 @@
+// ----- Imports ----- //
+
+import React, { FC, ReactNode } from 'react';
+import { css, SerializedStyles } from '@emotion/core';
+import { text } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import { between, from } from '@guardian/src-foundations/mq';
+import { remSpace, breakpoints } from '@guardian/src-foundations';
+
+import Image, { Props as ImageProps } from 'components/image';
+import { textPadding } from 'styles';
+import { Pillar, PillarStyles, getPillarStyles } from 'pillar';
+
+
+// ----- Setup ----- //
+
+const sizes = `(min-width: ${breakpoints.phablet}px) 620px, 100vw`;
+
+
+// ----- Component ----- //
+
+interface Props {
+    image: Omit<ImageProps, 'sizes'>;
+    figcaption: ReactNode;
+    pillar: Pillar;
+}
+
+const styles = css`
+    margin: 1rem 0 ${remSpace[3]};
+
+    ${from.wide} {
+        margin-bottom: 1rem;
+    }
+
+    img {
+        display: block;
+        width: 100%;
+
+        ${between.phablet.and.wide} {
+            margin: 0 ${remSpace[2]};
+        }
+    }
+`;
+
+const triangleStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
+    fill: ${kicker};
+    height: 0.8em;
+    padding-right: ${remSpace[1]};
+`;
+
+const captionStyles = css`
+    ${textSans.xsmall()}
+    ${textPadding}
+    padding-top: ${remSpace[2]};
+    color: ${text.supporting};
+`;
+
+const BodyImage: FC<Props> = ({ figcaption, image, pillar }) =>
+    <figure css={styles}>
+        <Image {...image} sizes={sizes} />
+        <figcaption css={captionStyles}>
+            <svg
+                css={triangleStyles(getPillarStyles(pillar))}
+                viewBox="0 0 10 9"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <polygon points="0,9 5,0 10,9 0,9" />
+            </svg>
+            {figcaption}
+        </figcaption>
+    </figure>
+
+
+// ----- Exports ----- //
+
+export default BodyImage;

--- a/src/components/image.ts
+++ b/src/components/image.ts
@@ -1,0 +1,103 @@
+// ----- Imports ----- //
+
+import { FC } from 'react';
+import { jsx as styledH, css, SerializedStyles } from '@emotion/core';
+import { createHash } from 'crypto';
+
+import { from } from '@guardian/src-foundations/mq';
+import { neutral } from '@guardian/src-foundations/palette';
+
+
+// ----- Setup ----- //
+
+const imageResizer = 'https://i.guim.co.uk/img';
+
+const widths = [
+    140,
+    500,
+    1000,
+    1500,
+    2000,
+];
+
+// Percentage.
+const defaultQuality = 85;
+
+
+// ----- Functions ----- //
+
+const getSubdomain = (domain: string): string =>
+    domain.split('.')[0];
+
+const sign = (salt: string, path: string): string =>
+    createHash('md5').update(salt + path).digest('hex')    
+
+function src(salt: string, input: string, width: number): string {
+    const url = new URL(input);
+    const service = getSubdomain(url.hostname);
+
+    const params = new URLSearchParams({
+        width: width.toString(),
+        quality: defaultQuality.toString(),
+        fit: 'bounds',
+        'sig-ignores-params': 'true',
+        s: sign(salt, url.pathname),
+    });
+
+    return `${imageResizer}/${service}${url.pathname}?${params.toString()}`;
+}
+
+const srcset = (url: string, salt: string): string =>
+    widths
+        .map(width => `${src(salt, url, width)} ${width}w`)
+        .join(', ');
+
+
+// ----- Component ----- //
+
+interface Props {
+    url: string;
+    alt: string;
+    width: number;
+    height: number;
+    salt: string;
+    sizes: string;
+    caption: string;
+    credit: string;
+}
+
+const styles = (width: number, height: number): SerializedStyles => css`
+    height: calc(100vw * ${height / width});
+    background: ${neutral[97]};
+
+    ${from.phablet} {
+        height: calc(620px * ${height / width});
+    }
+`;
+
+const Image: FC<Props> = ({ url, sizes, salt, alt, width, height, caption, credit }) => {
+
+    if (url === '') {
+        return null;
+    }
+
+    return styledH('img', {
+        sizes,
+        srcSet: srcset(url, salt),
+        alt,
+        className: 'js-launch-slideshow',
+        src: src(salt, url, 500),
+        css: styles(width, height),
+        'data-caption': caption,
+        'data-credit': credit,
+    });
+}
+
+
+// ----- Exports ----- //
+
+export default Image;
+
+export {
+    Props,
+}

--- a/src/components/paragraph.tsx
+++ b/src/components/paragraph.tsx
@@ -4,6 +4,7 @@ import { FC, ReactNode } from 'react';
 import React, { css } from '@emotion/core';
 import { body } from '@guardian/src-foundations/typography';
 import { remSpace } from '@guardian/src-foundations';
+import { textPadding } from 'styles';
 
 
 // ----- Component ----- //
@@ -14,6 +15,7 @@ interface Props {
 
 const styles = css`
     ${body.medium()}
+    ${textPadding}
     overflow-wrap: break-word;
     margin: 0 0 ${remSpace[3]};
 `;

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import {
-    sidePadding,
     darkModeCss,
     basePx,
     adStyles
@@ -38,7 +37,6 @@ const ArticleBodyStyles = css`
     }
 
     ${adStyles}
-    ${sidePadding}
 `;
 
 const ArticleBodyDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -120,7 +120,7 @@ describe('Renders different types of elements', () => {
         const nodes = render(imageElement())
         const bodyImage = shallow(nodes.flat()[0]);
         expect(bodyImage.html()).toContain('img');
-        expect(bodyImage.html()).toContain('<figcaption>');
+        expect(bodyImage.html()).toContain('figcaption');
         expect(bodyImage.html()).toContain('caption="caption"');
         expect(bodyImage.html()).toContain('credit="credit"');
     })

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -1,7 +1,7 @@
 import { ImageElement } from './renderer';
 import { JSDOM } from 'jsdom';
 import { Pillar } from 'pillar';
-import { ReactNode } from 'react';
+import { ReactNode, createElement as h } from 'react';
 import { renderAll } from 'renderer';
 import { compose } from 'lib';
 import { ElementKind, BodyElement } from 'item';
@@ -76,10 +76,28 @@ describe('renderer returns expected content', () => {
             captionString: "caption",
             caption: JSDOM.fragment('this caption contains <em>html</em>'),
             credit: "credit",
-            pillar: Pillar.news
-
-        }
+            pillar: Pillar.news,
+        };
         expect(ImageElement(imageProps)).toBe(null);
+    });
+
+    test('ImageElement returns image', () => {
+        const imageProps = {
+            url: 'https://media.guim.co.uk/image.jpg',
+            alt: "alt",
+            salt: "salt",
+            sizes: "sizes",
+            width: 500,
+            height: 500,
+            captionString: "caption",
+            caption: JSDOM.fragment('this caption contains <em>html</em>'),
+            credit: "credit",
+            pillar: Pillar.news,
+        };
+        const image = shallow(h(ImageElement, imageProps));
+
+        expect(image.html()).toContain('img');
+        expect(image.prop('alt')).toBe('alt');
     });
 
     test('Renders supported node types for text elements', () => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -7,10 +7,11 @@ import { neutral } from '@guardian/src-foundations/palette';
 
 import { Option, fromNullable, Some, None } from 'types/option';
 import { srcset, src } from 'image';
-import { basePx, icons, headlineFont, darkModeCss, textSans } from 'styles';
+import { basePx, icons, headlineFont, darkModeCss } from 'styles';
 import { getPillarStyles, Pillar } from 'pillar';
 import { ElementKind, BodyElement } from 'item';
 import Paragraph from 'components/paragraph';
+import BodyImage from 'components/bodyImage';
 
 
 // ----- Renderer ----- //
@@ -179,10 +180,6 @@ interface ImageProps {
     pillar: Pillar;
 }
 
-type FigureElement = ImageProps & {
-    className?: SerializedStyles;
-}
-
 const imageStyles = (width: number, height: number): SerializedStyles => css`
     height: calc(100vw * ${height / width});
     background: ${neutral[97]};
@@ -210,45 +207,6 @@ const ImageElement = (props: ImageProps): ReactElement | null => {
         credit,
     });
 }
-
-const FigureElement = (props: FigureElement): ReactElement =>
-    styledH('figure', { css: props.className },
-        h(ImageElement, props),
-        h('figcaption', null, text(props.caption, props.pillar)),
-    );
-
-const bodyImageStyles = css`
-    margin-left: ${basePx(-1)};
-    margin-right: ${basePx(-1)};
-
-    ${from.phablet} {
-        margin-left: 0;
-        margin-right: 0;
-    }
-
-    ${from.wide} {
-        margin: 1em 0;
-    }
-
-    img {
-        width: 100%; 
-    }
-
-    figcaption {
-        font-size: 1.4rem;
-        line-height: 1.8rem;
-        color: ${neutral[46]};
-        ${textSans}
-
-        ${until.phablet} {
-            padding-left: ${basePx(1)};
-            padding-right: ${basePx(1)};
-        }
-    }
-`;
-
-const BodyImage = (props: Omit<FigureElement, 'sizes'>): ReactElement =>
-    h(FigureElement, { ...props, sizes: '100vw', className: bodyImageStyles });
 
 const pullquoteStyles = (colour: string): SerializedStyles => css`
     font-weight: 200;
@@ -366,16 +324,17 @@ const render = (salt: string, pillar: Pillar) => (element: BodyElement, key: num
         case ElementKind.Image:
             const { file, alt, caption, captionString, credit, width, height } = element;
             return h(BodyImage, {
-                url: file,
-                alt,
-                salt,
-                caption,
-                captionString,
-                credit,
-                key,
-                width,
-                height,
-                pillar
+                image: {
+                    url: file,
+                    alt,
+                    salt,
+                    width,
+                    height,
+                    caption: captionString,
+                    credit,
+                },
+                figcaption: text(caption, pillar),
+                pillar,
             });
 
         case ElementKind.Pullquote:


### PR DESCRIPTION
## Why are you doing this?

Creating standalone components for images in general, and the `BodyImage` in particular. This also encompasses greater integration with the design system.

**Note:** The tests are probably going to fail because of this error: `"global" coverage threshold for branches (75%) not met: 74.92%`... They are actually all passing, it's just the coverage that's unhappy.

cc @SiAdcock I've created a new SVG for the triangle on image captions: around line 62 in `BodyImage`.

## Changes

- Removed `BodyImage` and `FigureElement` from `renderer`
- Created new components: `Image` and `BodyImage`
- Migrated image helpers (e.g. `srcset`) into component
- Updated `Paragraph` to handle text padding directly
