### PR TITLE
Rename Headline Font Family

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -15,16 +15,16 @@
     @font-Face{font-family:"Guardian Text Sans Web"; font-weight:700; src:url("/assets/fonts/GuardianTextSans-Bold.ttf")}
     @font-Face{font-family:"Guardian Text Sans Web"; font-weight:700; font-style:italic; src:url("/assets/fonts/GuardianTextSans-BoldItalic.ttf")}
     
-    @font-Face{font-family:"Guardian Headline"; font-weight:300; src:url("/assets/fonts/GHGuardianHeadline-Light.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:300; font-style: italic; src:url("/assets/fonts/GHGuardianHeadline-LightItalic.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:400; src:url("/assets/fonts/GHGuardianHeadline-Regular.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:400; font-style: italic; src:url("/assets/fonts/GHGuardianHeadline-RegularItalic.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:500; src:url("/assets/fonts/GHGuardianHeadline-Medium.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:500; font-style: italic; src:url( "/assets/fonts/GHGuardianHeadline-MediumItalic.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:600; src:url("/assets/fonts/GHGuardianHeadline-Semibold.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:600; font-style: italic; src:url( "/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:700; src:url("/assets/fonts/GHGuardianHeadline-Bold.ttf")}
-    @font-Face{font-family:"Guardian Headline"; font-weight:700; font-style: italic; src:url("/assets/fonts/GHGuardianHeadline-BoldItalic.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:300; src:url("/assets/fonts/GHGuardianHeadline-Light.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:300; font-style: italic; src:url("/assets/fonts/GHGuardianHeadline-LightItalic.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:400; src:url("/assets/fonts/GHGuardianHeadline-Regular.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:400; font-style: italic; src:url("/assets/fonts/GHGuardianHeadline-RegularItalic.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:500; src:url("/assets/fonts/GHGuardianHeadline-Medium.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:500; font-style: italic; src:url( "/assets/fonts/GHGuardianHeadline-MediumItalic.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:600; src:url("/assets/fonts/GHGuardianHeadline-Semibold.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:600; font-style: italic; src:url( "/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:700; src:url("/assets/fonts/GHGuardianHeadline-Bold.ttf")}
+    @font-Face{font-family:"GH Guardian Headline"; font-weight:700; font-style: italic; src:url("/assets/fonts/GHGuardianHeadline-BoldItalic.ttf")}
 
     @font-Face{font-family:"Guardian Icons"; src:url("/assets/fonts/icons.otf")}
 

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -34,16 +34,16 @@ const PageStyles = css`
     ${fontFace("Guardian Text Sans Web", new Some(700), new None, "/assets/fonts/GuardianTextSans-Bold.ttf")}
     ${fontFace("Guardian Text Sans Web", new Some(700), new Some("italic"), "/assets/fonts/GuardianTextSans-BoldItalic.ttf")}
 
-    ${fontFace("Guardian Headline", new Some(300), new None, "/assets/fonts/GHGuardianHeadline-Light.ttf")}
-    ${fontFace("Guardian Headline", new Some(300), new Some("italic"), "/assets/fonts/GHGuardianHeadline-LightItalic.ttf")}
-    ${fontFace("Guardian Headline", new Some(400), new None, "/assets/fonts/GHGuardianHeadline-Regular.ttf")}
-    ${fontFace("Guardian Headline", new Some(400), new Some("italic"), "/assets/fonts/GHGuardianHeadline-RegularItalic.ttf")}
-    ${fontFace("Guardian Headline", new Some(500), new None,  "/assets/fonts/GHGuardianHeadline-Medium.ttf")}
-    ${fontFace("Guardian Headline", new Some(500), new Some("italic"),  "/assets/fonts/GHGuardianHeadline-MediumItalic.ttf")}
-    ${fontFace("Guardian Headline", new Some(600), new None,  "/assets/fonts/GHGuardianHeadline-Semibold.ttf")}
-    ${fontFace("Guardian Headline", new Some(600), new Some("italic"),  "/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf")}
-    ${fontFace("Guardian Headline", new Some(700), new None, "/assets/fonts/GHGuardianHeadline-Bold.ttf")}
-    ${fontFace("Guardian Headline", new Some(700), new Some("italic"), "/assets/fonts/GHGuardianHeadline-BoldItalic.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(300), new None, "/assets/fonts/GHGuardianHeadline-Light.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(300), new Some("italic"), "/assets/fonts/GHGuardianHeadline-LightItalic.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(400), new None, "/assets/fonts/GHGuardianHeadline-Regular.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(400), new Some("italic"), "/assets/fonts/GHGuardianHeadline-RegularItalic.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(500), new None,  "/assets/fonts/GHGuardianHeadline-Medium.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(500), new Some("italic"),  "/assets/fonts/GHGuardianHeadline-MediumItalic.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(600), new None,  "/assets/fonts/GHGuardianHeadline-Semibold.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(600), new Some("italic"),  "/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(700), new None, "/assets/fonts/GHGuardianHeadline-Bold.ttf")}
+    ${fontFace("GH Guardian Headline", new Some(700), new Some("italic"), "/assets/fonts/GHGuardianHeadline-BoldItalic.ttf")}
 
     ${fontFace("Guardian Icons", new None, new None, "/assets/fonts/icons.otf")}
 


### PR DESCRIPTION
## Why are you doing this?

Our headline font was named differently to the one in the design system, which meant it wasn't loading and we were falling back to Georgia instead. For more information see [this design system PR](https://github.com/guardian/source/pull/291).

## Changes

- Renamed "Guardian Headline" to "GH Guardian Headline" for the app and for storybook

## Screenshots

| Before | After |
| --- | --- |
| ![headline-before](https://user-images.githubusercontent.com/53781962/77410162-64256500-6db2-11ea-8057-2df74605ca87.jpg) | ![headline-after](https://user-images.githubusercontent.com/53781962/77410154-62f43800-6db2-11ea-9f2e-7836950629fb.jpg) |
