### PR TITLE
default to opinion when news pillar used

### DIFF
--- a/src/item.ts
+++ b/src/item.ts
@@ -427,9 +427,11 @@ const fromCapi = (docParser: DocParser) => (content: Content): Item => {
             ...itemFieldsWithBody(docParser, content),
         };
     } else if (isComment(tags)) {
+        const item = itemFieldsWithBody(docParser, content);
         return {
             design: Design.Comment,
-            ...itemFieldsWithBody(docParser, content),
+            ...item,
+            pillar: item.pillar === Pillar.news ? Pillar.opinion : item.pillar
         };
     } else if (isFeature(tags)) {
         return {


### PR DESCRIPTION
## Why are you doing this?
I've never seen an Opinion article with news pillar styles. It is possible to use sports pillar colours: http://localhost:8080/football/commentisfree/2019/dec/18/mesut-ozil-china-row-western-brands-be-warned-self-censorship-wont-protect-you

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/77451581-c26f3980-6dec-11ea-9e44-9ba18676b056.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/77451616-ce5afb80-6dec-11ea-80f9-8b8e6ad240a2.png" width="300px" /> |

