### PR TITLE
only request necessary CAPI fields

### DIFF
--- a/src/capi.test.ts
+++ b/src/capi.test.ts
@@ -6,6 +6,6 @@ describe('server logic runs as expected', () => {
         const key = 'TEST_KEY';
         const capiUrl = capiEndpoint(articleId, key);
 
-        expect(capiUrl).toEqual('https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=all&show-tags=all&show-blocks=all&show-elements=all');
+        expect(capiUrl).toEqual('https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue&show-tags=all&show-blocks=all&show-elements=all');
     });
 });

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -102,11 +102,20 @@ const includesTweets = (content: Content): boolean => {
 
 const capiEndpoint = (articleId: string, key: string): string => {
 
+    const fields = [
+        'headline',
+        'standfirst',
+        'bylineHtml',
+        'firstPublicationDate',
+        'shouldHideAdverts',
+        'shouldHideReaderRevenue'
+    ];
+
     const params = new URLSearchParams({
       format: 'thrift',
       'api-key': key,
       'show-atoms': 'all',
-      'show-fields': 'all',
+      'show-fields': fields.join(','),
       'show-tags': 'all',
       'show-blocks': 'all',
       'show-elements': 'all',

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -101,7 +101,7 @@ const includesTweets = (content: Content): boolean => {
 // ----- Functions ----- //
 
 const capiEndpoint = (articleId: string, key: string): string => {
-
+    // If you need a new field here, MAPI probably also needs updating
     const fields = [
         'headline',
         'standfirst',


### PR DESCRIPTION
## Why are you doing this?
Request only what we need from Capi. This is only for local development but it should match prod in Mapi (PR in progress)