### PR TITLE
make paragraph styles specific to body

### DIFF
--- a/src/components/paragraph.tsx
+++ b/src/components/paragraph.tsx
@@ -1,7 +1,9 @@
 // ----- Imports ----- //
 
 import { FC, ReactNode } from 'react';
-import React from '@emotion/core';
+import React, { css } from '@emotion/core';
+import { body } from '@guardian/src-foundations/typography';
+import { remSpace } from '@guardian/src-foundations';
 
 // ----- Component ----- //
 
@@ -9,8 +11,14 @@ interface Props {
     children?: ReactNode;
 }
 
+const styles = css`
+    ${body.medium()};
+    overflow-wrap: break-word;
+    margin: 0 0 ${remSpace[3]};
+`;
+
 const Paragraph: FC<Props> = ({ children }: Props) =>
-    <p>{children}</p>;
+    <p css={styles}>{children}</p>;
 
 
 // ----- Exports ----- //

--- a/src/components/paragraph.tsx
+++ b/src/components/paragraph.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
-import { FC, ReactNode } from 'react';
-import React, { css } from '@emotion/core';
+import React, { FC, ReactNode } from 'react';
+import { css } from '@emotion/core';
 import { body } from '@guardian/src-foundations/typography';
 import { remSpace } from '@guardian/src-foundations';
 

--- a/src/components/paragraph.tsx
+++ b/src/components/paragraph.tsx
@@ -1,10 +1,7 @@
 // ----- Imports ----- //
 
 import { FC, ReactNode } from 'react';
-import React, { css } from '@emotion/core';
-import { body } from '@guardian/src-foundations/typography';
-import { remSpace } from '@guardian/src-foundations';
-
+import React from '@emotion/core';
 
 // ----- Component ----- //
 
@@ -12,14 +9,8 @@ interface Props {
     children?: ReactNode;
 }
 
-const styles = css`
-    ${body.medium()}
-    overflow-wrap: break-word;
-    margin: 0 0 ${remSpace[3]};
-`;
-
 const Paragraph: FC<Props> = ({ children }: Props) =>
-    <p css={styles}>{children}</p>;
+    <p>{children}</p>;
 
 
 // ----- Exports ----- //

--- a/src/components/paragraph.tsx
+++ b/src/components/paragraph.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const styles = css`
-    ${body.medium()};
+    ${body.medium()}
     overflow-wrap: break-word;
     margin: 0 0 ${remSpace[3]};
 `;

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -8,8 +8,6 @@ import {
 import { neutral, background } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
-import { body } from '@guardian/src-foundations/typography';
-import { remSpace } from '@guardian/src-foundations';
 
 const richLinkWidth = "13.75rem";
 
@@ -42,12 +40,6 @@ const ArticleBodyStyles = css`
 
     twitter-widget {
         margin: 1rem 0;
-    }
-
-    p {
-        ${body.medium()}
-        overflow-wrap: break-word;
-        margin: 0 0 ${remSpace[3]};
     }
 `;
 

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -8,6 +8,8 @@ import {
 import { neutral, background } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { PillarStyles, Pillar, getPillarStyles } from 'pillar';
+import { body } from '@guardian/src-foundations/typography';
+import { remSpace } from '@guardian/src-foundations';
 
 const richLinkWidth = "13.75rem";
 
@@ -40,6 +42,12 @@ const ArticleBodyStyles = css`
 
     twitter-widget {
         margin: 1rem 0;
+    }
+
+    p {
+        ${body.medium()}
+        overflow-wrap: break-word;
+        margin: 0 0 ${remSpace[3]};
     }
 `;
 

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -8,7 +8,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { remSpace } from '@guardian/src-foundations';
 
 import { Item, Design, Display } from 'item';
-import { renderText } from 'renderer';
+import { renderText, renderStandfirstText } from 'renderer';
 import { darkModeCss as darkMode } from 'styles';
 import { PillarStyles, getPillarStyles } from 'pillar';
 
@@ -86,7 +86,7 @@ const getStyles = (item: Item): SerializedStyles => {
 }
 
 function content(standfirst: DocumentFragment, item: Item): ReactNode {
-    const rendered = renderText(standfirst, item.pillar);
+    const rendered = renderStandfirstText(standfirst, item.pillar);
 
     // Immersives append the byline to the standfirst.
     // Sometimes CAPI includes this within the standfirst HTML,

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -1,4 +1,4 @@
-import { ImageElement } from './renderer';
+import { ImageElement, renderStandfirstText, renderText } from './renderer';
 import { JSDOM } from 'jsdom';
 import { Pillar } from 'pillar';
 import { ReactNode, createElement as h } from 'react';
@@ -6,8 +6,8 @@ import { renderAll } from 'renderer';
 import { compose } from 'lib';
 import { ElementKind, BodyElement, Role } from 'item';
 import { shallow, configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
 import { None, Some } from 'types/option';
+import Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
 
@@ -192,4 +192,20 @@ describe('Renders different types of elements', () => {
         const instagram = shallow(nodes.flat()[0]);
         expect(instagram.html()).toBe('<div><blockquote>Instagram</blockquote></div>');
     })
+});
+
+describe('Paragraph tags rendered correctly', () => {
+    test('Contains no styles in standfirsts', () => {
+        const fragment = JSDOM.fragment('<p>Parapraph tag</p><span>1</span>');
+        const nodes = renderStandfirstText(fragment, Pillar.news);
+        const html = shallow(nodes.flat()[0]).html();
+        expect(html).toBe('<p>Parapraph tag</p>')
+    });
+
+    test('Contains styles in article body', () => {
+        const fragment = JSDOM.fragment('<p>Parapraph tag</p><span>1</span>');
+        const nodes = renderText(fragment, Pillar.news);
+        const html = shallow(nodes.flat()[0]).html();
+        expect(html).not.toBe('<p>Parapraph tag</p>')
+    });
 });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -145,7 +145,7 @@ const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => 
         case '#text':
             return transform(text, pillar);
         case 'SPAN':
-            return h('span', null, text);
+            return text;
         case 'A':
             return h(Anchor, { href: getHref(node).withDefault(''), text, pillar, key }, children);
         case 'H2':

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -9,12 +9,11 @@ import { srcset, src } from 'image';
 import { basePx, icons, darkModeCss } from 'styles';
 import { getPillarStyles, Pillar } from 'pillar';
 import { ElementKind, BodyElement, Role } from 'item';
+import { headline, body } from '@guardian/src-foundations/typography';
+import { remSpace } from '@guardian/src-foundations';
 import Paragraph from 'components/paragraph';
 import BodyImage from 'components/bodyImage';
 import BodyImageThumbnail from 'components/bodyImageThumbnail';
-import { headline, body } from '@guardian/src-foundations/typography';
-import { remSpace } from '@guardian/src-foundations';
-
 
 // ----- Renderer ----- //
 
@@ -146,7 +145,7 @@ const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => 
         case '#text':
             return transform(text, pillar);
         case 'SPAN':
-            return text;
+            return h('span', null, text);
         case 'A':
             return h(Anchor, { href: getHref(node).withDefault(''), text, pillar, key }, children);
         case 'H2':

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -137,16 +137,6 @@ const TweetStyles = css`
     }
 `;
 
-const standfirstTextElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {
-    const children = Array.from(node.childNodes).map(textElement(pillar));
-    switch (node.nodeName) {
-        case 'P':
-            return h('p', { key }, children);
-        default:
-            return textElement(pillar)(node, key);
-    }
-}
-
 const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {
     const text = node.textContent ?? '';
     const children = Array.from(node.childNodes).map(textElement(pillar));
@@ -177,6 +167,16 @@ const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => 
             return styledH('mark', { key }, children);
         default:
             return null;
+    }
+}
+
+const standfirstTextElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {
+    const children = Array.from(node.childNodes).map(textElement(pillar));
+    switch (node.nodeName) {
+        case 'P':
+            return h('p', { key }, children);
+        default:
+            return textElement(pillar)(node, key);
     }
 }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -137,6 +137,16 @@ const TweetStyles = css`
     }
 `;
 
+const standfirstTextElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {
+    const children = Array.from(node.childNodes).map(textElement(pillar));
+    switch (node.nodeName) {
+        case 'P':
+            return h('p', { key }, children);
+        default:
+            return textElement(pillar)(node, key);
+    }
+}
+
 const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {
     const text = node.textContent ?? '';
     const children = Array.from(node.childNodes).map(textElement(pillar));
@@ -172,6 +182,9 @@ const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => 
 
 const text = (doc: DocumentFragment, pillar: Pillar): ReactNode[] =>
     Array.from(doc.childNodes).map(textElement(pillar));
+
+const standfirstText = (doc: DocumentFragment, pillar: Pillar): ReactNode[] =>
+    Array.from(doc.childNodes).map(standfirstTextElement(pillar));
 
 interface ImageProps {
     url: string;
@@ -378,5 +391,6 @@ const renderAll = (salt: string) => (pillar: Pillar, elements: BodyElement[]): R
 export {
     renderAll,
     text as renderText,
+    standfirstText as renderStandfirstText,
     ImageElement,
 };


### PR DESCRIPTION
## Why are you doing this?
Some paragraphs outside of the article body have their styles overridden by component styles.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/77767446-fe96da00-7038-11ea-89b3-5ec583b071ad.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/77767470-08204200-7039-11ea-8a9b-85c5e762c9e6.png" width="300px" /> |