### PR TITLE
line height tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3927,9 +3927,9 @@
       }
     },
     "@guardian/src-foundations": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-0.14.1.tgz",
-      "integrity": "sha512-FiH2nsPvHS6wG7b0AePXTGbDCIV+q0aRHZKhsH2X2WeS9K3fZqEF9y+8lTv22nW3r3sv6nSyh4tT7y5+XPC9pA=="
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-0.16.1.tgz",
+      "integrity": "sha512-E6YDqq53gy5CoO8xFPWDBjiYiI0o+4BE1/mFcwkpWGwtpkSnxi21LhkaQ63r+KRxoDB29clc86ChbNHXw9keFA=="
     },
     "@guardian/src-svgs": {
       "version": "0.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3927,9 +3927,9 @@
       }
     },
     "@guardian/src-foundations": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-0.16.1.tgz",
-      "integrity": "sha512-E6YDqq53gy5CoO8xFPWDBjiYiI0o+4BE1/mFcwkpWGwtpkSnxi21LhkaQ63r+KRxoDB29clc86ChbNHXw9keFA=="
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-0.14.2.tgz",
+      "integrity": "sha512-e+yrYM2WRRb5C4BkJuGstTbaPTn7WS+TdKT2LoxwYBlXWSM3qrHOOFHCTc97uuEgT5E39GqzA/6oScrwmSr9BA=="
     },
     "@guardian/src-svgs": {
       "version": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/node-riffraff-artifact": "^0.1.7",
     "@guardian/src-button": "^0.13.0",
-    "@guardian/src-foundations": "^0.14.1",
+    "@guardian/src-foundations": "^0.16.1",
     "@types/jsdom": "^12.2.4",
     "@types/uuid": "^3.4.6",
     "aws-sdk": "^2.604.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/node-riffraff-artifact": "^0.1.7",
     "@guardian/src-button": "^0.13.0",
-    "@guardian/src-foundations": "^0.16.1",
+    "@guardian/src-foundations": "^0.14.1",
     "@types/jsdom": "^12.2.4",
     "@types/uuid": "^3.4.6",
     "aws-sdk": "^2.604.0",

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -52,7 +52,7 @@ const bulletStyles = (colour: string): SerializedStyles => css`
 const Bullet = (props: { pillar: Pillar; text: string }): ReactElement =>
     styledH('p', { css: css`display: inline; ${body.medium({ lineHeight: 'loose' })} overflow-wrap: break-word; margin: 0 0 ${remSpace[3]};` },
         styledH('span', { css: bulletStyles(getPillarStyles(props.pillar).kicker) }, '•'),
-        props.text.replace(/•/, ''),
+        props.text.replace(/•/g, ''),
         null
     );
 
@@ -96,12 +96,11 @@ const listStyles: SerializedStyles = css`
     list-style: none;
     margin: ${remSpace[2]} 0;
     padding-left: 0;
-    {remSpace[2]};
 `
 
 const listItemStyles: SerializedStyles = css`
-    padding-left: 2rem;
-    padding-bottom: ${remSpace[2]};
+    padding-left: ${remSpace[4]};
+    padding-bottom: .375rem;
 
     &::before {
         display: inline-block;
@@ -109,9 +108,9 @@ const listItemStyles: SerializedStyles = css`
         border-radius: .5rem;
         height: 1rem;
         width: 1rem;
-        margin-right: 1rem;
+        margin-right: ${remSpace[2]};
         background-color: ${neutral[86]};
-        margin-left: -2rem;
+        margin-left: -${remSpace[4]};
         vertical-align: middle;
     }
 
@@ -122,7 +121,7 @@ const listItemStyles: SerializedStyles = css`
 `
 
 const HeadingTwoStyles = css`
-    font-size: 1.4rem;
+    font-size: 1.25rem;
     font-weight: 700;
     margin: 1rem 0 4px 0;
 
@@ -242,7 +241,7 @@ const pullquoteStyles = (colour: string): SerializedStyles => css`
         &::before {
             ${icons}
             font-size: 1.5rem;
-            line-height: 1.15;
+            line-height: 1.2;
             font-weight: 300;
             content: '\\e11c';
             display: inline-block;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -121,8 +121,7 @@ const listItemStyles: SerializedStyles = css`
 `
 
 const HeadingTwoStyles = css`
-    font-size: 1.25rem;
-    font-weight: 700;
+    ${headline.xxsmall({ fontWeight: 'bold' })}
     margin: 1rem 0 4px 0;
 
     & + p {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -99,7 +99,7 @@ const listStyles: SerializedStyles = css`
 `
 
 const listItemStyles: SerializedStyles = css`
-    padding-left: ${remSpace[4]};
+    padding-left: 1rem;
     padding-bottom: .375rem;
 
     &::before {
@@ -110,7 +110,7 @@ const listItemStyles: SerializedStyles = css`
         width: 1rem;
         margin-right: ${remSpace[2]};
         background-color: ${neutral[86]};
-        margin-left: -${remSpace[4]};
+        margin-left: -1rem;
         vertical-align: middle;
     }
 


### PR DESCRIPTION
## Changes

- Less space between bullet and text
- bullet points slightly closer (matches dotcom)
- Small increase to line-height in standfirst (matches dotcom)
- Smaller h2 font size (matches dotcom)
- Replace all bullets in transform. Some article use bullet points as article breaks http://localhost:8080/world/2020/apr/01/golden-eagles-us-dying-why

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/78140967-b7d32680-7422-11ea-8ac0-1d36c4a75097.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/78140985-befa3480-7422-11ea-8c67-e661d5613ea2.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/78141008-c6b9d900-7422-11ea-9b20-522dabf4511b.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/78141035-cfaaaa80-7422-11ea-9e3c-360fd5f0ae94.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/78141053-d6d1b880-7422-11ea-96f2-d951fdc9e30f.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/78141072-ddf8c680-7422-11ea-9695-4195ff7ac8f1.png" width="300px" /> |

