### PR TITLE
add figcaptions to thumbnail images

### DIFF
--- a/src/components/bodyImageThumbnail.tsx
+++ b/src/components/bodyImageThumbnail.tsx
@@ -1,9 +1,12 @@
 // ----- Imports ----- //
 
 import React, { FC, ReactNode } from 'react';
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import Image, { Props as ImageProps } from 'components/image';
-import { Pillar } from 'pillar';
+import { Pillar, PillarStyles, getPillarStyles } from 'pillar';
+import { remSpace, text } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+import { from } from '@guardian/src-foundations/mq';
 
 // ----- Setup ----- //
 
@@ -20,13 +23,43 @@ interface Props {
 
 const styles = css`
     display: block;
-    margin: 1rem 0 0 0;
+    float: left;
+    clear: left;
+    width: 8.75rem;
+    margin: 0 ${remSpace[3]} 0 0;
+
+    ${from.wide} {
+        margin-left: calc(-8.75rem - ${remSpace[3]} - ${remSpace[2]});
+        margin-right: 0;
+        padding: 0;
+    }
 `;
 
+const triangleStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
+    fill: ${kicker};
+    height: 0.8em;
+    padding-right: ${remSpace[1]};
+`;
 
-const BodyImageThumbnail: FC<Props> = ({ image }: Props) =>
+const captionStyles = css`
+    ${textSans.xsmall()}
+    padding-top: ${remSpace[2]};
+    color: ${text.supporting};
+`;
+
+const BodyImageThumbnail: FC<Props> = ({ image, figcaption, pillar }: Props) =>
     <figure css={styles}>
         <Image {...image} sizes={sizes} thumbnail={true} />
+        <figcaption css={captionStyles}>
+            <svg
+                css={triangleStyles(getPillarStyles(pillar))}
+                viewBox="0 0 10 9"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <polygon points="0,9 5,0 10,9 0,9" />
+            </svg>
+            {figcaption}
+        </figcaption>
     </figure>
 
 

--- a/src/components/image.ts
+++ b/src/components/image.ts
@@ -78,17 +78,7 @@ const standardStyles = (width: number, height: number): SerializedStyles => css`
 `;
 
 const thumbnailStyles = (width: number, height: number): SerializedStyles => css`
-    float: left;
-    clear: left;
-    width: 8.75rem;
     height: calc(8.75rem * ${height / width});
-    margin: 0 ${remSpace[3]} 0 ${remSpace[2]};
-
-    ${from.wide} {
-        margin-left: calc(-8.75rem - ${remSpace[3]} - ${remSpace[2]});
-        margin-right: 0;
-        padding: 0;
-    }
 `;
 
 const Image: FC<Props> = (props) => {

--- a/src/components/image.ts
+++ b/src/components/image.ts
@@ -7,7 +7,6 @@ import { createHash } from 'crypto';
 import { from } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
 import { ImageMappings } from './shared/page';
-import { remSpace } from '@guardian/src-foundations';
 
 // ----- Setup ----- //
 


### PR DESCRIPTION
## Why are you doing this?
Thumbnail images can have captions too. This will probably conflict with the gallery work and we might be able to refactor it afterwards.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/78157630-1787fc80-7438-11ea-8dfe-dd20c7ce4eda.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/78157673-279fdc00-7438-11ea-9c04-12126cfdad00.png" width="300px" /> |