### PR TITLE
Expand ESLint Ruleset

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -1,23 +1,27 @@
 module.exports =  {
-    parser:  '@typescript-eslint/parser',  // Specifies the ESLint parser
-    extends:  [
-        'plugin:react/recommended',  // Uses the recommended rules from @eslint-plugin-react
-        'plugin:@typescript-eslint/recommended',  // Uses the recommended rules from @typescript-eslint/eslint-plugin
-        'plugin:jsx-a11y/recommended'
+    parser: '@typescript-eslint/parser',
+    extends: [
+        'plugin:@typescript-eslint/recommended',
+        'plugin:react/recommended',
+        'plugin:jsx-a11y/recommended',
     ],
-    parserOptions:  {
-        ecmaVersion:  2018,  // Allows for the parsing of modern ECMAScript features
-        sourceType:  'module',  // Allows for the use of imports
-        ecmaFeatures:  {
-            jsx:  true,  // Allows for the parsing of JSX
+    parserOptions: {
+        // Allows for the parsing of modern ECMAScript features
+        ecmaVersion: 2018,
+        // Allows for the use of imports
+        sourceType: 'module',
+        ecmaFeatures: {
+            // Allows for the parsing of JSX
+            jsx:  true,
         },
     },
-    rules:  {
-        // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-        // e.g. "@typescript-eslint/explicit-function-return-type": "off",
-        "@typescript-eslint/no-unused-vars": "off",
+    rules: {
+        // Triple-equals equality in JS
+        'eqeqeq': 'error',
+        // Avoid let when variable is never re-assigned
+        'prefer-const': 'error',
         'max-len': [
-            "error",
+            'error',
             {
                 code: 100,
                 ignoreStrings: true,
@@ -25,14 +29,13 @@ module.exports =  {
                 ignoreUrls: true,
             },
         ],
-        '@typescript-eslint/explicit-function-return-type': 2,
-        'eqeqeq': 2,
-        'prefer-const': 2,
+        '@typescript-eslint/no-unused-vars': 'off',
+        '@typescript-eslint/explicit-function-return-type': 'error',
     },
-    settings:  {
-        react:  {
-            version:  'detect',  // Tells eslint-plugin-react to automatically detect the version of React to use
+    settings: {
+        react: {
+            // Tells eslint-plugin-react to automatically detect the version of React to use
+            version: 'detect',
         },
     },
 };
-  

--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -1,6 +1,8 @@
 module.exports =  {
     parser: '@typescript-eslint/parser',
     extends: [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
         'plugin:react/recommended',
         'plugin:jsx-a11y/recommended',

--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports =  {
         'eslint:recommended',
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
+        'plugin:@typescript-eslint/recommended-requiring-type-checking',
         'plugin:react/recommended',
         'plugin:jsx-a11y/recommended',
     ],
@@ -16,6 +17,7 @@ module.exports =  {
             // Allows for the parsing of JSX
             jsx:  true,
         },
+        project: 'tsconfig.json',
     },
     rules: {
         // Triple-equals equality in JS

--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -16,7 +16,7 @@ import { darkModeCss } from 'styles';
 
 interface Props extends Format {
     bylineHtml: Option<DocumentFragment>;
-};
+}
 
 const styles = (kicker: string): SerializedStyles => css`
     ${headline.xxxsmall()}
@@ -53,6 +53,7 @@ const anchorStyles = (kicker: string, inverted: string): SerializedStyles => css
 
 const getStyles = (format: Format): SerializedStyles => {
     const { kicker } = getPillarStyles(format.pillar);
+
     switch (format.design) {
         case Design.Comment:
             return commentStyles;
@@ -62,17 +63,23 @@ const getStyles = (format: Format): SerializedStyles => {
     }
 }
 
-const toReact = (format: Format) => (node: Node): ReactNode => {
+const getAnchorStyles = (format: Format): SerializedStyles => {
     const { kicker, inverted } = getPillarStyles(format.pillar);
 
+    switch (format.design) {
+        case Design.Comment:
+            return commentAnchorStyles(kicker, inverted);
+        
+        default:
+            return anchorStyles(kicker, inverted);
+    }
+}
+
+const toReact = (format: Format) => (node: Node): ReactNode => {
     switch (node.nodeName) {
         case 'A':
-            const anchor = format.design === Design.Comment
-                ? commentAnchorStyles
-                : anchorStyles
-
             return (
-                <a href={getHref(node).withDefault('')} css={anchor(kicker, inverted)}>
+                <a href={getHref(node).withDefault('')} css={getAnchorStyles(format)}>
                     {node.textContent ?? ''}
                 </a>
             );

--- a/src/components/shared/epic.tsx
+++ b/src/components/shared/epic.tsx
@@ -100,7 +100,7 @@ function Epic({ title, body, firstButton, secondButton }: EpicProps): React.Reac
         }
     }, [impressionSeen]);
 
-    const epicButton = (text: string, action: () => void): JSX.Element =>
+    const epicButton = (text: string, action: () => Promise<void>): JSX.Element =>
         <Button onClick={action} iconSide="right" icon={<SvgArrowRightStraight />}>
             {text}
         </Button>

--- a/src/components/shared/epic.tsx
+++ b/src/components/shared/epic.tsx
@@ -102,7 +102,7 @@ function Epic({ title, body, firstButton, secondButton }: EpicProps): React.Reac
 
     const epicButton = (text: string, action: () => void): JSX.Element =>
         <Button onClick={action} iconSide="right" icon={<SvgArrowRightStraight />}>
-	        {text}
+            {text}
         </Button>
 
     return (

--- a/src/components/shared/leftColumn.tsx
+++ b/src/components/shared/leftColumn.tsx
@@ -44,7 +44,7 @@ interface LeftColumnProps {
     children: React.ReactNode;
     columnContent?: JSX.Element | null;
     className?: SerializedStyles | null;
-};
+}
 
 
 // ----- Component ----- //

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -165,7 +165,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
 
     const insertAdPlaceholders = getAdPlaceholderInserter(capi.fields?.shouldHideAdverts ?? false);
 
-    const item = fromCapi(JSDOM.fragment)(capi);
+    const item = fromCapi(JSDOM.fragment.bind(null))(capi);
     const imageMappings = getImageMappings(imageSalt, capi);
 
     const articleScript = getAssetLocation('article.js');

--- a/src/item.ts
+++ b/src/item.ts
@@ -246,82 +246,110 @@ const parseIframe = (docParser: DocParser) =>
 const parseElement =
     (docParser: DocParser) => (element: BlockElement): Result<string, BodyElement> => {
     switch (element.type) {
-        case ElementType.TEXT:
+
+        case ElementType.TEXT: {
             const html = element?.textTypeData?.html;
+
             if (!html) {
-                return new Err('No html field on textTypeData')
+                return new Err('No html field on textTypeData');
             }
+
             return new Ok({ kind: ElementKind.Text, doc: docParser(html) });
+        }
 
         case ElementType.IMAGE:
             return parseImage(docParser)(element)
                 .fmap<Result<string, Image>>(image => new Ok(image))
                 .withDefault(new Err('I couldn\'t find a master asset'));
 
-        case ElementType.PULLQUOTE:
+        case ElementType.PULLQUOTE: {
             const { html: quote, attribution } = element.pullquoteTypeData ?? {};
+
             if (!quote) {
-                return new Err('No quote field on pullquoteTypeData')
+                return new Err('No quote field on pullquoteTypeData');
             }
+
             return new Ok({
                 kind: ElementKind.Pullquote,
                 quote,
                 attribution: fromNullable(attribution),
             });
+        }
 
-        case ElementType.INTERACTIVE:
+        case ElementType.INTERACTIVE: {
             const { iframeUrl } = element.interactiveTypeData ?? {};
-            if (!iframeUrl) {
-                return new Err('No iframeUrl field on interactiveTypeData')
-            }
-            return new Ok({ kind: ElementKind.Interactive, url: iframeUrl });
 
-        case ElementType.RICH_LINK:
+            if (!iframeUrl) {
+                return new Err('No iframeUrl field on interactiveTypeData');
+            }
+
+            return new Ok({ kind: ElementKind.Interactive, url: iframeUrl });
+        }
+
+        case ElementType.RICH_LINK: {
             const { url, linkText } = element.richLinkTypeData ?? {};
+
             if (!url) {
                 return new Err('No "url" field on richLinkTypeData');
             } else if (!linkText) {
                 return new Err('No "linkText" field on richLinkTypeData');
             }
-            return new Ok({ kind: ElementKind.RichLink, url, linkText });
 
-        case ElementType.TWEET:
+            return new Ok({ kind: ElementKind.RichLink, url, linkText });
+        }
+
+        case ElementType.TWEET: {
             const { id, html: h } = element.tweetTypeData ?? {};
+
             if (!id) {
                 return new Err('No "id" field on tweetTypeData')
             } else if (!h) {
                 return new Err('No "html" field on tweetTypeData')
             }
+
             return tweetContent(id, docParser(h))
                 .fmap(content => ({ kind: ElementKind.Tweet, content }));
+        }
 
-        case ElementType.EMBED:
+        case ElementType.EMBED: {
             const { html: embedHtml } = element.embedTypeData ?? {};
+
             if (!embedHtml) {
                 return new Err('No html field on embedTypeData')
             }
-            return new Ok({ kind: ElementKind.Embed, html: embedHtml });
 
-        case ElementType.INSTAGRAM:
+            return new Ok({ kind: ElementKind.Embed, html: embedHtml });
+        }
+
+        case ElementType.INSTAGRAM: {
             const { html: instagramHtml } = element.instagramTypeData ?? {};
+
             if (!instagramHtml) {
                 return new Err('No html field on instagramTypeData')
             }
-            return new Ok({ kind: ElementKind.Instagram, html: instagramHtml });
 
-        case ElementType.AUDIO:
+            return new Ok({ kind: ElementKind.Instagram, html: instagramHtml });
+        }
+
+        case ElementType.AUDIO: {
             const { html: audioHtml } = element.audioTypeData ?? {};
+
             if (!audioHtml) {
                 return new Err('No html field on audioTypeData')
             }
-            return parseIframe(docParser)(audioHtml, ElementKind.Audio);
 
-        case ElementType.VIDEO:
+            return parseIframe(docParser)(audioHtml, ElementKind.Audio);
+        }
+
+        case ElementType.VIDEO: {
             const { html: videoHtml } = element.videoTypeData ?? {};
+
             if (!videoHtml) {
                 return new Err('No html field on videoTypeData')
             }
+
             return parseIframe(docParser)(videoHtml, ElementKind.Video);
+        }
 
         default:
             return new Err(`I'm afraid I don't understand the element I was given: ${element.type}`);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -406,7 +406,7 @@ const render = (pillar: Pillar, imageMappings: ImageMappings) =>
         case ElementKind.Text:
             return text(element.doc, pillar);
 
-        case ElementKind.Image:
+        case ElementKind.Image: {
             const { file, alt, caption, captionString, credit, width, height, role } = element;
             const ImageComponent = role
                 .fmap(imageRole => imageRole === Role.Thumbnail ? BodyImageThumbnail : BodyImage)
@@ -428,14 +428,19 @@ const render = (pillar: Pillar, imageMappings: ImageMappings) =>
                 text: text(caption, pillar)
             })
             );
+        }
 
-        case ElementKind.Pullquote:
+        case ElementKind.Pullquote: {
             const { quote, attribution } = element;
-            return h(Pullquote, { quote, attribution, pillar, key });
 
-        case ElementKind.RichLink:
+            return h(Pullquote, { quote, attribution, pillar, key });
+        }
+
+        case ElementKind.RichLink: {
             const { url, linkText } = element;
+
             return h(RichLink, { url, linkText, pillar, key });
+        }
 
         case ElementKind.Interactive:
             return h(Interactive, { url: element.url, key });
@@ -450,13 +455,15 @@ const render = (pillar: Pillar, imageMappings: ImageMappings) =>
             return h(Video, { src: element.src, width: element.width, height: element.height })
 
         case ElementKind.Embed:
-        case ElementKind.Instagram:
+        case ElementKind.Instagram: {
             const props = {
                 dangerouslySetInnerHTML: {
                   __html: element.html,
                 },
             };
+
             return h('div', props);
+        }
     }
 };
 


### PR DESCRIPTION
## Why are you doing this?

It allows the linter to do more for us: keeping our code style more consistent and catching possible bugs. It also brings our lint rules more in line with DCR.

**Note:** It might be helpful to look through this commit-by-commit to break out refactorings from actual changes. Each of the points in the section below below corresponds to a specific commit.

## Changes

- Tidied up the `eslintrc` file
- Added the ESLint recommended rules and fixed errors
- Added a type-checked version of the recommended rules and fixed errors
