### PR TITLE
increase cutout image width

### DIFF
--- a/src/components/opinion/cutout.tsx
+++ b/src/components/opinion/cutout.tsx
@@ -10,7 +10,7 @@ import { ImageMappings } from 'components/shared/page';
 
 // ----- Constants ----- //
 
-const imageWidth = 68;
+const imageWidth = 100;
 
 
 // ----- Styles ----- //
@@ -23,7 +23,7 @@ const ImageStyles = css`
     position: absolute;
     height: 160px;
     right: 0;
-    top: -54px;
+    top: -48px;
 `;
 
 

--- a/src/components/shared/keyline.tsx
+++ b/src/components/shared/keyline.tsx
@@ -35,7 +35,7 @@ const KeylineNewsStyles = css`
 const KeylineOpinionStyles = css`
     background-image: repeating-linear-gradient(${neutral[86]}, ${neutral[86]} 1px, transparent 1px, transparent 3px);
     height: 24px;
-    margin-top: 84px;
+    margin-top: 90px;
 `;
 
 const KeylineDarkStyles = darkModeCss`


### PR DESCRIPTION
## Why are you doing this?
Cutout images were low quality compared to dotcom and templates. Also added some more space between the top of the cutout and the headline.
