### PR TITLE
Separate Format Module

### DIFF
--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -5,7 +5,7 @@ import { css, SerializedStyles } from '@emotion/core';
 
 import { srcsetWithWidths, src } from 'image';
 import { Contributor, isSingleContributor } from 'contributor';
-import { Format } from 'item';
+import { Format } from 'format';
 import { getPillarStyles } from 'pillar';
 import { ImageMappings } from 'components/shared/page';
 

--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -4,7 +4,7 @@ import React, { FC, ReactElement, ReactNode } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { headline } from '@guardian/src-foundations/typography';
 
-import { Design, Format } from 'item';
+import { Design, Format } from 'format';
 import { Option } from 'types/option';
 import { neutral } from '@guardian/src-foundations';
 import { getPillarStyles } from 'pillar';

--- a/src/components/commentCount.tsx
+++ b/src/components/commentCount.tsx
@@ -6,7 +6,7 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { border } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 
-import { Format } from 'item';
+import { Format } from 'format';
 import { getPillarStyles } from 'pillar';
 
 

--- a/src/components/follow.test.tsx
+++ b/src/components/follow.test.tsx
@@ -6,7 +6,7 @@ import Adapter from 'enzyme-adapter-react-16';
 
 import Follow from './follow';
 import { Pillar } from 'pillar';
-import { Design, Display } from 'item';
+import { Design, Display } from 'format';
 
 
 // ----- Setup ----- //

--- a/src/components/follow.tsx
+++ b/src/components/follow.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography';
 
-import { Format } from 'item';
+import { Format } from 'format';
 import { getPillarStyles } from 'pillar';
 import { Contributor, isSingleContributor } from 'contributor';
 import { darkModeCss } from 'styles';

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -6,10 +6,11 @@ import { headline } from '@guardian/src-foundations/typography';
 import { background, neutral, text } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 
-import { Item, Design, Display } from 'item';
+import { Item } from 'item';
 import { darkModeCss as darkMode } from 'styles';
 import { getPillarStyles, PillarStyles } from 'pillar';
 import StarRating from './starRating';
+import { Display, Design } from 'format';
 
 
 // ----- Component ----- //

--- a/src/components/shared/keyline.test.tsx
+++ b/src/components/shared/keyline.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { configure, shallow, ShallowWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Keyline } from 'components/shared/keyline';
-import { Design } from 'item';
+import { Design } from 'format';
 
 configure({ adapter: new Adapter() });
 

--- a/src/components/shared/keyline.tsx
+++ b/src/components/shared/keyline.tsx
@@ -3,7 +3,7 @@ import { css, SerializedStyles } from '@emotion/core'
 import { darkModeCss, wideContentWidth, wideColumnWidth } from 'styles';
 import { neutral } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
-import { Design } from 'item';
+import { Design } from 'format';
 
 const BaseStyles = css`
     height: 10px;

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -8,7 +8,6 @@ import LiveblogArticle from 'components/liveblog/article';
 import Opinion from 'components/opinion/article';
 import Immersive from 'components/immersive/article';
 import Media from 'components/media/article';
-
 import { IContent as Content } from 'mapiThriftModels/Content';
 import { includesTweets } from 'capi';
 import { fontFace } from 'styles';
@@ -17,6 +16,7 @@ import { renderAll, renderMedia } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { partition } from 'types/result';
 import { getAdPlaceholderInserter } from 'ads';
+import { fromCapi } from 'item';
 import { sign } from 'components/image';
 import {
     ElementType,
@@ -25,7 +25,7 @@ import {
     IBlock as Block,
     IBlockElement as BlockElement
 } from 'mapiThriftModels';
-import { Design, Display, fromCapi } from 'item';
+import { Design, Display } from 'format';
 
 
 // ----- Components ----- //

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -7,10 +7,11 @@ import { background, neutral, text } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { remSpace } from '@guardian/src-foundations';
 
-import { Item, Design, Display } from 'item';
+import { Item } from 'item';
 import { renderText, renderStandfirstText } from 'renderer';
 import { darkModeCss as darkMode } from 'styles';
 import { PillarStyles, getPillarStyles } from 'pillar';
+import { Display, Design } from 'format';
 
 
 // ----- Component ----- //

--- a/src/components/starRating.tsx
+++ b/src/components/starRating.tsx
@@ -5,8 +5,9 @@ import { css } from '@emotion/core';
 import { brandAltBackground, text } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 
-import { Item, Design } from 'item';
+import { Item } from 'item';
 import { icons } from 'styles';
+import { Design } from 'format';
 
 
 // ----- Subcomponents ----- //

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,43 @@
+// ----- Imports ----- //
+
+import { Pillar } from 'pillar';
+
+
+// ----- Types ----- //
+
+const enum Design {
+    Article,
+    Media,
+    Review,
+    Analysis,
+    Comment,
+    Feature,
+    Live,
+    Recipe,
+    MatchReport,
+    Interview,
+    GuardianView,
+    Quiz,
+    AdvertisementFeature,
+}
+
+const enum Display {
+    Standard,
+    Immersive,
+    Showcase,
+}
+
+interface Format {
+    pillar: Pillar;
+    design: Design;
+    display: Display;
+}
+
+
+// ----- Exports ----- //
+
+export {
+    Format,
+    Design,
+    Display,
+}

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -1,7 +1,8 @@
-import { ContentType, Tag, TagType, ElementType, AssetType, IBlockElement as BlockElement } from "mapiThriftModels";
-import { fromCapi, Design, Standard, ElementKind, Image, Review, Audio, Video } from 'item';
-import { JSDOM } from "jsdom";
-import { None } from "types/option";
+import { ContentType, Tag, TagType, ElementType, AssetType, IBlockElement as BlockElement } from 'mapiThriftModels';
+import { fromCapi, Standard, ElementKind, Image, Review, Audio, Video } from 'item';
+import { Design } from 'format';
+import { JSDOM } from 'jsdom';
+import { None } from 'types/option';
 
 const articleContent = {
     id: "",

--- a/src/item.ts
+++ b/src/item.ts
@@ -15,33 +15,11 @@ import {
     AssetType,
     IAsset as Asset,
 } from 'mapiThriftModels';
-import { logger } from "logger";
+import { logger } from 'logger';
+import { Format, Design, Display } from 'format';
+
 
 // ----- Item Type ----- //
-
-const enum Design {
-    Article,
-    Media,
-    Review,
-    Analysis,
-    Comment,
-    Feature,
-    Live,
-    SpecialReport, // Not used?
-    Recipe,
-    MatchReport,
-    Interview,
-    GuardianView,
-    GuardianLabs, // Not used?
-    Quiz,
-    AdvertisementFeature,
-}
-
-const enum Display {
-    Standard,
-    Immersive,
-    Showcase,
-}
 
 const enum ElementKind {
     Text,
@@ -58,12 +36,6 @@ const enum ElementKind {
 
 enum Role {
     Thumbnail,
-}
-
-interface Format {
-    pillar: Pillar;
-    design: Design;
-    display: Display;
 }
 
 interface Fields extends Format {
@@ -584,8 +556,6 @@ const fromCapi = (docParser: DocParser) => (content: Content): Item => {
 // ----- Exports ----- //
 
 export {
-    Design,
-    Display,
     Item,
     Comment,
     Liveblog,
@@ -598,7 +568,6 @@ export {
     Video,
     Role,
     Image,
-    Format,
     fromCapi,
     fromCapiLiveBlog
 };


### PR DESCRIPTION
## Why are you doing this?

Breaking `Format` out into its own module. There are a few reasons why:

- Improve code clarity
- Less reason to import the entire `item` module in rendering code, which may reduce client bundle sizes
- Preparation for future changes, including integration with the [guardian/types](https://github.com/guardian/types) repo

## Changes

- Pulled `Format` type into its own module
- Updated imports
- Dropped `SpecialReport` and `GuardianLabs` from `Design` since we don't think they're used
