### PR TITLE
add title to interactive iframes and increase maximum scale

### DIFF
--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -265,7 +265,7 @@ function Page({ content, imageSalt, getAssetLocation }: Props): ElementWithResou
             <head>
                 <title>{content.id}</title>
                 <meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
-                <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+                <meta name="viewport" content="initial-scale=1, maximum-scale=5" />
             </head>
             <body>
                 { element }

--- a/src/item.ts
+++ b/src/item.ts
@@ -90,6 +90,7 @@ type BodyElement = {
 } | {
     kind: ElementKind.Interactive;
     url: string;
+    alt?: string;
 } | {
     kind: ElementKind.RichLink;
     url: string;
@@ -249,13 +250,13 @@ const parseElement =
         }
 
         case ElementType.INTERACTIVE: {
-            const { iframeUrl } = element.interactiveTypeData ?? {};
+            const { iframeUrl, alt } = element.interactiveTypeData ?? {};
 
             if (!iframeUrl) {
                 return new Err('No iframeUrl field on interactiveTypeData');
             }
 
-            return new Ok({ kind: ElementKind.Interactive, url: iframeUrl });
+            return new Ok({ kind: ElementKind.Interactive, url: iframeUrl, alt });
         }
 
         case ElementType.RICH_LINK: {

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -193,7 +193,7 @@ describe('Renders different types of elements', () => {
     test('ElementKind.Interactive', () => {
         const nodes = render(interactiveElement())
         const interactive = shallow(nodes.flat()[0]);
-        expect(interactive.html()).toContain('<iframe src="https://gu.com/interactive" height="500"></iframe>');
+        expect(interactive.html()).toContain('<iframe src="https://gu.com/interactive" height="500" title=""></iframe>');
     })
 
     test('ElementKind.Tweet', () => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -389,7 +389,7 @@ const RichLink = (props: { url: string; linkText: string; pillar: Pillar }): Rea
         h(Anchor, { href: props.url, pillar: props.pillar, text: 'Read more' }),
     );
 
-const Interactive = (props: { url: string, title?: string }): ReactElement =>
+const Interactive = (props: { url: string; title?: string }): ReactElement =>
     styledH('figure', { className: 'interactive' },
         h('iframe', { src: props.url, height: 500, title: props.title ?? "" }, null)
     );

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -389,9 +389,9 @@ const RichLink = (props: { url: string; linkText: string; pillar: Pillar }): Rea
         h(Anchor, { href: props.url, pillar: props.pillar, text: 'Read more' }),
     );
 
-const Interactive = (props: { url: string }): ReactElement =>
+const Interactive = (props: { url: string, title?: string }): ReactElement =>
     styledH('figure', { className: 'interactive' },
-        h('iframe', { src: props.url, height: 500 }, null)
+        h('iframe', { src: props.url, height: 500, title: props.title ?? "" }, null)
     );
 
 const Tweet = (props: { content: NodeList; pillar: Pillar; key: number }): ReactElement => {
@@ -441,7 +441,7 @@ const render = (pillar: Pillar, imageMappings: ImageMappings) =>
         }
 
         case ElementKind.Interactive:
-            return h(Interactive, { url: element.url, key });
+            return h(Interactive, { url: element.url, key, title: element.alt });
 
         case ElementKind.Tweet:
             return h(Tweet, { content: element.content, pillar, key });


### PR DESCRIPTION
## Why are you doing this?
Chrome lighthouse suggested two accessibility improvements. 

## Changes

- Add title to interactive iframes
- Increase maximum scale to recommended amount

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/79335935-c3dae000-7f1a-11ea-9b11-e12ea2faea4f.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/79335967-d1906580-7f1a-11ea-80a4-3dd4c779eaa5.png" width="300px" /> |

I'm wondering if we might have to revert the maximum scale as it might loose the native feel.