### PR TITLE
Add displayHint To Fields

### DIFF
--- a/src/capi.test.ts
+++ b/src/capi.test.ts
@@ -6,6 +6,6 @@ describe('server logic runs as expected', () => {
         const key = 'TEST_KEY';
         const capiUrl = capiEndpoint(articleId, key);
 
-        expect(capiUrl).toEqual('https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue&show-tags=all&show-blocks=all&show-elements=all');
+        expect(capiUrl).toEqual('https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue%2CdisplayHint&show-tags=all&show-blocks=all&show-elements=all');
     });
 });

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -97,7 +97,8 @@ const capiEndpoint = (articleId: string, key: string): string => {
         'bylineHtml',
         'firstPublicationDate',
         'shouldHideAdverts',
-        'shouldHideReaderRevenue'
+        'shouldHideReaderRevenue',
+        'displayHint'
     ];
 
     const params = new URLSearchParams({


### PR DESCRIPTION
## Why are you doing this?

We need `displayHint` to tell us if an article is immersive.

## Changes

- Added `displayHint` to list of fields requested from CAPI.
