### PR TITLE
Document Data Types

### DIFF
--- a/src/types/option.ts
+++ b/src/types/option.ts
@@ -6,10 +6,6 @@ import { Monad } from './monad';
 // ----- Classes ----- //
 
 interface OptionInterface<A> extends Monad<A> {
-    /**
-     * Returns the value if `Some`, otherwise returns `a`. You can think of it
-     * as "unwrapping" the `Option`, getting you back a plain value
-     */
     withDefault(a: A): A;
 }
 

--- a/src/types/option.ts
+++ b/src/types/option.ts
@@ -37,7 +37,8 @@ class Some<A> implements OptionInterface<A> {
      * @returns {Option<B>} A new `Option`
      * @example
      * const creditOne = new Some('Nicéphore Niépce');
-     * creditOne.fmap(name => `Photograph: ${name}`); // Returns Some('Photograph: Nicéphore Niépce')
+     * // Returns Some('Photograph: Nicéphore Niépce')
+     * creditOne.fmap(name => `Photograph: ${name}`);
      * 
      * const creditTwo = new None();
      * creditTwo.fmap(name => `Photograph: ${name}`); // Returns None()

--- a/src/types/option.ts
+++ b/src/types/option.ts
@@ -6,6 +6,10 @@ import { Monad } from './monad';
 // ----- Classes ----- //
 
 interface OptionInterface<A> extends Monad<A> {
+    /**
+     * Returns the value if `Some`, otherwise returns `a`. You can think of it
+     * as "unwrapping" the `Option`, getting you back a plain value
+     */
     withDefault(a: A): A;
 }
 
@@ -13,14 +17,55 @@ class Some<A> implements OptionInterface<A> {
 
     value: A;
 
+    /**
+     * Returns the value if `Some`, otherwise returns `a`. You can think of it
+     * as "unwrapping" the `Option`, getting you back a plain value
+     * @param a The value to fall back to if the `Option` is `None`
+     * @returns {A} The value for a `Some`, `a` for a `None`
+     * @example
+     * const bylineOne = new Some('CP Scott');
+     * bylineOne.withDefault('Jane Smith'); // Returns 'CP Scott'
+     *
+     * const bylineTwo = new None();
+     * bylineTwo.withDefault('Jane Smith'); // Returns 'Jane Smith'
+     */
     withDefault(_a: A): A {
         return this.value;
     }
 
+    /**
+     * Also called `map` (we've called it `fmap` for
+     * [reasons](https://github.com/guardian/apps-rendering/pull/166)).
+     * Applies a function to a `Some`, does nothing to a `None`.
+     * @param f The function to apply
+     * @returns {Option<B>} A new `Option`
+     * @example
+     * const creditOne = new Some('Nicéphore Niépce');
+     * creditOne.fmap(name => `Photograph: ${name}`); // Returns Some('Photograph: Nicéphore Niépce')
+     * 
+     * const creditTwo = new None();
+     * creditTwo.fmap(name => `Photograph: ${name}`); // Returns None()
+     * 
+     * // All together
+     * credit.fmap(name => `Photograph: ${name}`).withDefault('');
+     */
     fmap<B>(f: (a: A) => B): Option<B> {
         return new Some(f(this.value));
     }
 
+    /**
+     * Like `fmap` but applies a function that *also* returns an `Option`.
+     * Then "unwraps" the result for you so you don't end up with
+     * `Option<Option<A>>`
+     * @param f The function to apply
+     * @returns {Option<B>} A new `Option`
+     * @example
+     * type GetUser = number => Option<User>;
+     * type GetUserName = User => Option<string>;
+     * 
+     * const userId = 1;
+     * const username: Option<string> = getUser(userId).andThen(getUserName);
+     */
     andThen<B>(f: (a: A) => Option<B>): Option<B> {
         return f(this.value);
     }
@@ -47,11 +92,22 @@ class None<A> implements OptionInterface<A> {
 
 }
 
+/**
+ * Represents a value that may or may not exist; it's either a Some or a None.
+ * @extends Monad
+ */
 type Option<A> = Some<A> | None<A>;
 
 
 // ----- Constructors ----- //
 
+/**
+ * Turns a value that may be `null` or `undefined` into an `Option`.
+ * If it's `null` or `undefined` the `Option` will be a `None`. If it's
+ * some other value the `Option` will be a `Some` "wrapping" that value.
+ * @param a The value that may be `null` or `undefined`
+ * @returns {Option<A>} An `Option`
+ */
 const fromNullable = <A>(a: A | null | undefined): Option<A> =>
     a === null || a === undefined ? new None() : new Some(a);
 

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -16,22 +16,65 @@ class Ok<E, B> implements ResultInterface<E, B> {
 
     value: B;
 
+    /**
+     * The method for turning a `Result<E, A>` into a plain value.
+     * If this is an `Err`, apply the first function to the error value and
+     * return the result. If this is an `Ok`, apply the second function to
+     * the value and return the result.
+     * @param f The function to apply if this is an `Err`
+     * @param g The function to apply if this is an `Ok`
+     * @example
+     * const flakyTaskResult: Result<string, number> = flakyTask(options);
+     * 
+     * flakyTaskResult.either(
+     *     data => `We got the data! Here it is: ${data}`,
+     *     error => `Uh oh, an error: ${error}`,
+     * )
+     */
     either<C>(_f: (e: E) => C, g: (b: B) => C): C {
         return g(this.value);
     }
 
+    /**
+     * Similar to `Option.fmap`.
+     * Applies a function to the value in an `Ok`, does nothing to an `Err`.
+     * @param f The function to apply if this is an `Ok`
+     */
     fmap<C>(f: (a: B) => C): Result<E, C> {
         return new Ok(f(this.value));
     }
 
+    /**
+     * Similar to `Option.andThen`. Applies to a `Result` a function that
+     * *also* returns a `Result`, and unwraps them to avoid nested `Result`s.
+     * Can be useful for stringing together operations that might fail.
+     * @example
+     * type RequestUser = number => Result<string, User>;
+     * type GetEmail = User => Result<string, string>;
+     * 
+     * // Request fails: Err('Network failure')
+     * // Request succeeds, problem accessing email: Err('Email field missing')
+     * // Both succeed: Ok('email_address')
+     * requestUser(id).andThen(getEmail)
+     */
     andThen<C>(f: (b: B) => Result<E, C>): Result<E, C> {
         return f(this.value);
     }
 
+    /**
+     * The companion to `fmap`.
+     * Applies a function to the error in `Err`, does nothing to an `Ok`.
+     * @param g The function to apply if this is an `Err`
+     */
     mapError<F>(_g: (e: E) => F): Result<F, B> {
         return new Ok(this.value);
     }
 
+    /**
+     * Converts a `Result<E, A>` into an `Option<A>`. If the result is an
+     * `Ok` this will be a `Some`, if the result is an `Err` this will be
+     * a `None`.
+     */
     toOption(): Option<B> {
         return new Some(this.value);
     }
@@ -72,8 +115,16 @@ class Err<E, B> implements ResultInterface<E, B> {
 
 }
 
+/**
+ * Represents either a value or an error; it's either an `Ok` or an `Err`.
+ */
 type Result<E, A> = Ok<E, A> | Err<E, A>;
 
+/**
+ * Converts an operation that might throw into a `Result`
+ * @param f The operation that might throw
+ * @param error The error to return if the operation throws
+ */
 function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
     try {
         return new Ok(f());
@@ -82,8 +133,17 @@ function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
     }
 }
 
+/**
+ * The return type of the `partition` function
+ */
 type Partitioned<A, B> = { errs: A[]; oks: B[] };
 
+/**
+ * Takes a list of `Result`s and separates out the `Ok`s from the `Err`s.
+ * @param results A list of `Result`s
+ * @return {Partitioned} An object with two fields, one for the list of `Err`s
+ * and one for the list of `Ok`s
+ */
 const partition = <A, B>(results: Result<A, B>[]): Partitioned<A, B> =>
     results.reduce(({ errs, oks }: Partitioned<A, B>, result) =>
         result.either(


### PR DESCRIPTION
## Why are you doing this?

Used JSDoc to provide documentation for our data types: `Option` and `Result`. This is picked up by VSCode via Intellisense and *should* also work in IntelliJ (although I haven't tested it).

Derived from [this issue](https://github.com/guardian/types/issues/5).

## Changes

- Added JSDoc comments to `Option`
- Added JSDoc comments to `Result`
