### PR TITLE
TypeScript 3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20927,9 +20927,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw=="
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
     "ua-parser-js": {
       "version": "0.7.21",

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
     "@emotion/babel-preset-css-prop": "^10.0.27",
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
+    "@guardian/bridget": "^0.52.0",
     "@guardian/node-riffraff-artifact": "^0.1.7",
     "@guardian/src-button": "^0.13.0",
     "@guardian/src-foundations": "^0.14.1",
-    "@guardian/bridget": "^0.52.0",
     "@types/jsdom": "^12.2.4",
     "@types/uuid": "^3.4.6",
     "aws-sdk": "^2.604.0",
@@ -75,7 +75,7 @@
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "typescript": "^3.7.4"
+    "typescript": "^3.8.3"
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",


### PR DESCRIPTION
## Why are you doing this?

Keeping TypeScript up-to-date. The release notes are [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html).

## Changes

- Bumped TypeScript to 3.8.3
