### PR TITLE
Arts To Culture And Titlecase Pillars

### DIFF
--- a/src/ads.test.ts
+++ b/src/ads.test.ts
@@ -19,7 +19,7 @@ const generateParas = (paras: number): BodyElement =>
     textElement(Array(paras).fill('<p>foo</p>'));
 
 const render = (element: BodyElement): ReactNode[] =>
-    renderAll({})(Pillar.news, [element]);
+    renderAll({})(Pillar.News, [element]);
 
 const renderParagraphs = compose(render, generateParas);
 

--- a/src/components/byline.stories.tsx
+++ b/src/components/byline.stories.tsx
@@ -34,7 +34,7 @@ const mockBylineHtml = (): Option<DocumentFragment> =>
 
 const Default: FC = () =>
     <Byline
-        pillar={selectPillar(Pillar.news)}
+        pillar={selectPillar(Pillar.News)}
         design={Design.Article}
         display={Display.Standard}
         bylineHtml={mockBylineHtml()}
@@ -42,7 +42,7 @@ const Default: FC = () =>
 
 const Comment: FC = () =>
     <Byline
-        pillar={selectPillar(Pillar.opinion)}
+        pillar={selectPillar(Pillar.Opinion)}
         design={Design.Comment}
         display={Display.Standard}
         bylineHtml={mockBylineHtml()}

--- a/src/components/commentCount.stories.tsx
+++ b/src/components/commentCount.stories.tsx
@@ -14,7 +14,7 @@ import { selectPillar } from 'storybookHelpers';
 const Default: FC = () =>
     <CommentCount
         count={number('Count', 1234, { min: 0 })}
-        pillar={selectPillar(Pillar.news)}
+        pillar={selectPillar(Pillar.News)}
         design={Design.Article}
         display={Display.Standard}
         commentable={boolean('Commentable', true)}

--- a/src/components/follow.stories.tsx
+++ b/src/components/follow.stories.tsx
@@ -20,7 +20,7 @@ const Default: FC = () =>
                 webTitle: 'Jane Smith',
             }
         ]}
-        pillar={selectPillar(Pillar.news)}
+        pillar={selectPillar(Pillar.News)}
         design={Design.Article}
         display={Display.Standard}
     />

--- a/src/components/follow.test.tsx
+++ b/src/components/follow.test.tsx
@@ -14,7 +14,7 @@ import { Design, Display } from 'format';
 configure({ adapter: new Adapter() });
 
 const followFormat = {
-    pillar: Pillar.news,
+    pillar: Pillar.News,
     design: Design.Article,
     display: Display.Standard,
 };

--- a/src/components/headline.stories.tsx
+++ b/src/components/headline.stories.tsx
@@ -13,7 +13,7 @@ import { None } from 'types/option';
 // ----- Setup ----- //
 
 const item: Item = {
-    pillar: Pillar.news,
+    pillar: Pillar.News,
     design: Design.Article,
     display: Display.Standard,
     body: [],
@@ -38,11 +38,11 @@ const item: Item = {
 };
 
 const pillarOptions = {
-    News: Pillar.news,
-    Opinion: Pillar.opinion,
-    Sport: Pillar.sport,
-    Culture: Pillar.arts,
-    Lifestyle: Pillar.lifestyle,
+    News: Pillar.News,
+    Opinion: Pillar.Opinion,
+    Sport: Pillar.Sport,
+    Culture: Pillar.Culture,
+    Lifestyle: Pillar.Lifestyle,
 };
 
 const starRating: Record<number, number> = [0, 1, 2, 3, 4, 5];
@@ -54,7 +54,7 @@ const Default = (): ReactElement =>
     <Headline item={{
         ...item,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: select('Pillar', pillarOptions, Pillar.news),
+        pillar: select('Pillar', pillarOptions, Pillar.News),
     }} />
 
 const Analysis = (): ReactElement =>
@@ -62,7 +62,7 @@ const Analysis = (): ReactElement =>
         ...item,
         design: Design.Analysis,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: select('Pillar', pillarOptions, Pillar.news),
+        pillar: select('Pillar', pillarOptions, Pillar.News),
     }} />
 
 const Feature = (): ReactElement =>
@@ -70,7 +70,7 @@ const Feature = (): ReactElement =>
         ...item,
         design: Design.Feature,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: select('Pillar', pillarOptions, Pillar.news),
+        pillar: select('Pillar', pillarOptions, Pillar.News),
     }} />
 
 const Review = (): ReactElement =>

--- a/src/components/liveblog/liveblog.stories.tsx
+++ b/src/components/liveblog/liveblog.stories.tsx
@@ -8,8 +8,8 @@ export default { title: 'Liveblog', decorators: [withKnobs] };
 export const LoadMore = (): JSX.Element => <LiveblogLoadMore
   pillar={select(
     "Pillar",
-    [ Pillar.news, Pillar.opinion, Pillar.sport, Pillar.arts, Pillar.lifestyle ],
-    Pillar.news,
+    [ Pillar.News, Pillar.Opinion, Pillar.Sport, Pillar.Culture, Pillar.Lifestyle ],
+    Pillar.News,
   )}
   onLoadMore={(): Promise<void>=>Promise.resolve()}
 />

--- a/src/components/shared/headerImage.test.tsx
+++ b/src/components/shared/headerImage.test.tsx
@@ -11,7 +11,7 @@ configure({ adapter: new Adapter() });
 describe('HeaderImage component renders as expected', () => {
     it('Renders null if no block element', () => {
         const image: Option<Image> = new None;
-        const news = Pillar.news;
+        const news = Pillar.News;
         const headerImage = shallow(<HeaderImage image={image} imageMappings={{}} pillar={news}/>)
         expect(headerImage.html()).toBe(null);
     })

--- a/src/components/standfirst.stories.tsx
+++ b/src/components/standfirst.stories.tsx
@@ -21,7 +21,7 @@ const standfirst: Option<DocumentFragment> =
         .toOption();
 
 const item: Item = {
-    pillar: Pillar.news,
+    pillar: Pillar.News,
     design: Design.Article,
     display: Display.Standard,
     body: [],
@@ -46,11 +46,11 @@ const item: Item = {
 };
 
 const pillarOptions = {
-    News: Pillar.news,
-    Opinion: Pillar.opinion,
-    Sport: Pillar.sport,
-    Culture: Pillar.arts,
-    Lifestyle: Pillar.lifestyle,
+    News: Pillar.News,
+    Opinion: Pillar.Opinion,
+    Sport: Pillar.Sport,
+    Culture: Pillar.Culture,
+    Lifestyle: Pillar.Lifestyle,
 };
 
 
@@ -60,7 +60,7 @@ const Default = (): ReactElement =>
     <Standfirst item={{
         ...item,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: select('Pillar', pillarOptions, Pillar.news),
+        pillar: select('Pillar', pillarOptions, Pillar.News),
     }} />
 
 const Review = (): ReactElement =>
@@ -69,7 +69,7 @@ const Review = (): ReactElement =>
         design: Design.Review,
         starRating: 4,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: select('Pillar', pillarOptions, Pillar.arts),
+        pillar: select('Pillar', pillarOptions, Pillar.Culture),
     }} />
 
 const Feature = (): ReactElement =>
@@ -77,7 +77,7 @@ const Feature = (): ReactElement =>
         ...item,
         design: Design.Feature,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: select('Pillar', pillarOptions, Pillar.sport),
+        pillar: select('Pillar', pillarOptions, Pillar.Sport),
     }} />
 
 const Comment = (): ReactElement =>
@@ -85,7 +85,7 @@ const Comment = (): ReactElement =>
         ...item,
         design: Design.Comment,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: select('Pillar', pillarOptions, Pillar.opinion),
+        pillar: select('Pillar', pillarOptions, Pillar.Opinion),
     }} />
 
 

--- a/src/components/starRating.stories.tsx
+++ b/src/components/starRating.stories.tsx
@@ -13,7 +13,7 @@ import { None } from 'types/option';
 // ----- Setup ----- //
 
 const item: Item = {
-    pillar: Pillar.news,
+    pillar: Pillar.News,
     design: Design.Article,
     display: Display.Standard,
     body: [],

--- a/src/item.ts
+++ b/src/item.ts
@@ -506,7 +506,7 @@ const fromCapi = (docParser: DocParser) => (content: Content): Item => {
         return {
             design: Design.Comment,
             ...item,
-            pillar: item.pillar === Pillar.news ? Pillar.opinion : item.pillar
+            pillar: item.pillar === Pillar.News ? Pillar.Opinion : item.pillar
         };
     } else if (isFeature(tags)) {
         return {

--- a/src/pillar.ts
+++ b/src/pillar.ts
@@ -8,11 +8,11 @@ import { compose } from 'lib';
 // ----- Types ----- //
 
 const enum Pillar {
-    news,
-    opinion,
-    sport,
-    arts,
-    lifestyle,
+    News,
+    Opinion,
+    Sport,
+    Culture,
+    Lifestyle,
 }
 
 interface PillarStyles {
@@ -28,35 +28,35 @@ type PillarColours = {
 };
 
 export const pillarColours: PillarColours = {
-    [Pillar.news]: {
+    [Pillar.News]: {
         kicker: palette.news[400],
         featureHeadline: palette.news[300],
         soft: palette.neutral[97],
         inverted: palette.news[500],
         liveblogBackground: palette.news[300],
     },
-    [Pillar.opinion]: {
+    [Pillar.Opinion]: {
         kicker: palette.opinion[400],
         featureHeadline: palette.opinion[300],
         soft: palette.opinion[800],
         inverted: palette.opinion[500],
         liveblogBackground: palette.opinion[300],
     },
-    [Pillar.sport]: {
+    [Pillar.Sport]: {
         kicker: palette.sport[400],
         featureHeadline: palette.sport[300],
         soft: palette.sport[800],
         inverted: palette.sport[500],
         liveblogBackground: palette.sport[300],
     },
-    [Pillar.arts]: {
+    [Pillar.Culture]: {
         kicker: palette.culture[400],
         featureHeadline: palette.culture[300],
         soft: palette.culture[800],
         inverted: palette.culture[500],
         liveblogBackground: palette.culture[300],
     },
-    [Pillar.lifestyle]: {
+    [Pillar.Lifestyle]: {
         kicker: palette.lifestyle[400],
         featureHeadline: palette.lifestyle[300],
         soft: palette.lifestyle[800],
@@ -70,16 +70,16 @@ const getPillarStyles = (pillar: Pillar): PillarStyles => pillarColours[pillar];
 function pillarFromString(pillar: string | undefined): Pillar {
     switch (pillar) {
         case 'pillar/opinion':
-            return Pillar.opinion;
+            return Pillar.Opinion;
         case 'pillar/sport':
-            return Pillar.sport;
+            return Pillar.Sport;
         case 'pillar/arts':
-            return Pillar.arts;
+            return Pillar.Culture;
         case 'pillar/lifestyle':
-            return Pillar.lifestyle;
+            return Pillar.Lifestyle;
         case 'pillar/news':
         default:
-            return Pillar.news;
+            return Pillar.News;
     }
 }
 

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -73,10 +73,10 @@ const instagramElement = (): BodyElement =>
     })
 
 const render = (element: BodyElement): ReactNode[] =>
-    renderAll({})(Pillar.news, [element]);
+    renderAll({})(Pillar.News, [element]);
 
 const renderCaption = (element: BodyElement): ReactNode[] =>
-    renderMedia({})(Pillar.news, [element]);
+    renderMedia({})(Pillar.News, [element]);
 
 const renderTextElement = compose(render, textElement);
 
@@ -94,7 +94,7 @@ describe('renderer returns expected content', () => {
             captionString: "caption",
             caption: JSDOM.fragment('this caption contains <em>html</em>'),
             credit: "credit",
-            pillar: Pillar.news,
+            pillar: Pillar.News,
         };
         expect(ImageElement(imageProps)).toBe(null);
     });
@@ -110,7 +110,7 @@ describe('renderer returns expected content', () => {
             captionString: "caption",
             caption: JSDOM.fragment('this caption contains <em>html</em>'),
             credit: "credit",
-            pillar: Pillar.news,
+            pillar: Pillar.News,
         };
         const image = shallow(h(ImageElement, imageProps));
 
@@ -212,14 +212,14 @@ describe('Renders different types of elements', () => {
 describe('Paragraph tags rendered correctly', () => {
     test('Contains no styles in standfirsts', () => {
         const fragment = JSDOM.fragment('<p>Parapraph tag</p><span>1</span>');
-        const nodes = renderStandfirstText(fragment, Pillar.news);
+        const nodes = renderStandfirstText(fragment, Pillar.News);
         const html = shallow(nodes.flat()[0]).html();
         expect(html).toBe('<p>Parapraph tag</p>')
     });
 
     test('Contains styles in article body', () => {
         const fragment = JSDOM.fragment('<p>Parapraph tag</p><span>1</span>');
-        const nodes = renderText(fragment, Pillar.news);
+        const nodes = renderText(fragment, Pillar.News);
         const html = shallow(nodes.flat()[0]).html();
         expect(html).not.toBe('<p>Parapraph tag</p>')
     });

--- a/src/storybookHelpers.ts
+++ b/src/storybookHelpers.ts
@@ -8,11 +8,11 @@ import { Pillar } from 'pillar';
 // ----- Helpers ----- //
 
 const pillarOptions = {
-    News: Pillar.news,
-    Opinion: Pillar.opinion,
-    Sport: Pillar.sport,
-    Culture: Pillar.arts,
-    Lifestyle: Pillar.lifestyle,
+    News: Pillar.News,
+    Opinion: Pillar.Opinion,
+    Sport: Pillar.Sport,
+    Culture: Pillar.Culture,
+    Lifestyle: Pillar.Lifestyle,
 };
 
 const selectPillar = (initial: Pillar): Pillar =>

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -11,7 +11,7 @@ describe('helper functions return correct styles', () => {
     });
 
     test('Returns correct pillar styles for pillar', () => {
-        const pillarStyles = getPillarStyles(Pillar.news);
+        const pillarStyles = getPillarStyles(Pillar.News);
         const expectedNewsPillarStyles =  {
             kicker: '#C70000',
             featureHeadline: '#AB0613',


### PR DESCRIPTION
## Why are you doing this?

Although CAPI still refers to it as "arts", the Pillar is really called "culture". It's called this in the nav and a number of other places, including [DCR](https://github.com/guardian/dotcom-rendering/blob/ff97d314f091c57dd297ca5e8f8bced078b672a9/src/lib/pillars.ts#L25).

Also, the convention for types in general and [enums in particular](https://www.typescriptlang.org/docs/handbook/enums.html) is to use titlecase. This brings us into line with the [types repo](https://github.com/guardian/types/blob/3e70de6fb9443650ec14f9e8c9d99a31e5d1f078/Format.ts).

## Changes

- Migrated "arts" to "culture"
- Made Pillars titlecase
