### PR TITLE
Use @guardian/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3998,6 +3998,14 @@
       "resolved": "https://registry.npmjs.org/@guardian/src-svgs/-/src-svgs-0.13.0.tgz",
       "integrity": "sha512-cDIGNOaatYVDk+eWCv2cAdBlXZ2ECDxOcc897GowJYCHmy+HifL0AvzHlHRLKYRQXzVcaPfoXDOjVonA4ViHqw=="
     },
+    "@guardian/types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-0.1.0.tgz",
+      "integrity": "sha512-MXdSxV560PV+Vtjdo/SyLFfsCCMkF3vo14ukeC+PvgIfdWFbzm4Jnbs2T65GbPZWJEMVLA1l8LYiXOV2mJ4qrw==",
+      "requires": {
+        "typescript": "^3.8.3"
+      }
+    },
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@guardian/node-riffraff-artifact": "^0.1.7",
     "@guardian/src-button": "^0.13.0",
     "@guardian/src-foundations": "^0.14.1",
+    "@guardian/types": "^0.1.0",
     "@types/jsdom": "^12.2.4",
     "@types/uuid": "^3.4.6",
     "aws-sdk": "^2.604.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:server:prod": "webpack --config webpack.config.js --config-name server --env.production",
     "build:client:prod": "webpack --config webpack.config.js --config-name clientProduction",
     "storybook": "start-storybook -s ./ -p 8181 --ci",
-    "build-storybook": "node --max-old-space-size=4096 $(npm bin)/build-storybook -o dist",
+    "build-storybook": "build-storybook -o dist",
     "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:server:prod": "webpack --config webpack.config.js --config-name server --env.production",
     "build:client:prod": "webpack --config webpack.config.js --config-name clientProduction",
     "storybook": "start-storybook -s ./ -p 8181 --ci",
-    "build-storybook": "node --max-old-space-size=1024 $(npm bin)/build-storybook -o dist",
+    "build-storybook": "node --max-old-space-size=4096 $(npm bin)/build-storybook -o dist",
     "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:server:prod": "webpack --config webpack.config.js --config-name server --env.production",
     "build:client:prod": "webpack --config webpack.config.js --config-name clientProduction",
     "storybook": "start-storybook -s ./ -p 8181 --ci",
-    "build-storybook": "build-storybook -o dist",
+    "build-storybook": "node --max-old-space-size=1024 $(npm bin)/build-storybook -o dist",
     "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh"
   },
   "jest": {

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,40 +1,6 @@
-// ----- Types ----- //
+// ----- Imports ----- //
 
-const enum Pillar {
-    News,
-    Opinion,
-    Sport,
-    Culture,
-    Lifestyle,
-}
-
-const enum Design {
-    Article,
-    Media,
-    Review,
-    Analysis,
-    Comment,
-    Feature,
-    Live,
-    Recipe,
-    MatchReport,
-    Interview,
-    GuardianView,
-    Quiz,
-    AdvertisementFeature,
-}
-
-const enum Display {
-    Standard,
-    Immersive,
-    Showcase,
-}
-
-interface Format {
-    pillar: Pillar;
-    design: Design;
-    display: Display;
-}
+import { Pillar, Design, Display, Format } from '@guardian/types/format'
 
 
 // ----- Exports ----- //

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Pillar, Design, Display, Format } from '@guardian/types/format'
+import { Pillar, Design, Display, Format } from '@guardian/types/Format'
 
 
 // ----- Exports ----- //


### PR DESCRIPTION
## Why are you doing this?

It would be good to start using the centralised [types repo](https://github.com/guardian/types) that we created. This does that, and it seems to work! What do people think about this?

**Note:** Long term we'd want to get rid of the `format` module and import this directly. I've done this for now to try it out.

## Changes

- Added `@guardian/types` as a dependency
- Replaced the types in the `format` module with imports from the types repo
