### PR TITLE
Chromatic Continue On Error

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,7 @@ jobs:
             - run: |
                   npm i
             - uses: chromaui/action@v1
+              continue-on-error: true
               with:
                   appCode: ${{ secrets.CHROMATIC_APP_CODE }}
                   token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why are you doing this?

Prevents chromatic/storybook issues from blocking the build while we stabilise the action. From the docs [here](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error).

## Changes

- Added `continue-on-error` to chromatic build
