### PR TITLE
Native Stylesheet

### DIFF
--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -266,6 +266,7 @@ function Page({ content, imageSalt, getAssetLocation }: Props): ElementWithResou
                 <title>{content.id}</title>
                 <meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
                 <meta name="viewport" content="initial-scale=1, maximum-scale=5" />
+                <link rel="stylesheet" href="native://fontSize.css" />
             </head>
             <body>
                 { element }


### PR DESCRIPTION
## Why are you doing this?

When a webview containing an article first loads, we need to know if the user has specified an alternate font size for the content. In order for this to be performant and reliable (i.e. to happen quickly, before first paint but without noticeable delaying it, and consistently on every article render) we've decided it's best not to rely on JavaScript (via the native comms layer). Therefore we're going to make a (render-blocking) request for a very small stylesheet in the `<head>`, which we expect the native layers to intercept and use to return a stylesheet of the form:

```css
html {
  font-size: 16px;
}
```

We've used the custom `native://` protocol for this because [`WKWebView`](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/2875766-seturlschemehandler) doesn't allow interception of `http` or `https` requests.

## Changes

- Added `<link>` to native stylesheet
