### PR TITLE
Consistent News Colours

### DIFF
--- a/src/pillarStyles.ts
+++ b/src/pillarStyles.ts
@@ -23,7 +23,7 @@ export const pillarColours: PillarColours = {
     [Pillar.News]: {
         kicker: palette.news[400],
         featureHeadline: palette.news[300],
-        soft: palette.neutral[97],
+        soft: palette.news[800],
         inverted: palette.news[500],
         liveblogBackground: palette.news[300],
     },

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -16,7 +16,7 @@ describe('helper functions return correct styles', () => {
         const expectedNewsPillarStyles =  {
             kicker: '#C70000',
             featureHeadline: '#AB0613',
-            soft: '#F6F6F6',
+            soft: '#FFF4F2',
             inverted: '#FF5943',
             liveblogBackground: '#AB0613'
         }


### PR DESCRIPTION
## Why are you doing this?

Brings the news colours into line with the other pillar palettes.

## Changes

- Used `news[800]` rather than `neutral[97]` for news `soft`

Before | After
-|-
![before](https://user-images.githubusercontent.com/53781962/79970720-41f33580-848b-11ea-9675-d1913bb35d3c.png) | ![after](https://user-images.githubusercontent.com/53781962/79970712-40c20880-848b-11ea-9626-278e45d2a1b9.png)
