### PR TITLE
Renderer Takes Format

### DIFF
--- a/src/ads.test.ts
+++ b/src/ads.test.ts
@@ -2,12 +2,17 @@ import { getAdPlaceholderInserter } from './ads';
 import { ReactNode } from 'react';
 import { renderAll } from 'renderer';
 import { JSDOM } from 'jsdom';
-import { Pillar } from 'format';
+import { Pillar, Format, Design, Display } from 'format';
 import { compose } from 'lib';
 import { ElementKind, BodyElement } from 'item';
 
 const shouldHideAdverts = false;
 const insertAdPlaceholders = getAdPlaceholderInserter(shouldHideAdverts);
+const mockFormat: Format = {
+    pillar: Pillar.News,
+    design: Design.Article,
+    display: Display.Standard,
+};
 
 const textElement = (nodes: string[]): BodyElement =>
     ({
@@ -19,7 +24,7 @@ const generateParas = (paras: number): BodyElement =>
     textElement(Array(paras).fill('<p>foo</p>'));
 
 const render = (element: BodyElement): ReactNode[] =>
-    renderAll({})(Pillar.News, [element]);
+    renderAll({})(mockFormat, [element]);
 
 const renderParagraphs = compose(render, generateParas);
 

--- a/src/client/liveblog.ts
+++ b/src/client/liveblog.ts
@@ -2,7 +2,7 @@
 
 
 import setup from 'client/setup';
-import { fromCapiLiveBlog } from 'item';
+import { fromCapiLiveBlog, getFormat } from 'item';
 import ReactDOM from 'react-dom';
 import LiveblogBody from 'components/liveblog/body';
 import { createElement as h } from 'react';
@@ -32,14 +32,14 @@ try {
     const hydrationProps = JSON.parse(document.getElementById('hydrationProps')?.textContent ?? "");
 
     if (hydrationProps) {
-        const {
-            pillar,
-            blocks,
-            totalBodyBlocks
-        } = fromCapiLiveBlog(browserParser)(hydrationProps);
+        const item = fromCapiLiveBlog(browserParser)(hydrationProps);
+        const { blocks, totalBodyBlocks } = item;
 
         const { imageMappings } = hydrationProps;
-        ReactDOM.hydrate(h(LiveblogBody, { pillar, blocks, imageMappings, totalBodyBlocks }), document.querySelector('#blocks'))
+        ReactDOM.hydrate(
+            h(LiveblogBody, { format: getFormat(item), blocks, imageMappings, totalBodyBlocks }),
+            document.querySelector('#blocks'),
+        );
     }
 } catch (e) {
     console.error(`Unable to hydrate LiveblogBody: ${e}`)

--- a/src/components/liveblog/article.tsx
+++ b/src/components/liveblog/article.tsx
@@ -44,24 +44,26 @@ interface LiveblogArticleProps {
 }
 
 const LiveblogArticle = ({ item, imageMappings }: LiveblogArticleProps): JSX.Element => {
+    const format = getFormat(item);
+
     return (
         <main css={LiveblogArticleStyles}>
             <div css={BorderStyles}>
                 <LiveblogSeries series={item.series} pillar={item.pillar} />
                 <LiveblogHeadline headline={item.headline} pillar={item.pillar} />
-                <LiveblogStandfirst standfirst={item.standfirst} pillar={item.pillar} />
+                <LiveblogStandfirst standfirst={item.standfirst} format={format} />
                 <Metadata item={item} imageMappings={imageMappings} />
                 <div css={headerImageStyles(getPillarStyles(item.pillar))}>
                     <HeaderImage
                         image={item.mainImage}
                         imageMappings={imageMappings}
-                        format={getFormat(item)}
+                        format={format}
                     />
                 </div>
                 <LiveblogKeyEvents blocks={item.blocks} pillar={item.pillar} />
                 <LiveblogBody
                     blocks={item.blocks}
-                    pillar={item.pillar}
+                    format={format}
                     imageMappings={imageMappings}
                     totalBodyBlocks={item.totalBodyBlocks}
                 />

--- a/src/components/liveblog/body.tsx
+++ b/src/components/liveblog/body.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import LiveblogBlock from './block';
 import LiveblogLoadMore from './loadMore';
-import { css, SerializedStyles } from '@emotion/core'
-import { PillarStyles, getPillarStyles } from 'pillarStyles';
-import { Pillar } from 'format';
+import { css } from '@emotion/core'
+import { Pillar, Format } from 'format';
 import { LiveBlock } from 'item';
 import { renderAll } from 'renderer';
 import { partition } from 'types/result';
@@ -12,7 +11,7 @@ import { Blocks } from 'mapiThriftModels';
 import { ImageMappings } from 'components/shared/page';
 import { remSpace } from '@guardian/src-foundations';
 
-const LiveBodyStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
+const LiveBodyStyles = css`
     .rich-link,
     .element-membership {
         width: calc(100% - 16px);
@@ -25,7 +24,7 @@ const LiveBodyStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
 `;
 
 interface LiveblogBodyProps {
-    pillar: Pillar;
+    format: Format;
     blocks: LiveBlock[];
     totalBodyBlocks: number;
     imageMappings: ImageMappings;
@@ -46,25 +45,25 @@ const LoadMore = ({ total, pillar }: { total: number; pillar: Pillar }): JSX.Ele
         : null;
 
 const LiveblogBody = (props: LiveblogBodyProps): JSX.Element => {
-    const { pillar, blocks: initialBlocks, imageMappings, totalBodyBlocks } = props;
+    const { format, blocks: initialBlocks, imageMappings, totalBodyBlocks } = props;
     const [blocks] = useState(initialBlocks);
 
     return (
-        <article id="blocks" css={LiveBodyStyles(getPillarStyles(pillar))}>
+        <article id="blocks" css={LiveBodyStyles}>
             {
                 blocks.map((block: LiveBlock) => {
                     return <LiveblogBlock
                         key={block.id}
-                        pillar={pillar} 
+                        pillar={format.pillar} 
                         highlighted={block.isKeyEvent}
                         title={block.title}
                         firstPublishedDate={block.firstPublished}
                         lastModifiedDate={block.lastModified}>
-                            <>{ renderAll(imageMappings)(pillar, partition(block.body).oks) }</>
+                            <>{ renderAll(imageMappings)(format, partition(block.body).oks) }</>
                         </LiveblogBlock>
                 })
             }
-            <LoadMore total={totalBodyBlocks} pillar={pillar}/>
+            <LoadMore total={totalBodyBlocks} pillar={format.pillar}/>
         </article>
     );
 

--- a/src/components/liveblog/metadata.tsx
+++ b/src/components/liveblog/metadata.tsx
@@ -7,7 +7,7 @@ import Avatar from './avatar';
 import LeftColumn from 'components/shared/leftColumn';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { CommentCount } from './commentCount';
-import { Liveblog } from 'item';
+import { Liveblog, getFormat } from 'item';
 import { renderText } from 'renderer';
 import Dateline from 'components/dateline';
 import { ImageMappings } from 'components/shared/page';
@@ -75,7 +75,7 @@ const Metadata = ({ item, imageMappings}: Props): JSX.Element => {
     const pillarStyles = getPillarStyles(item.pillar);
 
     const byline = item.bylineHtml.fmap<ReactNode>(html =>
-        <address>{ renderText(html, item.pillar) }</address>
+        <address>{ renderText(html, getFormat(item)) }</address>
     ).withDefault(null);
 
     return (

--- a/src/components/liveblog/standfirst.tsx
+++ b/src/components/liveblog/standfirst.tsx
@@ -3,7 +3,7 @@ import { css, SerializedStyles } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 import LeftColumn from 'components/shared/leftColumn';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
-import { Pillar } from 'format';
+import { Format } from 'format';
 import { renderText } from 'renderer';
 import { Option } from 'types/option';
 
@@ -24,13 +24,13 @@ const StandfirstStyles = ({ liveblogBackground }: PillarStyles): SerializedStyle
 
 interface LiveblogStandfirstProps {
     standfirst: Option<DocumentFragment>;
-    pillar: Pillar;
+    format: Format;
 }
 
-const LiveblogStandfirst = ({ standfirst, pillar }: LiveblogStandfirstProps): JSX.Element | null =>
+const LiveblogStandfirst = ({ standfirst, format }: LiveblogStandfirstProps): JSX.Element | null =>
     standfirst.fmap<JSX.Element | null>(doc =>
-        <LeftColumn className={StandfirstStyles(getPillarStyles(pillar))}>
-            <div>{ renderText(doc, pillar) }</div>
+        <LeftColumn className={StandfirstStyles(getPillarStyles(format.pillar))}>
+            <div>{ renderText(doc, format) }</div>
         </LeftColumn>
     ).withDefault(null)
 

--- a/src/components/media/byline.tsx
+++ b/src/components/media/byline.tsx
@@ -7,7 +7,7 @@ import { getPillarStyles, PillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
 import { Option } from 'types/option';
 import Dateline from 'components/dateline';
-import { Item } from 'item';
+import { Item, getFormat } from 'item';
 import { textSans } from "@guardian/src-foundations/typography";
 import { renderText } from "../../renderer";
 import { remSpace } from "@guardian/src-foundations";
@@ -48,7 +48,7 @@ interface Props {
 function Byline({ pillar, publicationDate, className, item }: Props): JSX.Element {
 
     const byline = item.bylineHtml.fmap<ReactNode>(html =>
-        <address>{ renderText(html, item.pillar) }</address>
+        <address>{ renderText(html, getFormat(item)) }</address>
     ).withDefault(null);
 
     return (

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -16,7 +16,7 @@ import { renderAll, renderMedia } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { partition } from 'types/result';
 import { getAdPlaceholderInserter } from 'ads';
-import { fromCapi } from 'item';
+import { fromCapi, getFormat } from 'item';
 import { sign } from 'image';
 import {
     ElementType,
@@ -166,6 +166,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
     const insertAdPlaceholders = getAdPlaceholderInserter(capi.fields?.shouldHideAdverts ?? false);
 
     const item = fromCapi(JSDOM.fragment.bind(null))(capi);
+    const format = getFormat(item);
     const imageMappings = getImageMappings(imageSalt, capi);
 
     const articleScript = getAssetLocation('article.js');
@@ -175,7 +176,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
     if (item.design === Design.Comment) {
         const commentBody = partition(item.body).oks;
         const commentContent =
-            insertAdPlaceholders(renderAll(imageMappings)(item.pillar, commentBody));
+            insertAdPlaceholders(renderAll(imageMappings)(format, commentBody));
 
         return { element: (
             <WithScript src={articleScript}>
@@ -197,7 +198,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
     if (item.display === Display.Immersive) {
         const immersiveBody = partition(item.body).oks;
         const immersiveContent =
-            insertAdPlaceholders(renderAll(imageMappings)(item.pillar, immersiveBody));
+            insertAdPlaceholders(renderAll(imageMappings)(format, immersiveBody));
 
         return { element: (
             <WithScript src={articleScript}>
@@ -211,7 +212,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
     if (item.design === Design.Media) {
         const body = partition(item.body).oks;
         const mediaContent =
-            insertAdPlaceholders(renderMedia(imageMappings)(item.pillar, body));
+            insertAdPlaceholders(renderMedia(imageMappings)(format, body));
         return { element: (
                 <WithScript src={mediaScript}>
                     <Media imageMappings={imageMappings} item={item}>
@@ -228,7 +229,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
         item.design === Design.Article
     ) {
         const body = partition(item.body).oks;
-        const content = insertAdPlaceholders(renderAll(imageMappings)(item.pillar, body));
+        const content = insertAdPlaceholders(renderAll(imageMappings)(format, body));
 
         return { element: (
             <WithScript src={articleScript}>

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -7,7 +7,7 @@ import { background, neutral, text } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { remSpace } from '@guardian/src-foundations';
 
-import { Item } from 'item';
+import { Item, getFormat } from 'item';
 import { renderText, renderStandfirstText } from 'renderer';
 import { darkModeCss as darkMode } from 'styles';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
@@ -109,7 +109,8 @@ const getStyles = (item: Item): SerializedStyles => {
 }
 
 function content(standfirst: DocumentFragment, item: Item): ReactNode {
-    const rendered = renderStandfirstText(standfirst, item.pillar);
+    const format = getFormat(item);
+    const rendered = renderStandfirstText(standfirst, format);
 
     // Immersives append the byline to the standfirst.
     // Sometimes CAPI includes this within the standfirst HTML,
@@ -121,7 +122,7 @@ function content(standfirst: DocumentFragment, item: Item): ReactNode {
             <>
                 {rendered}
                 <address>
-                    <p>By {renderText(byline, item.pillar)}</p>
+                    <p>By {renderText(byline, format)}</p>
                 </address>
             </>
         ).withDefault(rendered);

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -9,8 +9,14 @@ import { Role } from 'image';
 import { configure, shallow } from 'enzyme';
 import { None, Some } from 'types/option';
 import Adapter from 'enzyme-adapter-react-16';
+import { Format, Design, Display } from '@guardian/types/Format';
 
 configure({ adapter: new Adapter() });
+const mockFormat: Format = {
+    pillar: Pillar.News,
+    design: Design.Article,
+    display: Display.Standard,
+};
 
 beforeEach(() => {
     console.error = jest.fn()
@@ -74,10 +80,10 @@ const instagramElement = (): BodyElement =>
     })
 
 const render = (element: BodyElement): ReactNode[] =>
-    renderAll({})(Pillar.News, [element]);
+    renderAll({})(mockFormat, [element]);
 
 const renderCaption = (element: BodyElement): ReactNode[] =>
-    renderMedia({})(Pillar.News, [element]);
+    renderMedia({})(mockFormat, [element]);
 
 const renderTextElement = compose(render, textElement);
 
@@ -178,14 +184,14 @@ describe('Renders different types of elements', () => {
 describe('Paragraph tags rendered correctly', () => {
     test('Contains no styles in standfirsts', () => {
         const fragment = JSDOM.fragment('<p>Parapraph tag</p><span>1</span>');
-        const nodes = renderStandfirstText(fragment, Pillar.News);
+        const nodes = renderStandfirstText(fragment, mockFormat);
         const html = shallow(nodes.flat()[0]).html();
         expect(html).toBe('<p>Parapraph tag</p>')
     });
 
     test('Contains styles in article body', () => {
         const fragment = JSDOM.fragment('<p>Parapraph tag</p><span>1</span>');
-        const nodes = renderText(fragment, Pillar.News);
+        const nodes = renderText(fragment, mockFormat);
         const html = shallow(nodes.flat()[0]).html();
         expect(html).not.toBe('<p>Parapraph tag</p>')
     });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -107,7 +107,7 @@ interface AnchorProps {
     format: Format;
 }
 
-const Anchor: FC<AnchorProps> = ({ format, text, href}): ReactElement =>
+const Anchor: FC<AnchorProps> = ({ format, text, href }): ReactElement =>
     styledH(
         'a',
         { css: anchorStyles(getPillarStyles(format.pillar).kicker), href },

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,13 +1,13 @@
 // ----- Imports ----- //
 
-import { ReactNode, createElement as h, ReactElement } from 'react';
+import { ReactNode, createElement as h, ReactElement, FC } from 'react';
 import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { from, until } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Option, fromNullable, Some, None } from 'types/option';
 import { basePx, icons, darkModeCss } from 'styles';
 import { getPillarStyles } from 'pillarStyles';
-import { Pillar } from 'format';
+import { Format } from 'format';
 import { ElementKind, BodyElement } from 'item';
 import { Role } from 'image';
 import { body, headline, textSans } from '@guardian/src-foundations/typography';
@@ -55,10 +55,15 @@ const bulletStyles = (colour: string): SerializedStyles => css`
     }
 `;
 
-const Bullet = (props: { pillar: Pillar; text: string }): ReactElement =>
+interface BulletProps {
+    format: Format;
+    text: string;
+}
+
+const Bullet: FC<BulletProps> = ({ format, text }: BulletProps): ReactElement =>
     styledH('p', { css: css`display: inline; ${body.medium({ lineHeight: 'loose' })} overflow-wrap: break-word; margin: 0 0 ${remSpace[3]};` },
-        styledH('span', { css: bulletStyles(getPillarStyles(props.pillar).kicker) }, '•'),
-        props.text.replace(/•/g, ''),
+        styledH('span', { css: bulletStyles(getPillarStyles(format.pillar).kicker) }, '•'),
+        text.replace(/•/g, ''),
         null
     );
 
@@ -77,9 +82,9 @@ const HorizontalRule = (): ReactElement =>
     styledH('hr', { css: HorizontalRuleStyles }, null);
 
 
-const transform = (text: string, pillar: Pillar): ReactElement | string => {
+const transform = (text: string, format: Format): ReactElement | string => {
     if (text.includes('•')) {
-        return h(Bullet, { pillar, text });
+        return h(Bullet, { format, text });
     } else if (text.includes('* * *')) {
         return h(HorizontalRule, null, null);
     }
@@ -96,11 +101,17 @@ const anchorStyles = (colour: string): SerializedStyles => css`
     `}
 `;
 
-const Anchor = (props: { href: string; text: string; pillar: Pillar }): ReactElement =>
+interface AnchorProps {
+    href: string;
+    text: string;
+    format: Format;
+}
+
+const Anchor: FC<AnchorProps> = ({ format, text, href}): ReactElement =>
     styledH(
         'a',
-        { css: anchorStyles(getPillarStyles(props.pillar).kicker), href: props.href },
-        transform(props.text, props.pillar),
+        { css: anchorStyles(getPillarStyles(format.pillar).kicker), href },
+        transform(text, format),
     );
 
 const listStyles: SerializedStyles = css`
@@ -152,18 +163,18 @@ const TweetStyles = css`
     }
 `;
 
-const textElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {
+const textElement = (format: Format) => (node: Node, key: number): ReactNode => {
     const text = node.textContent ?? '';
-    const children = Array.from(node.childNodes).map(textElement(pillar));
+    const children = Array.from(node.childNodes).map(textElement(format));
     switch (node.nodeName) {
         case 'P':
             return h(Paragraph, { key }, children);
         case '#text':
-            return transform(text, pillar);
+            return transform(text, format);
         case 'SPAN':
             return text;
         case 'A':
-            return h(Anchor, { href: getHref(node).withDefault(''), text, pillar, key }, children);
+            return h(Anchor, { href: getHref(node).withDefault(''), text, format, key }, children);
         case 'H2':
             return styledH('h2', { css: HeadingTwoStyles, key }, children );
         case 'BLOCKQUOTE':
@@ -197,7 +208,7 @@ const captionHeadingStyles = css`
     }
 `;
 
-const MediaCaptionText = (props: { text: string; pillar: Pillar }): ReactElement =>
+const MediaCaptionText = (props: { text: string }): ReactElement =>
     styledH(
         'p',
         { css: css`
@@ -208,49 +219,46 @@ const MediaCaptionText = (props: { text: string; pillar: Pillar }): ReactElement
         props.text,
     );
 
-const CaptionItalicStyles = (props: { text: string; pillar: Pillar }): ReactElement =>
-    styledH(
-        'span',
-        { css: css`
-              ${textSans.xsmall({ italic: true })}
-               ${textSans.xsmall({ fontWeight: 'bold' })}
-               color: ${neutral[86]};
-        ` },
-        props.text,
-    );
+const emphasisStyles = css`
+    ${textSans.xsmall({ italic: true, fontWeight: 'bold' })}
+    color: ${neutral[86]};
+`;
 
-const captionElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {
+const Emphasis = ({ text }: { text: string }): ReactElement =>
+    styledH('span', { css: emphasisStyles }, text);
+
+const captionElement = (format: Format) => (node: Node, key: number): ReactNode => {
     const text = node.textContent ?? '';
-    const children = Array.from(node.childNodes).map(captionElement(pillar));
+    const children = Array.from(node.childNodes).map(captionElement(format));
     switch (node.nodeName) {
         case 'STRONG':
             return styledH('p', {css: captionHeadingStyles, key}, children);
         case 'BR':
             return null;
         case 'EM':
-            return h(CaptionItalicStyles, {text, pillar, key}, children);
+            return h(Emphasis, { text, key }, children);
         case '#text':
-            return h(MediaCaptionText, { text, pillar, key }, children);
+            return h(MediaCaptionText, { text, key }, children);
         default:
-            return textElement(pillar)(node, key);
+            return textElement(format)(node, key);
     }
 }
 
-const standfirstTextElement = (pillar: Pillar) => (node: Node, key: number): ReactNode => {
-    const children = Array.from(node.childNodes).map(standfirstTextElement(pillar));
+const standfirstTextElement = (format: Format) => (node: Node, key: number): ReactNode => {
+    const children = Array.from(node.childNodes).map(standfirstTextElement(format));
     switch (node.nodeName) {
         case 'P':
             return h('p', { key }, children);
         default:
-            return textElement(pillar)(node, key);
+            return textElement(format)(node, key);
     }
 };
 
-const text = (doc: DocumentFragment, pillar: Pillar): ReactNode[] =>
-    Array.from(doc.childNodes).map(textElement(pillar));
+const text = (doc: DocumentFragment, format: Format): ReactNode[] =>
+    Array.from(doc.childNodes).map(textElement(format));
 
-const standfirstText = (doc: DocumentFragment, pillar: Pillar): ReactNode[] =>
-    Array.from(doc.childNodes).map(standfirstTextElement(pillar));
+const standfirstText = (doc: DocumentFragment, format: Format): ReactNode[] =>
+    Array.from(doc.childNodes).map(standfirstTextElement(format));
 
 const pullquoteStyles = (colour: string): SerializedStyles => css`
     color: ${colour};
@@ -287,15 +295,15 @@ const pullquoteStyles = (colour: string): SerializedStyles => css`
 
 type PullquoteProps = {
     quote: string;
-    attribution: Option<string>;
-    pillar: Pillar;
+    format: Format;
 };
 
-const Pullquote = (props: PullquoteProps): ReactElement =>
-    styledH('aside', { css: pullquoteStyles(getPillarStyles(props.pillar).kicker) },
+const Pullquote: FC<PullquoteProps> = ({ quote, format }: PullquoteProps) =>
+    styledH('aside',
+        { css: pullquoteStyles(getPillarStyles(format.pillar).kicker) },
         h('blockquote', null,
-            h('p', null, props.quote)
-        )
+            h('p', null, quote)
+        ),
     );
 
 const richLinkWidth = '8.75rem';
@@ -339,10 +347,10 @@ const richLinkStyles = css`
     `}
 `;
 
-const RichLink = (props: { url: string; linkText: string; pillar: Pillar }): ReactElement =>
+const RichLink = (props: { url: string; linkText: string; format: Format }): ReactElement =>
     styledH('aside', { css: richLinkStyles },
         h('h1', null, props.linkText),
-        h(Anchor, { href: props.url, pillar: props.pillar, text: 'Read more' }),
+        h(Anchor, { href: props.url, format: props.format, text: 'Read more' }),
     );
 
 const Interactive = (props: { url: string; title?: string }): ReactElement =>
@@ -350,17 +358,20 @@ const Interactive = (props: { url: string; title?: string }): ReactElement =>
         h('iframe', { src: props.url, height: 500, title: props.title ?? "" }, null)
     );
 
-const Tweet = (props: { content: NodeList; pillar: Pillar; key: number }): ReactElement => {
+const Tweet = (props: { content: NodeList; format: Format; key: number }): ReactElement =>
     // twitter script relies on twitter-tweet class being present
-    return styledH('blockquote', { key: props.key, className: 'twitter-tweet', css: TweetStyles }, ...Array.from(props.content).map(textElement(props.pillar)));
-};
+    styledH(
+        'blockquote',
+        { key: props.key, className: 'twitter-tweet', css: TweetStyles },
+        ...Array.from(props.content).map(textElement(props.format)),
+    );
 
-const render = (pillar: Pillar, imageMappings: ImageMappings) =>
+const render = (format: Format, imageMappings: ImageMappings) =>
     (element: BodyElement, key: number): ReactNode => {
     switch (element.kind) {
 
         case ElementKind.Text:
-            return text(element.doc, pillar);
+            return text(element.doc, format);
 
         case ElementKind.Image: {
             const { caption, credit, role } = element;
@@ -369,29 +380,26 @@ const render = (pillar: Pillar, imageMappings: ImageMappings) =>
                 .withDefault(BodyImage);
 
             const figcaption = caption.fmap<ReactNode>(c =>
-                h(FigCaption, { pillar, text: text(c, pillar), credit })
+                h(FigCaption, { pillar: format.pillar, text: text(c, format), credit })
             ).withDefault(null);
             
             return h(ImageComponent, { image: element, imageMappings }, figcaption);
         }
 
-        case ElementKind.Pullquote: {
-            const { quote, attribution } = element;
-
-            return h(Pullquote, { quote, attribution, pillar, key });
-        }
+        case ElementKind.Pullquote:
+            return h(Pullquote, { quote: element.quote, format, key });
 
         case ElementKind.RichLink: {
             const { url, linkText } = element;
 
-            return h(RichLink, { url, linkText, pillar, key });
+            return h(RichLink, { url, linkText, format, key });
         }
 
         case ElementKind.Interactive:
             return h(Interactive, { url: element.url, key, title: element.alt });
 
         case ElementKind.Tweet:
-            return h(Tweet, { content: element.content, pillar, key });
+            return h(Tweet, { content: element.content, format, key });
 
         case ElementKind.Audio:
             return h(Audio, { src: element.src, width: element.width, height: element.height });
@@ -413,21 +421,21 @@ const render = (pillar: Pillar, imageMappings: ImageMappings) =>
 };
 
 const renderAll = (imageMappings: ImageMappings) =>
-    (pillar: Pillar, elements: BodyElement[]): ReactNode[] =>
-        elements.map(render(pillar, imageMappings));
+    (format: Format, elements: BodyElement[]): ReactNode[] =>
+        elements.map(render(format, imageMappings));
 
-const renderCaption = (doc: DocumentFragment, pillar: Pillar): ReactNode[] =>
-    Array.from(doc.childNodes).map(captionElement(pillar));
+const renderCaption = (doc: DocumentFragment, format: Format): ReactNode[] =>
+    Array.from(doc.childNodes).map(captionElement(format));
 
 const renderMedia = (imageMappings: ImageMappings) =>
-    (pillar: Pillar, elements: BodyElement[]): ReactNode[] =>
+    (format: Format, elements: BodyElement[]): ReactNode[] =>
         elements.map((element) => {
 
             if (element.kind === ElementKind.Image) {
                 const { caption, credit } = element;
 
                 const figcaption = caption.fmap<ReactNode>(c => 
-                    h(MediaFigCaption, { text: renderCaption(c, pillar), credit })
+                    h(MediaFigCaption, { text: renderCaption(c, format), credit })
                 ).withDefault(null);
 
                 return h(BodyImage, {


### PR DESCRIPTION
## Why are you doing this?

The functions in the renderer now take the wider `Format` type instead of just `Pillar`. This reflects the fact that `Format` describes everything that's needed to express the design of a piece of content. It also paves the way for some upcoming work that relies on this fact.

## Changes

- Updated `renderer` functions to take `Format`
- Updated corresponding components to take `Format`
