### PR TITLE
support photo essay articles

### DIFF
--- a/src/capi.ts
+++ b/src/capi.ts
@@ -50,8 +50,12 @@ interface Series {
 const tagsOfType = (tagType: TagType) => (tags: Tag[]): Tag[] =>
     tags.filter((tag: Tag) => tag.type === tagType);
 
+
 const isImmersive = (content: Content): boolean =>
     content?.fields?.displayHint === 'immersive';
+
+const isPhotoEssay = (content: Content): boolean =>
+    content?.fields?.displayHint === 'photoEssay';
 
 const isFeature = (content: Content): boolean =>
     content.tags.some(tag => tag.id === 'tone/features');
@@ -121,6 +125,7 @@ export {
     Series,
     ErrorStatus as CapiError,
     getContent,
+    isPhotoEssay,
     isImmersive,
     isFeature,
     isReview,

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -1,15 +1,13 @@
 // ----- Imports ----- //
 
-import React, { FC, ReactNode } from 'react';
+import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { from } from '@guardian/src-foundations/mq';
 import { remSpace, breakpoints } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 
-import { Image } from 'image';
 import Img from 'components/img';
-import { ImageMappings } from 'components/shared/page';
-
+import { BodyImageProps } from 'image';
 
 // ----- Setup ----- //
 
@@ -18,18 +16,8 @@ const sizes = `(min-width: ${breakpoints.phablet}px) 620px, 100vw`;
 
 // ----- Component ----- //
 
-interface Props {
-    image: Image;
-    imageMappings: ImageMappings;
-    children?: ReactNode;
-}
-
 const styles = css`
-    margin: ${remSpace[4]} 0 ${remSpace[3]};
-
-    ${from.wide} {
-        margin-bottom: ${remSpace[4]};
-    }
+    margin: ${remSpace[4]} 0;
 `;
 
 const imgStyles = (width: number, height: number): SerializedStyles => css`
@@ -43,7 +31,7 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     }
 `;
 
-const BodyImage: FC<Props> = ({ image, imageMappings, children }: Props) =>
+const BodyImage: FC<BodyImageProps> = ({ image, imageMappings, children }: BodyImageProps) =>
     <figure css={styles}>
         <Img
             image={image}

--- a/src/components/bodyImageHalfWidth.tsx
+++ b/src/components/bodyImageHalfWidth.tsx
@@ -4,18 +4,19 @@ import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import Img from 'components/img';
 import { BodyImageProps as Props } from 'image';
-import { remSpace } from '@guardian/src-foundations';
+import { remSpace, breakpoints } from '@guardian/src-foundations';
 
 // ----- Setup ----- //
 
-const size = `calc(50% - ${remSpace[1]})`;
+const figureWidth = `calc(50% - ${remSpace[1]})`;
+const size = `(min-width: ${breakpoints.phablet}px) 310px, 50vw`;
 
 // ----- Component ----- //
 
 const styles = css`
     margin: ${remSpace[1]} 0 0 0;
     display: inline-block;
-    width: ${size};
+    width: ${figureWidth};
 
     + .halfWidth, + .halfWidth + .halfWidth + .halfWidth {
         margin-left: ${remSpace[2]};
@@ -27,7 +28,7 @@ const styles = css`
 `;
 
 const imgStyles = (width: number, height: number): SerializedStyles => css`
-    height: calc(${size} * ${height / width});
+    height: calc(${figureWidth} * ${height / width});
     width: 100%;
 `;
 

--- a/src/components/bodyImageHalfWidth.tsx
+++ b/src/components/bodyImageHalfWidth.tsx
@@ -2,38 +2,41 @@
 
 import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
-import { remSpace } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
 import Img from 'components/img';
 import { BodyImageProps } from 'image';
+import { remSpace } from '@guardian/src-foundations';
 
 // ----- Setup ----- //
 
-const size = '8.75rem';
-
+const size = `calc(50% - ${remSpace[1]})`;
 
 // ----- Component ----- //
 
 const styles = css`
-    display: block;
-    float: left;
-    clear: left;
+    margin: ${remSpace[1]} 0 0 0;
+    display: inline-block;
     width: ${size};
-    margin: 0 ${remSpace[3]} 0 0;
 
-    ${from.wide} {
-        margin-left: calc(-${size} - ${remSpace[3]} - ${remSpace[2]});
-        margin-right: 0;
-        padding: 0;
+    figcaption {
+        display: none;
+    }
+
+    + .halfWidth, + .halfWidth + .halfWidth + .halfWidth {
+        margin-left: ${remSpace[2]};
+    }
+
+    + .halfWidth + .halfWidth  {
+        margin-left: 0;
     }
 `;
 
 const imgStyles = (width: number, height: number): SerializedStyles => css`
     height: calc(${size} * ${height / width});
+    width: 100%;
 `;
 
-const BodyImageThumbnail: FC<BodyImageProps> = ({ image, imageMappings, children }: BodyImageProps) =>
-    <figure css={styles}>
+const BodyImageHalfWidth: FC<BodyImageProps> = ({ image, imageMappings, children }: BodyImageProps) =>
+    <figure css={styles} className="halfWidth">
         <Img
             image={image}
             imageMappings={imageMappings}
@@ -46,4 +49,4 @@ const BodyImageThumbnail: FC<BodyImageProps> = ({ image, imageMappings, children
 
 // ----- Exports ----- //
 
-export default BodyImageThumbnail;
+export default BodyImageHalfWidth;

--- a/src/components/bodyImageHalfWidth.tsx
+++ b/src/components/bodyImageHalfWidth.tsx
@@ -3,7 +3,7 @@
 import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import Img from 'components/img';
-import { BodyImageProps } from 'image';
+import { BodyImageProps as Props } from 'image';
 import { remSpace } from '@guardian/src-foundations';
 
 // ----- Setup ----- //
@@ -35,7 +35,7 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     width: 100%;
 `;
 
-const BodyImageHalfWidth: FC<BodyImageProps> = ({ image, imageMappings, children }: BodyImageProps) =>
+const BodyImageHalfWidth: FC<Props> = ({ image, imageMappings, children }: Props) =>
     <figure css={styles} className="halfWidth">
         <Img
             image={image}

--- a/src/components/bodyImageHalfWidth.tsx
+++ b/src/components/bodyImageHalfWidth.tsx
@@ -17,10 +17,6 @@ const styles = css`
     display: inline-block;
     width: ${size};
 
-    figcaption {
-        display: none;
-    }
-
     + .halfWidth, + .halfWidth + .halfWidth + .halfWidth {
         margin-left: ${remSpace[2]};
     }
@@ -35,7 +31,7 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     width: 100%;
 `;
 
-const BodyImageHalfWidth: FC<Props> = ({ image, imageMappings, children }: Props) =>
+const BodyImageHalfWidth: FC<Props> = ({ image, imageMappings }: Props) =>
     <figure css={styles} className="halfWidth">
         <Img
             image={image}
@@ -43,7 +39,6 @@ const BodyImageHalfWidth: FC<Props> = ({ image, imageMappings, children }: Props
             sizes={size}
             className={imgStyles(image.width, image.height)}
         />
-        {children}
     </figure>;
 
 

--- a/src/components/bodyImageThumbnail.tsx
+++ b/src/components/bodyImageThumbnail.tsx
@@ -5,7 +5,7 @@ import { css, SerializedStyles } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import Img from 'components/img';
-import { BodyImageProps } from 'image';
+import { BodyImageProps as Props } from 'image';
 
 // ----- Setup ----- //
 
@@ -32,7 +32,7 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     height: calc(${size} * ${height / width});
 `;
 
-const BodyImageThumbnail: FC<BodyImageProps> = ({ image, imageMappings, children }: BodyImageProps) =>
+const BodyImageThumbnail: FC<Props> = ({ image, imageMappings, children }: Props) =>
     <figure css={styles}>
         <Img
             image={image}

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -10,7 +10,6 @@ import { remSpace } from '@guardian/src-foundations';
 import { Item } from 'item';
 import { renderText, renderStandfirstText } from 'renderer';
 import { darkModeCss as darkMode } from 'styles';
-import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Display, Design } from 'format';
 
 
@@ -58,15 +57,10 @@ const thinHeadline = css`
     }
 `;
 
-const immersive = (pillarStyles: PillarStyles): SerializedStyles => css`
+const immersive: SerializedStyles = css`
     ${styles}
     ${headline.xsmall({ fontWeight: 'light' })}
     margin-top: ${remSpace[3]};
-
-    a {
-        box-shadow: inset 0 -0.1rem ${pillarStyles.kicker};
-        padding-bottom: 0.2rem;
-    }
 `;
 
 const media = css`
@@ -80,18 +74,11 @@ const media = css`
         height: 0.7rem;
         width: 0.7rem;
     }
-   
-    a {
-        color: ${neutral[86]};
-        box-shadow: inset 0 -0.1rem ${neutral[46]};
-    }
 `;
 
 const getStyles = (item: Item): SerializedStyles => {
-    const pillarStyles = getPillarStyles(item.pillar);
-
     if (item.display === Display.Immersive) {
-        return immersive(pillarStyles);
+        return immersive;
     }
 
     switch (item.design) {

--- a/src/image.ts
+++ b/src/image.ts
@@ -5,6 +5,7 @@ import { createHash } from 'crypto';
 import { ImageMappings } from 'components/shared/page';
 import { Option, Some, None, fromNullable } from 'types/option';
 import { IBlockElement as BlockElement } from 'mapiThriftModels';
+import { ReactNode } from 'react';
 
 
 // ----- Setup ----- //
@@ -27,6 +28,7 @@ const defaultQuality = 85;
 
 enum Role {
     Thumbnail,
+    HalfWidth
 }
 
 interface Image {
@@ -40,6 +42,11 @@ interface Image {
     role: Option<Role>;
 }
 
+interface BodyImageProps {
+    image: Image;
+    imageMappings: ImageMappings;
+    children?: ReactNode;
+}
 
 // ----- Functions ----- //
 
@@ -98,7 +105,16 @@ const parseImage = (docParser: (html: string) => DocumentFragment) =>
             ),
             nativeCaption: fromNullable(data?.caption),
             role: fromNullable(data?.role).andThen<Role>(
-                r => r === 'thumbnail' ? new Some(Role.Thumbnail) : new None()
+                role => {
+                    switch(role) {
+                        case 'thumbnail':
+                            return new Some(Role.Thumbnail)
+                        case 'halfWidth':
+                            return new Some(Role.HalfWidth)
+                        default:
+                            return new None()
+                    }
+                }
             ),
         });
     });
@@ -115,4 +131,5 @@ export {
     srcsetWithWidths,
     sign,
     parseImage,
+    BodyImageProps
 };

--- a/src/item.ts
+++ b/src/item.ts
@@ -4,7 +4,7 @@ import { pillarFromString } from 'pillarStyles';
 import { IContent as Content } from 'mapiThriftModels/Content';
 import { IBlockElement as BlockElement } from 'mapiThriftModels/BlockElement';
 import { ITag as Tag } from 'mapiThriftModels/Tag';
-import { articleMainImage, articleContributors, articleSeries } from 'capi';
+import { articleMainImage, articleContributors, articleSeries, isPhotoEssay, isImmersive } from 'capi';
 import { Option, fromNullable, None, Some } from 'types/option';
 import { Err, Ok, Result } from 'types/result';
 import {
@@ -359,7 +359,7 @@ const isShowcaseEmbed = (content: Content): boolean =>
 
 function getDisplay(content: Content): Display {
 
-    if (content.fields?.displayHint === 'immersive') {
+    if (isImmersive(content) || isPhotoEssay(content)) {
         return Display.Immersive;
     // This is meant to replicate the current logic in frontend:
     // https://github.com/guardian/frontend/blob/88cfa609c73545085c3e5f3921631ec344a3eb83/common/app/model/meta.scala#L586

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -379,9 +379,11 @@ const render = (pillar: Pillar, imageMappings: ImageMappings) =>
                 .fmap(imageComponentFromRole)
                 .withDefault(BodyImage);
 
-            const figcaption = caption.fmap<ReactNode>(c =>
-                h(FigCaption, { pillar, text: text(c, pillar), credit })
-            ).withDefault(null);
+            const figcaption = role.withDefault(Role.Thumbnail) === Role.HalfWidth
+                ? caption.fmap<ReactNode>(c =>
+                    h(FigCaption, { pillar, text: text(c, pillar), credit })
+                  ).withDefault(null)
+                : null;
             
             return h(ImageComponent, { image: element, imageMappings }, figcaption);
         }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { ReactNode, createElement as h, ReactElement } from 'react';
+import { ReactNode, createElement as h, ReactElement, FC } from 'react';
 import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { from, until } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
@@ -9,7 +9,7 @@ import { basePx, icons, darkModeCss } from 'styles';
 import { getPillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
 import { ElementKind, BodyElement } from 'item';
-import { Role } from 'image';
+import { Role, BodyImageProps } from 'image';
 import { body, headline, textSans } from '@guardian/src-foundations/typography';
 import { remSpace } from '@guardian/src-foundations';
 import { ImageMappings } from 'components/shared/page';
@@ -20,6 +20,7 @@ import BodyImage from 'components/bodyImage';
 import BodyImageThumbnail from 'components/bodyImageThumbnail';
 import FigCaption from 'components/figCaption';
 import MediaFigCaption from 'components/media/mediaFigCaption';
+import BodyImageHalfWidth from 'components/bodyImageHalfWidth';
 
 
 // ----- Renderer ----- //
@@ -355,6 +356,16 @@ const Tweet = (props: { content: NodeList; pillar: Pillar; key: number }): React
     return styledH('blockquote', { key: props.key, className: 'twitter-tweet', css: TweetStyles }, ...Array.from(props.content).map(textElement(props.pillar)));
 };
 
+const imageComponentFromRole = (role: Role): FC<BodyImageProps> => {
+    if (role === Role.Thumbnail) {
+        return BodyImageThumbnail;
+    } else if (role === Role.HalfWidth) {
+        return BodyImageHalfWidth;
+    } else {
+        return BodyImage;
+    }
+}
+
 const render = (pillar: Pillar, imageMappings: ImageMappings) =>
     (element: BodyElement, key: number): ReactNode => {
     switch (element.kind) {
@@ -365,7 +376,7 @@ const render = (pillar: Pillar, imageMappings: ImageMappings) =>
         case ElementKind.Image: {
             const { caption, credit, role } = element;
             const ImageComponent = role
-                .fmap(imageRole => imageRole === Role.Thumbnail ? BodyImageThumbnail : BodyImage)
+                .fmap(imageComponentFromRole)
                 .withDefault(BodyImage);
 
             const figcaption = caption.fmap<ReactNode>(c =>

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -379,7 +379,7 @@ const render = (pillar: Pillar, imageMappings: ImageMappings) =>
                 .fmap(imageComponentFromRole)
                 .withDefault(BodyImage);
 
-            const figcaption = role.withDefault(Role.Thumbnail) === Role.HalfWidth
+            const figcaption = role.withDefault(Role.Thumbnail) !== Role.HalfWidth
                 ? caption.fmap<ReactNode>(c =>
                     h(FigCaption, { pillar, text: text(c, pillar), credit })
                   ).withDefault(null)


### PR DESCRIPTION
## Changes

- Support new image role "halfWidth"
- Remove old anchor styles on immersive articles
- Render as immersive if an article contains a displayHint of "photoEssay"
- Abstract `bodyImageProps`

## Screenshots

`HalfWidthBodyImage`

<img width="633" alt="Screen Shot 2020-04-22 at 17 45 09" src="https://user-images.githubusercontent.com/11618797/80010014-b648cb80-84c1-11ea-87f3-f8af14c236f9.png">

