### PR TITLE
Consolidate Caption Rendering In FigCaption

### DIFF
--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -1,0 +1,39 @@
+// ----- Imports ----- //
+
+import React, { FC, ReactNode } from 'react';
+import { SerializedStyles, css } from '@emotion/core';
+import { Format } from '@guardian/types/Format';
+import { neutral } from '@guardian/src-foundations/palette';
+
+import { darkModeCss } from 'styles';
+import { getPillarStyles } from 'pillarStyles';
+
+
+// ----- Component ----- //
+
+interface Props {
+    href: string;
+    children?: ReactNode;
+    format: Format;
+    className?: SerializedStyles;
+}
+
+const styles = (colour: string): SerializedStyles => css`
+    color: ${colour};
+    text-decoration: none;
+    border-bottom: 0.0625rem solid ${neutral[86]};
+
+    ${darkModeCss`
+        color: ${neutral[86]};
+    `}
+`;
+
+const Anchor: FC<Props> = ({ format, children, href, className }: Props) =>
+    <a css={[styles(getPillarStyles(format.pillar).kicker), className]} href={href}>
+        {children}
+    </a>
+
+
+// ----- Exports ----- //
+
+export default Anchor;

--- a/src/components/figCaption.stories.tsx
+++ b/src/components/figCaption.stories.tsx
@@ -26,7 +26,16 @@ const credit = (): Option<string> => {
     return new None();
 }
 
-const caption = 'A generic caption for an image on the page';
+const caption = (): Option<DocumentFragment> => {
+    const fragment = document.createDocumentFragment();
+    const node = document.createTextNode(
+        text('Copy', 'A generic caption for an image on the page'),
+    );
+
+    fragment.appendChild(node);
+
+    return new Some(fragment);
+}
 
 
 // ----- Stories ----- //
@@ -34,7 +43,7 @@ const caption = 'A generic caption for an image on the page';
 const Default: FC = () =>
     <FigCaption
         format={format}
-        text={text('Copy', caption)}
+        caption={caption()}
         credit={credit()}
     />
 
@@ -42,7 +51,7 @@ const Media: FC = () =>
     <div css={css`background-color: ${background.inverse};`}>
         <FigCaption
             format={{ ...format, design: Design.Media }}
-            text={text('Copy', caption)}
+            caption={caption()}
             credit={credit()}
         />
     </div>

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -42,6 +42,21 @@ const Triangle: FC<TriangleProps> = ({ format }: TriangleProps) => {
     }
 }
 
+interface CreditProps {
+    credit: Option<string>;
+    format: Format;
+}
+
+const Credit: FC<CreditProps> = ({ format, credit }: CreditProps) =>
+    credit.fmap<ReactElement | null>(cred => {
+        switch (format.design) {
+            case Design.Media:
+                return <p>{cred}</p>;
+            default:
+                return <> {cred}</>;
+        }
+    }).withDefault(null);
+
 const captionHeadingStyles = css`
     ${headline.xxxsmall()}
     color: ${neutral[86]};
@@ -119,7 +134,7 @@ const FigCaption: FC<Props> = ({ format, caption, credit }: Props) =>
         <figcaption css={getStyles(format)}>
             <Triangle format={format} />
             {renderCaption(cap, format)}
-            {credit.fmap<ReactElement | null>(cred => <p>{cred}</p>).withDefault(null)}
+            <Credit format={format} credit={credit} />
         </figcaption>
     ).withDefault(null);
 

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -64,6 +64,8 @@ const captionElement = (format: Format) => (node: Node, key: number): ReactNode 
             return <h2 css={captionHeadingStyles} key={key}>{children}</h2>;
         case 'BR':
             return null;
+        case 'EM':
+            return <em key={key}>{children}</em>
         case 'A':
             return (
                 <Anchor

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -12,11 +12,11 @@ import { IContent as Content } from 'mapiThriftModels/Content';
 import { includesTweets } from 'capi';
 import { fontFace } from 'styles';
 import { None, Some } from 'types/option';
-import { renderAll, renderMedia } from 'renderer';
+import { renderAll } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { partition } from 'types/result';
 import { getAdPlaceholderInserter } from 'ads';
-import { fromCapi, getFormat } from 'item';
+import { fromCapi, getFormat, ElementKind } from 'item';
 import { sign } from 'image';
 import {
     ElementType,
@@ -210,9 +210,9 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
     }
 
     if (item.design === Design.Media) {
-        const body = partition(item.body).oks;
+        const body = partition(item.body).oks.filter(elem => elem.kind === ElementKind.Image);
         const mediaContent =
-            insertAdPlaceholders(renderMedia(imageMappings)(format, body));
+            insertAdPlaceholders(renderAll(imageMappings)(format, body));
         return { element: (
                 <WithScript src={mediaScript}>
                     <Media imageMappings={imageMappings} item={item}>

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -1,8 +1,7 @@
-import { renderMedia, renderStandfirstText, renderText } from './renderer';
+import { renderAll, renderStandfirstText, renderText } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { Pillar } from 'format';
 import { ReactNode } from 'react';
-import { renderAll } from 'renderer';
 import { compose } from 'lib';
 import { BodyElement, ElementKind } from 'item';
 import { Role } from 'image';
@@ -83,7 +82,7 @@ const render = (element: BodyElement): ReactNode[] =>
     renderAll({})(mockFormat, [element]);
 
 const renderCaption = (element: BodyElement): ReactNode[] =>
-    renderMedia({})(mockFormat, [element]);
+    renderAll({})(mockFormat, [element]);
 
 const renderTextElement = compose(render, textElement);
 


### PR DESCRIPTION
## Why are you doing this?

Consolidating the caption rendering code in the `FigCaption` component and simplifying the `renderer` module. Also brings the media captions more in line with dotcom. This change is possible in part due to the splitting out of captions and credits in #288.

## Changes

- Migrated caption rendering functions to `FigCaption`
- Updated media caption styles to match dotcom
- Pulled `Anchor` component into own module
- Allowed `renderAll` to handle media content

## Screenshots

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/53781962/80228802-698efd00-8647-11ea-8255-84e583780bad.jpg) | ![after](https://user-images.githubusercontent.com/53781962/80228785-6431b280-8647-11ea-9b76-6e57888a13a7.jpg)
