### PR TITLE
render advertisementFeatures

### DIFF
--- a/src/components/advertisementFeature/article.tsx
+++ b/src/components/advertisementFeature/article.tsx
@@ -1,0 +1,79 @@
+// ----- Imports ----- //
+
+import React, { ReactNode } from 'react';
+import { css } from '@emotion/core';
+import { neutral, background } from '@guardian/src-foundations/palette';
+import { from, breakpoints } from '@guardian/src-foundations/mq';
+
+import HeaderImage from 'components/headerImage';
+import Series from 'components/shared/articleSeries';
+import Headline from 'components/headline';
+import Standfirst from 'components/standfirst';
+import Body from 'components/shared/articleBody';
+import Metadata from 'components/standard/metadata';
+import { darkModeCss, articleWidthStyles } from 'styles';
+import { Keyline } from 'components/shared/keyline';
+import { Standard, Review, getFormat } from 'item';
+import { ImageMappings } from 'components/shared/page';
+
+
+// ----- Styles ----- //
+
+const Styles = css`
+    background: ${neutral[97]};
+`;
+
+const DarkStyles = darkModeCss`
+    background: ${background.inverse};
+`;
+
+const BorderStyles = css`
+    background: ${neutral[100]};
+    ${darkModeCss`background: ${background.inverse};`}
+
+    ${from.wide} {
+        width: ${breakpoints.wide}px;
+        margin: 0 auto;
+    }
+`;
+
+
+// ----- Component ----- //
+
+interface Props {
+    imageMappings: ImageMappings;
+    item: Standard | Review;
+    children: ReactNode[];
+}
+
+const AdvertisementFeature = ({ imageMappings, item, children }: Props): JSX.Element => {
+    return <main css={[Styles, DarkStyles]}>
+        <article css={BorderStyles}>
+            <header>
+                <HeaderImage
+                    image={item.mainImage}
+                    imageMappings={imageMappings}
+                    format={getFormat(item)}
+                />
+                <div css={articleWidthStyles}>
+                    <Series series={item.series} pillar={item.pillar} />
+                    <Headline item={item} />
+                    <Standfirst item={item} />
+
+                </div>
+                <Keyline {...item} />
+                <section css={articleWidthStyles}>
+                    <Metadata imageMappings={imageMappings} item={item} />
+                </section>
+            </header>
+            <Body pillar={item.pillar} className={[articleWidthStyles]}>
+                {children}
+            </Body>
+        </article>
+    </main>
+}
+
+
+// ----- Exports ----- //
+
+export default AdvertisementFeature;

--- a/src/components/advertisementFeature/article.tsx
+++ b/src/components/advertisementFeature/article.tsx
@@ -13,7 +13,7 @@ import Body from 'components/shared/articleBody';
 import Metadata from 'components/standard/metadata';
 import { darkModeCss, articleWidthStyles } from 'styles';
 import { Keyline } from 'components/shared/keyline';
-import { Standard, Review, getFormat } from 'item';
+import { Standard, getFormat } from 'item';
 import { ImageMappings } from 'components/shared/page';
 
 
@@ -42,7 +42,7 @@ const BorderStyles = css`
 
 interface Props {
     imageMappings: ImageMappings;
-    item: Standard | Review;
+    item: Standard;
     children: ReactNode[];
 }
 

--- a/src/components/byline.stories.tsx
+++ b/src/components/byline.stories.tsx
@@ -47,6 +47,14 @@ const Comment: FC = () =>
         bylineHtml={mockBylineHtml()}
     />
 
+const Labs: FC = () =>
+    <Byline
+        pillar={selectPillar(Pillar.News)}
+        design={Design.AdvertisementFeature}
+        display={Display.Standard}
+        bylineHtml={mockBylineHtml()}
+    />
+
 
 // ----- Exports ----- //
 
@@ -59,4 +67,5 @@ export default {
 export {
     Default,
     Comment,
+    Labs
 }

--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -9,7 +9,7 @@ import { Option } from 'types/option';
 import { neutral, palette } from '@guardian/src-foundations';
 import { getPillarStyles } from 'pillarStyles';
 import { getHref } from 'renderer';
-import { darkModeCss } from 'styles';
+import { darkModeCss, textSans } from 'styles';
 
 
 // ----- Component ----- //
@@ -54,6 +54,7 @@ const commentAnchorStyles = (kicker: string, inverted: string): SerializedStyles
 
 const advertisementFeatureStyles = css`
     ${headline.xxxsmall()}
+    ${textSans}
     color: ${palette.labs[300]};
 
     ${darkModeCss`
@@ -62,7 +63,7 @@ const advertisementFeatureStyles = css`
 `;
 
 const advertisementFeatureAnchorStyles = css`
-    ${headline.xxxsmall({ fontWeight: 'bold' })}
+    font-weight: bold;
     color: ${palette.labs[300]};
     font-style: normal;
     text-decoration: none;

--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -6,7 +6,7 @@ import { headline } from '@guardian/src-foundations/typography';
 
 import { Design, Format } from 'format';
 import { Option } from 'types/option';
-import { neutral } from '@guardian/src-foundations';
+import { neutral, palette } from '@guardian/src-foundations';
 import { getPillarStyles } from 'pillarStyles';
 import { getHref } from 'renderer';
 import { darkModeCss } from 'styles';
@@ -27,6 +27,17 @@ const styles = (kicker: string): SerializedStyles => css`
     `}
 `;
 
+const anchorStyles = (kicker: string, inverted: string): SerializedStyles => css`
+    ${headline.xxxsmall({ fontWeight: 'bold' })}
+    font-style: normal;
+    color: ${kicker};
+    text-decoration: none;
+
+    ${darkModeCss`
+        color: ${inverted};
+    `}
+`;
+
 const commentStyles = (kicker: string): SerializedStyles => css`
     color: ${kicker};
     ${headline.medium({ fontWeight: 'light', italic: true })}
@@ -41,14 +52,23 @@ const commentAnchorStyles = (kicker: string, inverted: string): SerializedStyles
     `}
 `;
 
-const anchorStyles = (kicker: string, inverted: string): SerializedStyles => css`
+const advertisementFeatureStyles = css`
+    ${headline.xxxsmall()}
+    color: ${palette.labs[300]};
+
+    ${darkModeCss`
+        color: ${palette.labs[400]};
+    `}
+`;
+
+const advertisementFeatureAnchorStyles = css`
     ${headline.xxxsmall({ fontWeight: 'bold' })}
+    color: ${palette.labs[300]};
     font-style: normal;
-    color: ${kicker};
     text-decoration: none;
 
     ${darkModeCss`
-        color: ${inverted};
+        color: ${palette.labs[400]};
     `}
 `;
 
@@ -58,6 +78,9 @@ const getStyles = (format: Format): SerializedStyles => {
     switch (format.design) {
         case Design.Comment:
             return commentStyles(kicker);
+
+        case Design.AdvertisementFeature:
+            return advertisementFeatureStyles;
 
         default:
             return styles(kicker);
@@ -70,6 +93,9 @@ const getAnchorStyles = (format: Format): SerializedStyles => {
     switch (format.design) {
         case Design.Comment:
             return commentAnchorStyles(kicker, inverted);
+
+        case Design.AdvertisementFeature:
+            return advertisementFeatureAnchorStyles;
         
         default:
             return anchorStyles(kicker, inverted);

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -4,10 +4,10 @@ import React, { FC, ReactElement, ReactNode } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { text, neutral } from '@guardian/src-foundations/palette';
-import { remSpace } from '@guardian/src-foundations';
+import { remSpace, palette } from '@guardian/src-foundations';
 import { Format, Design } from '@guardian/types/Format';
 
-import { PillarStyles, getPillarStyles } from 'pillarStyles';
+import { getPillarStyles } from 'pillarStyles';
 import { Option } from 'types/option';
 import { renderTextElement, getHref } from 'renderer';
 import Anchor from 'components/anchor';
@@ -19,26 +19,30 @@ interface TriangleProps {
     format: Format;
 }
 
-const triangleStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
-    fill: ${kicker};
+const triangleStyles = (colour: string): SerializedStyles => css`
+    fill: ${colour};
     height: 0.8em;
     padding-right: ${remSpace[1]};
 `;
+
+const triangleSvg = (colour: string) =>
+    <svg
+        css={triangleStyles(colour)}
+        viewBox="0 0 10 9"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <polygon points="0,9 5,0 10,9 0,9" />
+    </svg>
 
 const Triangle: FC<TriangleProps> = ({ format }: TriangleProps) => {
     switch (format.design) {
         case Design.Media:
             return null;
+        case Design.AdvertisementFeature:
+            return triangleSvg(palette.labs[300]);
         default:
-            return (
-                <svg
-                    css={triangleStyles(getPillarStyles(format.pillar))}
-                    viewBox="0 0 10 9"
-                    xmlns="http://www.w3.org/2000/svg"
-                >
-                    <polygon points="0,9 5,0 10,9 0,9" />
-                </svg>
-            );
+            const colour = getPillarStyles(format.pillar).kicker;
+            return triangleSvg(colour);
     }
 }
 

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -25,7 +25,7 @@ const triangleStyles = (colour: string): SerializedStyles => css`
     padding-right: ${remSpace[1]};
 `;
 
-const triangleSvg = (colour: string) =>
+const triangleSvg = (colour: string): ReactElement =>
     <svg
         css={triangleStyles(colour)}
         viewBox="0 0 10 9"
@@ -41,8 +41,7 @@ const Triangle: FC<TriangleProps> = ({ format }: TriangleProps) => {
         case Design.AdvertisementFeature:
             return triangleSvg(palette.labs[300]);
         default:
-            const colour = getPillarStyles(format.pillar).kicker;
-            return triangleSvg(colour);
+            return triangleSvg(getPillarStyles(format.pillar).kicker);
     }
 }
 

--- a/src/components/follow.tsx
+++ b/src/components/follow.tsx
@@ -8,6 +8,7 @@ import { Format } from 'format';
 import { getPillarStyles } from 'pillarStyles';
 import { Contributor, isSingleContributor } from 'contributor';
 import { darkModeCss } from 'styles';
+import { Design } from '@guardian/types/Format';
 
 
 // ----- Component ----- //
@@ -40,7 +41,11 @@ function Follow({ contributors, ...format }: Props): JSX.Element | null {
 
     const [contributor] = contributors;
 
-    if (isSingleContributor(contributors) && contributor.apiUrl !== '') {
+    if (
+        isSingleContributor(contributors) &&
+        contributor.apiUrl !== '' &&
+        format.design !== Design.AdvertisementFeature
+    ) {
         return (
             <button className="js-follow" css={getStyles(format)} data-id={contributor.id}>
                 <span className="js-status">Follow </span>

--- a/src/components/headline.stories.tsx
+++ b/src/components/headline.stories.tsx
@@ -72,6 +72,13 @@ const Review = (): ReactElement =>
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
     }} />
 
+const Labs = (): ReactElement =>
+    <Headline item={{
+        ...item,
+        design: Design.AdvertisementFeature,
+        display: Display.Standard,
+    }} />
+
 
 // ----- Exports ----- //
 
@@ -86,4 +93,5 @@ export {
     Analysis,
     Feature,
     Review,
+    Labs,
 }

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -7,7 +7,7 @@ import { background, neutral, text } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 
 import { Item } from 'item';
-import { darkModeCss as darkMode } from 'styles';
+import { darkModeCss as darkMode, textSans } from 'styles';
 import { getPillarStyles, PillarStyles } from 'pillarStyles';
 import StarRating from './starRating';
 import { Display, Design } from 'format';
@@ -76,6 +76,11 @@ const commentStyles = css`
     padding-bottom: ${remSpace[1]};
 `;
 
+const advertisementFeatureStyles = css`
+    ${styles}
+    ${textSans}
+`;
+
 const getStyles = (item: Item): SerializedStyles => {
     const pillarStyles = getPillarStyles(item.pillar);
 
@@ -92,6 +97,8 @@ const getStyles = (item: Item): SerializedStyles => {
             return commentStyles;
         case Design.Media:
             return mediaStyles;
+        case Design.AdvertisementFeature:
+            return advertisementFeatureStyles;
         default:
             return styles;
     }

--- a/src/components/paragraph.stories.tsx
+++ b/src/components/paragraph.stories.tsx
@@ -3,12 +3,31 @@
 import React, { FC } from 'react';
 
 import Paragraph from './paragraph';
+import { Design, Display, Pillar } from '@guardian/types/Format';
 
 
 // ----- Stories ----- //
 
+const standard = {
+    design: Design.Article,
+    display: Display.Standard,
+    pillar: Pillar.News
+}
+
+const labs = {
+    design: Design.AdvertisementFeature,
+    display: Display.Standard,
+    pillar: Pillar.News
+}
+
 const Default: FC = () =>
-    <Paragraph>
+    <Paragraph format={standard}>
+        Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have
+        dreamed of water: containing it, draining it and now retaining it.
+    </Paragraph>
+
+const Labs: FC = () =>
+    <Paragraph format={labs}>
         Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have
         dreamed of water: containing it, draining it and now retaining it.
     </Paragraph>
@@ -23,4 +42,5 @@ export default {
 
 export {
     Default,
+    Labs
 }

--- a/src/components/paragraph.tsx
+++ b/src/components/paragraph.tsx
@@ -1,24 +1,35 @@
 // ----- Imports ----- //
 
 import React, { FC, ReactNode } from 'react';
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import { body } from '@guardian/src-foundations/typography';
 import { remSpace } from '@guardian/src-foundations';
+import { textSans } from 'styles';
+import { Format, Design } from '@guardian/types/Format';
 
 // ----- Component ----- //
 
 interface Props {
     children?: ReactNode;
+    format: Format;
 }
 
-const styles = css`
-    ${body.medium()}
-    overflow-wrap: break-word;
-    margin: 0 0 ${remSpace[3]};
-`;
+const styles = (design: Design): SerializedStyles => {
+    const advertisementFeature = design === Design.AdvertisementFeature
+        ? textSans
+        : null;
 
-const Paragraph: FC<Props> = ({ children }: Props) =>
-    <p css={styles}>{children}</p>;
+    return css`
+        ${body.medium()}
+        overflow-wrap: break-word;
+        margin: 0 0 ${remSpace[3]};
+
+        ${advertisementFeature}
+    `;
+}
+
+const Paragraph: FC<Props> = ({ children, format }: Props) =>
+    <p css={styles(format.design)}>{children}</p>;
 
 
 // ----- Exports ----- //

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -76,7 +76,6 @@ interface ArticleBodyProps {
 }
 
 const ArticleBody = ({
-    pillar,
     className,
     children,
 }: ArticleBodyProps): JSX.Element =>

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -1,9 +1,9 @@
 // ----- Imports ----- //
 
-import React, {ReactElement, ReactNode} from 'react';
-import {css} from '@emotion/core';
-
+import React, { ReactElement, ReactNode } from 'react';
+import { css } from '@emotion/core';
 import Standard from 'components/standard/article';
+import AdvertisementFeature from 'components/advertisementFeature/article';
 import LiveblogArticle from 'components/liveblog/article';
 import Opinion from 'components/opinion/article';
 import Immersive from 'components/immersive/article';
@@ -238,6 +238,17 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
                 </Standard>
             </WithScript>
         ), resources: [articleScript], hydrationProps: {} };
+    }
+
+    if (item.design === Design.AdvertisementFeature) {
+        const body = partition(item.body).oks;
+        const content = insertAdPlaceholders(renderAll(imageMappings)(format, body));
+
+        return { element: (
+            <AdvertisementFeature imageMappings={imageMappings} item={item}>
+                {content}
+            </AdvertisementFeature>
+        ), resources: [], hydrationProps: {} };
     }
 
     const element = <p>Content format not implemented yet</p>;

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -9,7 +9,7 @@ import { remSpace } from '@guardian/src-foundations';
 
 import { Item, getFormat } from 'item';
 import { renderText, renderStandfirstText } from 'renderer';
-import { darkModeCss as darkMode } from 'styles';
+import { darkModeCss as darkMode, textSans } from 'styles';
 import { Display, Design } from 'format';
 
 
@@ -76,6 +76,11 @@ const media = css`
     }
 `;
 
+const advertisementFeature = css`
+    ${styles}
+    ${textSans}
+`
+
 const getStyles = (item: Item): SerializedStyles => {
     if (item.display === Display.Immersive) {
         return immersive;
@@ -86,9 +91,10 @@ const getStyles = (item: Item): SerializedStyles => {
         case Design.Feature:
         case Design.Comment:
             return css(styles, thinHeadline);
-
         case Design.Media:
-            return css(media);
+            return media;
+        case Design.AdvertisementFeature:
+            return advertisementFeature;
 
         default:
             return css(styles, normalHeadline);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -148,7 +148,7 @@ const textElement = (format: Format) => (node: Node, key: number): ReactNode => 
     const children = Array.from(node.childNodes).map(textElement(format));
     switch (node.nodeName) {
         case 'P':
-            return h(Paragraph, { key }, children);
+            return h(Paragraph, { key, format }, children);
         case '#text':
             return transform(text, format);
         case 'SPAN':

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -20,7 +20,7 @@ export const sidePadding = css`
         padding-right: 0;
     }`;
 
-export const textSans = "font-family: 'Guardian Text Sans Web';";
+export const textSans = "font-family: 'Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif';";
 
 export const icons = "font-family: 'Guardian Icons';";
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -20,7 +20,7 @@ export const sidePadding = css`
         padding-right: 0;
     }`;
 
-export const textSans = "font-family: 'Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif';";
+export const textSans = "font-family: 'Guardian Text Sans Web', Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;";
 
 export const icons = "font-family: 'Guardian Icons';";
 


### PR DESCRIPTION
Render AdvertisementFeatures. Also known as Guardian Labs.

- Use textSans font
- Use labs colours rather than pillar colours
- Remove tags and follow options
- Added lab stories

## Screenshots

<img width="644" alt="Screen Shot 2020-04-28 at 15 03 59" src="https://user-images.githubusercontent.com/11618797/80497422-58553180-8962-11ea-82a8-cf2bc44df198.png">

