### PR TITLE
Thrift Decoders

### DIFF
--- a/src/server/decoders.ts
+++ b/src/server/decoders.ts
@@ -1,0 +1,41 @@
+// ----- Imports ----- //
+
+import {
+    BufferedTransport,
+    CompactProtocol,
+    TProtocol,
+} from '@creditkarma/thrift-server-core';
+
+import { Response as CapiResponse } from 'mapiThriftModels/Response';
+import { Content as MapiContent } from 'mapiThriftModels/Content';
+import { ErrorResponse } from 'mapiThriftModels/ErrorResponse';
+
+
+// ----- Types ----- //
+
+interface ThriftDecoder<A> {
+    read(p: TProtocol): A;
+}
+
+
+// ----- Functions ----- //
+
+const decodeContent = <A>(decoder: ThriftDecoder<A>) => (content: Buffer | undefined): A => {
+    const transport = new BufferedTransport(content);
+    const protocol = new CompactProtocol(transport);
+
+    return decoder.read(protocol);
+}
+
+const capiDecoder = decodeContent(CapiResponse);
+const errorDecoder = decodeContent(ErrorResponse);
+const mapiDecoder = decodeContent(MapiContent);
+
+
+// ----- Exports ----- //
+
+export {
+    capiDecoder,
+    errorDecoder,
+    mapiDecoder,
+};


### PR DESCRIPTION
## Why are you doing this?

Abstracted the decoding of Thrift types into TypeScript types into a `decoders` module. This will hopefully make them easier to re-use in some upcoming changes, and keep the `server` module more tightly focused on the "request-response" cycle.

## Changes

- Wrapped Thrift decoding into `decoders` module
