### PR TITLE
use inverted colour for anchors on dark backgrounds

### DIFF
--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -2,7 +2,7 @@
 
 import React, { FC, ReactNode } from 'react';
 import { SerializedStyles, css } from '@emotion/core';
-import { Format } from '@guardian/types/Format';
+import { Format, Design } from '@guardian/types/Format';
 import { neutral } from '@guardian/src-foundations/palette';
 
 import { darkModeCss } from 'styles';
@@ -18,18 +18,32 @@ interface Props {
     className?: SerializedStyles;
 }
 
-const styles = (colour: string): SerializedStyles => css`
-    color: ${colour};
+const styles = css`
     text-decoration: none;
-    border-bottom: 0.0625rem solid ${neutral[86]};
 
     ${darkModeCss`
         color: ${neutral[86]};
     `}
 `;
 
+const colour = (format: Format): SerializedStyles => {
+    const { kicker, inverted } = getPillarStyles(format.pillar);
+    switch (format.design) {
+        case Design.Media:
+            return css`
+                color: ${inverted};
+                border-bottom: 0.0625rem solid ${neutral[20]};
+            `
+        default:
+            return css`
+                color: ${kicker};
+                border-bottom: 0.0625rem solid ${neutral[86]};
+            `
+    }
+}
+
 const Anchor: FC<Props> = ({ format, children, href, className }: Props) =>
-    <a css={[styles(getPillarStyles(format.pillar).kicker), className]} href={href}>
+    <a css={[styles, className, colour(format)]} href={href}>
         {children}
     </a>
 

--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -43,7 +43,7 @@ const colour = (format: Format): SerializedStyles => {
 }
 
 const Anchor: FC<Props> = ({ format, children, href, className }: Props) =>
-    <a css={[styles, className, colour(format)]} href={href}>
+    <a css={[styles, colour(format), className]} href={href}>
         {children}
     </a>
 

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -66,6 +66,7 @@ const captionHeadingStyles = css`
     ${headline.xxxsmall()}
     color: ${neutral[86]};
     margin: 0 0 ${remSpace[3]};
+    display: inline;
 `;
 
 const anchorStyles = css`
@@ -77,7 +78,7 @@ const captionElement = (format: Format) => (node: Node, key: number): ReactNode 
     const children = Array.from(node.childNodes).map(captionElement(format));
     switch (node.nodeName) {
         case 'STRONG':
-            return <strong css={captionHeadingStyles} key={key}>{children}</strong>;
+            return <h2 css={captionHeadingStyles} key={key}>{children}</h2>;
         case 'BR':
             return null;
         case 'EM':
@@ -120,7 +121,7 @@ const styles = css`
 const mediaStyles = css`
     color: ${neutral[86]};
 
-    strong + span {
+    h2 + span {
         display: block;
         ${textSans.xsmall()}
         margin: ${remSpace[1]} 0;

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -47,11 +47,16 @@ interface CreditProps {
     format: Format;
 }
 
+const creditStyles = css`
+    ${textSans.xsmall()}
+    margin: ${remSpace[1]} 0;
+`;
+
 const Credit: FC<CreditProps> = ({ format, credit }: CreditProps) =>
     credit.fmap<ReactElement | null>(cred => {
         switch (format.design) {
             case Design.Media:
-                return <p>{cred}</p>;
+                return <p css={creditStyles}>{cred}</p>;
             default:
                 return <> {cred}</>;
         }
@@ -61,10 +66,6 @@ const captionHeadingStyles = css`
     ${headline.xxxsmall()}
     color: ${neutral[86]};
     margin: 0 0 ${remSpace[3]};
-
-    em {
-        ${textSans.xsmall({ italic: true, fontWeight: 'bold'})}
-    }
 `;
 
 const anchorStyles = css`
@@ -76,11 +77,11 @@ const captionElement = (format: Format) => (node: Node, key: number): ReactNode 
     const children = Array.from(node.childNodes).map(captionElement(format));
     switch (node.nodeName) {
         case 'STRONG':
-            return <h2 css={captionHeadingStyles} key={key}>{children}</h2>;
+            return <strong css={captionHeadingStyles} key={key}>{children}</strong>;
         case 'BR':
             return null;
         case 'EM':
-            return <em key={key}>{children}</em>
+            return <em css={ textSans.xsmall({ italic: true, fontWeight: 'bold'})} key={key}>{children}</em>
         case 'A':
             return (
                 <Anchor
@@ -92,7 +93,7 @@ const captionElement = (format: Format) => (node: Node, key: number): ReactNode 
                 </Anchor>
             );
         case '#text':
-            return text;
+            return <span>{ text }</span>;
         default:
             return renderTextElement(format)(node, key);
     }
@@ -118,6 +119,12 @@ const styles = css`
 
 const mediaStyles = css`
     color: ${neutral[86]};
+
+    strong + span {
+        display: block;
+        ${textSans.xsmall()}
+        margin: ${remSpace[1]} 0;
+    }
 `;
 
 const getStyles = (format: Format): SerializedStyles => {


### PR DESCRIPTION
## Changes

- Improve contrast of anchors on media pages 
- Use strong elements to keep inline display

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/80586372-c2c2ac00-8a0c-11ea-9d26-26037e152433.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/80586445-e2f26b00-8a0c-11ea-9501-515f2a236370.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/80586473-ebe33c80-8a0c-11ea-9035-8e5d1de4cc05.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/80586500-f4d40e00-8a0c-11ea-8129-73f25945b2c5.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/80586524-fbfb1c00-8a0c-11ea-8e95-759476fecb57.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/80586547-04535700-8a0d-11ea-93ff-4e9d3bc9b1e9.png" width="300px" /> |


