### PR TITLE
Split Up Item Module

### DIFF
--- a/src/ads.test.ts
+++ b/src/ads.test.ts
@@ -4,7 +4,7 @@ import { renderAll } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { Pillar, Format, Design, Display } from 'format';
 import { compose } from 'lib';
-import { ElementKind, BodyElement } from 'item';
+import { ElementKind, BodyElement } from 'bodyElement';
 
 const shouldHideAdverts = false;
 const insertAdPlaceholders = getAdPlaceholderInserter(shouldHideAdverts);

--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -1,0 +1,236 @@
+// ----- Imports ----- //
+
+import { IBlockElement as BlockElement } from 'mapiThriftModels/BlockElement';
+import { ElementType } from 'mapiThriftModels/ElementType';
+import { Option, fromNullable } from 'types/option';
+import { Result, Err, Ok } from 'types/result';
+import DocParser from 'types/docParser';
+import { Image as ImageData, parseImage } from 'image';
+
+
+// ----- Types ----- //
+
+const enum ElementKind {
+    Text,
+    Image,
+    Pullquote,
+    Interactive,
+    RichLink,
+    Tweet,
+    Instagram,
+    Audio,
+    Embed,
+    Video,
+}
+
+type Image = ImageData & {
+    kind: ElementKind.Image;
+}
+
+type Audio = {
+    kind: ElementKind.Audio;
+    src: string;
+    height: string;
+    width: string;
+}
+
+type Video = {
+    kind: ElementKind.Video;
+    src: string;
+    height: string;
+    width: string;
+}
+
+type MediaKind = ElementKind.Audio | ElementKind.Video;
+
+type BodyElement = {
+    kind: ElementKind.Text;
+    doc: DocumentFragment;
+} | Image | {
+    kind: ElementKind.Pullquote;
+    quote: string;
+    attribution: Option<string>;
+} | {
+    kind: ElementKind.Interactive;
+    url: string;
+    alt?: string;
+} | {
+    kind: ElementKind.RichLink;
+    url: string;
+    linkText: string;
+} | {
+    kind: ElementKind.Tweet;
+    content: NodeList;
+} | {
+    kind: ElementKind.Instagram;
+    html: string;
+} | Audio | {
+    kind: ElementKind.Embed;
+    html: string;
+} | Video;
+
+type Elements = BlockElement[] | undefined;
+
+
+// ----- Functions ----- //
+
+const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, NodeList> => {
+    const blockquote = doc.querySelector('blockquote');
+
+    if (blockquote !== null) {
+        return new Ok(blockquote.childNodes);
+    }
+
+    return new Err(`There was no blockquote element in the tweet with id: ${tweetId}`);
+}
+
+const parseIframe = (docParser: DocParser) =>
+    (html: string, kind: MediaKind): Result<string, Audio | Video> => {
+        const iframe = docParser(html).querySelector('iframe');
+        const src = iframe?.getAttribute('src');
+
+        if (!iframe || !src) {
+            return new Err('No iframe within html');
+        }
+
+        return new Ok({
+            kind,
+            src,
+            width: iframe.getAttribute('width') ?? "380",
+            height: iframe.getAttribute('height') ?? "300",
+        });
+}
+
+const parse =
+    (docParser: DocParser) => (element: BlockElement): Result<string, BodyElement> => {
+    switch (element.type) {
+
+        case ElementType.TEXT: {
+            const html = element?.textTypeData?.html;
+
+            if (!html) {
+                return new Err('No html field on textTypeData');
+            }
+
+            return new Ok({ kind: ElementKind.Text, doc: docParser(html) });
+        }
+
+        case ElementType.IMAGE:
+            return parseImage(docParser)(element)
+                .fmap<Result<string, Image>>(image => new Ok({
+                    kind: ElementKind.Image,
+                    ...image
+                }))
+                .withDefault(new Err('I couldn\'t find a master asset'));
+
+        case ElementType.PULLQUOTE: {
+            const { html: quote, attribution } = element.pullquoteTypeData ?? {};
+
+            if (!quote) {
+                return new Err('No quote field on pullquoteTypeData');
+            }
+
+            return new Ok({
+                kind: ElementKind.Pullquote,
+                quote,
+                attribution: fromNullable(attribution),
+            });
+        }
+
+        case ElementType.INTERACTIVE: {
+            const { iframeUrl, alt } = element.interactiveTypeData ?? {};
+
+            if (!iframeUrl) {
+                return new Err('No iframeUrl field on interactiveTypeData');
+            }
+
+            return new Ok({ kind: ElementKind.Interactive, url: iframeUrl, alt });
+        }
+
+        case ElementType.RICH_LINK: {
+            const { url, linkText } = element.richLinkTypeData ?? {};
+
+            if (!url) {
+                return new Err('No "url" field on richLinkTypeData');
+            } else if (!linkText) {
+                return new Err('No "linkText" field on richLinkTypeData');
+            }
+
+            return new Ok({ kind: ElementKind.RichLink, url, linkText });
+        }
+
+        case ElementType.TWEET: {
+            const { id, html: h } = element.tweetTypeData ?? {};
+
+            if (!id) {
+                return new Err('No "id" field on tweetTypeData')
+            } else if (!h) {
+                return new Err('No "html" field on tweetTypeData')
+            }
+
+            return tweetContent(id, docParser(h))
+                .fmap(content => ({ kind: ElementKind.Tweet, content }));
+        }
+
+        case ElementType.EMBED: {
+            const { html: embedHtml } = element.embedTypeData ?? {};
+
+            if (!embedHtml) {
+                return new Err('No html field on embedTypeData')
+            }
+
+            return new Ok({ kind: ElementKind.Embed, html: embedHtml });
+        }
+
+        case ElementType.INSTAGRAM: {
+            const { html: instagramHtml } = element.instagramTypeData ?? {};
+
+            if (!instagramHtml) {
+                return new Err('No html field on instagramTypeData')
+            }
+
+            return new Ok({ kind: ElementKind.Instagram, html: instagramHtml });
+        }
+
+        case ElementType.AUDIO: {
+            const { html: audioHtml } = element.audioTypeData ?? {};
+
+            if (!audioHtml) {
+                return new Err('No html field on audioTypeData')
+            }
+
+            return parseIframe(docParser)(audioHtml, ElementKind.Audio);
+        }
+
+        case ElementType.VIDEO: {
+            const { html: videoHtml } = element.videoTypeData ?? {};
+
+            if (!videoHtml) {
+                return new Err('No html field on videoTypeData')
+            }
+
+            return parseIframe(docParser)(videoHtml, ElementKind.Video);
+        }
+
+        default:
+            return new Err(`I'm afraid I don't understand the element I was given: ${element.type}`);
+    }
+
+}
+
+const parseElements =
+    (docParser: DocParser) => (elements: Elements): Result<string, BodyElement>[] => {
+        if (!elements) {
+            return [new Err('No body elements available')];
+        }
+        return elements.map(parse(docParser));
+    }
+
+
+// ----- Exports ----- //
+
+export {
+    ElementKind,
+    BodyElement,
+    parseElements,
+};

--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -71,6 +71,9 @@ type BodyElement = {
 
 type Elements = BlockElement[] | undefined;
 
+type Body =
+    Result<string, BodyElement>[];
+
 
 // ----- Functions ----- //
 
@@ -234,5 +237,6 @@ export {
     BodyElement,
     Audio,
     Video,
+    Body,
     parseElements,
 };

--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -232,5 +232,7 @@ const parseElements =
 export {
     ElementKind,
     BodyElement,
+    Audio,
+    Video,
     parseElements,
 };

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -5,8 +5,9 @@ import { IContent as Content} from 'mapiThriftModels/Content';
 import { ITag as Tag } from 'mapiThriftModels/Tag';
 import { IBlockElement} from 'mapiThriftModels/BlockElement';
 import { ElementType } from 'mapiThriftModels/ElementType';
-import { Option, fromNullable } from 'types/option';
-import { TagType } from 'mapiThriftModels';
+import { Option, fromNullable, Some, None } from 'types/option';
+import { TagType, ICapiDateTime as CapiDateTime } from 'mapiThriftModels';
+
 
 // ----- Parsing ----- //
 
@@ -118,6 +119,18 @@ const capiEndpoint = (articleId: string, key: string): string => {
     return `https://content.guardianapis.com/${articleId}?${params.toString()}`;
 }
 
+const capiDateTimeToDate = (date: CapiDateTime): Option<Date> => {
+    // Thrift definitions define some dates as CapiDateTime but CAPI returns strings
+    try {
+        return new Some(new Date(date.iso8601));
+    } catch(e) {
+        return new None();
+    }
+}
+
+const maybeCapiDate = (date: CapiDateTime | undefined): Option<Date> =>
+    fromNullable(date).andThen(capiDateTimeToDate);
+
 
 // ----- Exports ----- //
 
@@ -135,4 +148,5 @@ export {
     articleMainImage,
     capiEndpoint,
     includesTweets,
+    maybeCapiDate,
 };

--- a/src/components/liveblog/body.tsx
+++ b/src/components/liveblog/body.tsx
@@ -3,7 +3,7 @@ import LiveblogBlock from './block';
 import LiveblogLoadMore from './loadMore';
 import { css } from '@emotion/core'
 import { Pillar, Format } from 'format';
-import { LiveBlock } from 'item';
+import { LiveBlock } from 'liveBlock';
 import { renderAll } from 'renderer';
 import { partition } from 'types/result';
 import { BufferedTransport, CompactProtocol } from '@creditkarma/thrift-server-core';

--- a/src/components/liveblog/keyEvents.tsx
+++ b/src/components/liveblog/keyEvents.tsx
@@ -5,7 +5,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { makeRelativeDate } from 'date';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
-import { LiveBlock } from 'item';
+import { LiveBlock } from 'liveBlock';
 import { body, headline } from '@guardian/src-foundations/typography';
 
 const LiveblogKeyEventsStyles = ({ kicker }: PillarStyles): SerializedStyles => css`

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -16,7 +16,8 @@ import { renderAll } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { partition } from 'types/result';
 import { getAdPlaceholderInserter } from 'ads';
-import { fromCapi, getFormat, ElementKind } from 'item';
+import { fromCapi, getFormat } from 'item';
+import { ElementKind } from 'bodyElement';
 import { sign } from 'image';
 import {
     ElementType,

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -1,5 +1,6 @@
 import { ContentType, Tag, TagType, ElementType, AssetType, IBlockElement as BlockElement } from 'mapiThriftModels';
-import { fromCapi, Standard, ElementKind, Review, Audio, Video, getFormat } from 'item';
+import { fromCapi, Standard, Review, getFormat } from 'item';
+import { ElementKind, Audio, Video } from 'bodyElement';
 import { Design } from 'format';
 import { JSDOM } from 'jsdom';
 import { Display } from '@guardian/types/Format';

--- a/src/item.ts
+++ b/src/item.ts
@@ -13,8 +13,8 @@ import {
 } from 'mapiThriftModels';
 import { Format, Pillar, Design, Display } from 'format';
 import { Image as ImageData, parseImage } from 'image';
-import { LiveBlock, Body as LiveBody, parseLiveBlocks } from 'liveBlock';
-import { parseElements } from 'bodyElement';
+import { LiveBlock, parseLiveBlocks } from 'liveBlock';
+import { Body, parseElements } from 'bodyElement';
 
 
 // ----- Item Type ----- //
@@ -41,20 +41,20 @@ interface Liveblog extends Fields {
 
 interface Review extends Fields {
     design: Design.Review;
-    body: LiveBody;
+    body: Body;
     starRating: number;
 }
 
 interface Comment extends Fields {
     design: Design.Comment;
-    body: LiveBody;
+    body: Body;
 }
 
 // Catch-all for other Designs for now. As coverage of Designs increases,
 // this will likely be split out into each Design type.
 interface Standard extends Fields {
     design: Exclude<Design, Design.Live | Design.Review | Design.Comment>;
-    body: LiveBody;
+    body: Body;
     shouldHideReaderRevenue: boolean;
 }
 
@@ -74,7 +74,7 @@ type ItemFields =
     Omit<Fields, 'design'>;
 
 type ItemFieldsWithBody =
-    ItemFields & { body: LiveBody };
+    ItemFields & { body: Body };
 
 
 // ----- Functions ----- //

--- a/src/item.ts
+++ b/src/item.ts
@@ -2,38 +2,22 @@
 
 import { pillarFromString } from 'pillarStyles';
 import { IContent as Content } from 'mapiThriftModels/Content';
-import { IBlockElement as BlockElement } from 'mapiThriftModels/BlockElement';
 import { ITag as Tag } from 'mapiThriftModels/Tag';
-import { articleMainImage, articleContributors, articleSeries, isPhotoEssay, isImmersive } from 'capi';
-import { Option, fromNullable, None, Some } from 'types/option';
-import { Err, Ok, Result } from 'types/result';
+import { articleMainImage, articleContributors, articleSeries, isPhotoEssay, isImmersive, maybeCapiDate } from 'capi';
+import { Option, fromNullable } from 'types/option';
 import {
-    IBlock as Block,
-    ICapiDateTime as CapiDateTime,
     ElementType,
     IElement as Element,
     AssetType,
     IAsset as Asset,
 } from 'mapiThriftModels';
-import { logger } from 'logger';
 import { Format, Pillar, Design, Display } from 'format';
 import { Image as ImageData, parseImage } from 'image';
+import { LiveBlock, Body as LiveBody, parseLiveBlocks } from 'liveBlock';
+import { parseElements } from 'bodyElement';
 
 
 // ----- Item Type ----- //
-
-const enum ElementKind {
-    Text,
-    Image,
-    Pullquote,
-    Interactive,
-    RichLink,
-    Tweet,
-    Instagram,
-    Audio,
-    Embed,
-    Video
-}
 
 interface Fields extends Format {
     headline: string;
@@ -49,64 +33,6 @@ interface Fields extends Format {
     shouldHideReaderRevenue: boolean;
 }
 
-type Image = ImageData & {
-    kind: ElementKind.Image;
-}
-
-type Audio = {
-    kind: ElementKind.Audio;
-    src: string;
-    height: string;
-    width: string;
-}
-
-type Video = {
-    kind: ElementKind.Video;
-    src: string;
-    height: string;
-    width: string;
-}
-
-type MediaKind = ElementKind.Audio | ElementKind.Video;
-
-type BodyElement = {
-    kind: ElementKind.Text;
-    doc: DocumentFragment;
-} | Image | {
-    kind: ElementKind.Pullquote;
-    quote: string;
-    attribution: Option<string>;
-} | {
-    kind: ElementKind.Interactive;
-    url: string;
-    alt?: string;
-} | {
-    kind: ElementKind.RichLink;
-    url: string;
-    linkText: string;
-} | {
-    kind: ElementKind.Tweet;
-    content: NodeList;
-} | {
-    kind: ElementKind.Instagram;
-    html: string;
-} | Audio | {
-    kind: ElementKind.Embed;
-    html: string;
-} | Video;
-
-type Body =
-    Result<string, BodyElement>[];
-
-type LiveBlock = {
-    id: string;
-    isKeyEvent: boolean;
-    title: string;
-    firstPublished: Option<Date>;
-    lastModified: Option<Date>;
-    body: Body;
-}
-
 interface Liveblog extends Fields {
     design: Design.Live;
     blocks: LiveBlock[];
@@ -115,20 +41,20 @@ interface Liveblog extends Fields {
 
 interface Review extends Fields {
     design: Design.Review;
-    body: Body;
+    body: LiveBody;
     starRating: number;
 }
 
 interface Comment extends Fields {
     design: Design.Comment;
-    body: Body;
+    body: LiveBody;
 }
 
 // Catch-all for other Designs for now. As coverage of Designs increases,
 // this will likely be split out into each Design type.
 interface Standard extends Fields {
     design: Exclude<Design, Design.Live | Design.Review | Design.Comment>;
-    body: Body;
+    body: LiveBody;
     shouldHideReaderRevenue: boolean;
 }
 
@@ -148,194 +74,13 @@ type ItemFields =
     Omit<Fields, 'design'>;
 
 type ItemFieldsWithBody =
-    ItemFields & { body: Body };
+    ItemFields & { body: LiveBody };
 
 
 // ----- Functions ----- //
 
 const getFormat = (item: Item): Format =>
     ({ design: item.design, display: item.display, pillar: item.pillar });
-
-const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, NodeList> => {
-    const blockquote = doc.querySelector('blockquote');
-
-    if (blockquote !== null) {
-        return new Ok(blockquote.childNodes);
-    }
-
-    return new Err(`There was no blockquote element in the tweet with id: ${tweetId}`);
-}
-
-const parseIframe = (docParser: DocParser) =>
-    (html: string, kind: MediaKind): Result<string, Audio | Video> => {
-        const iframe = docParser(html).querySelector('iframe');
-        const src = iframe?.getAttribute('src');
-
-        if (!iframe || !src) {
-            return new Err('No iframe within html');
-        }
-
-        return new Ok({
-            kind,
-            src,
-            width: iframe.getAttribute('width') ?? "380",
-            height: iframe.getAttribute('height') ?? "300",
-        });
-}
-
-const parseElement =
-    (docParser: DocParser) => (element: BlockElement): Result<string, BodyElement> => {
-    switch (element.type) {
-
-        case ElementType.TEXT: {
-            const html = element?.textTypeData?.html;
-
-            if (!html) {
-                return new Err('No html field on textTypeData');
-            }
-
-            return new Ok({ kind: ElementKind.Text, doc: docParser(html) });
-        }
-
-        case ElementType.IMAGE:
-            return parseImage(docParser)(element)
-                .fmap<Result<string, Image>>(image => new Ok({
-                    kind: ElementKind.Image,
-                    ...image
-                }))
-                .withDefault(new Err('I couldn\'t find a master asset'));
-
-        case ElementType.PULLQUOTE: {
-            const { html: quote, attribution } = element.pullquoteTypeData ?? {};
-
-            if (!quote) {
-                return new Err('No quote field on pullquoteTypeData');
-            }
-
-            return new Ok({
-                kind: ElementKind.Pullquote,
-                quote,
-                attribution: fromNullable(attribution),
-            });
-        }
-
-        case ElementType.INTERACTIVE: {
-            const { iframeUrl, alt } = element.interactiveTypeData ?? {};
-
-            if (!iframeUrl) {
-                return new Err('No iframeUrl field on interactiveTypeData');
-            }
-
-            return new Ok({ kind: ElementKind.Interactive, url: iframeUrl, alt });
-        }
-
-        case ElementType.RICH_LINK: {
-            const { url, linkText } = element.richLinkTypeData ?? {};
-
-            if (!url) {
-                return new Err('No "url" field on richLinkTypeData');
-            } else if (!linkText) {
-                return new Err('No "linkText" field on richLinkTypeData');
-            }
-
-            return new Ok({ kind: ElementKind.RichLink, url, linkText });
-        }
-
-        case ElementType.TWEET: {
-            const { id, html: h } = element.tweetTypeData ?? {};
-
-            if (!id) {
-                return new Err('No "id" field on tweetTypeData')
-            } else if (!h) {
-                return new Err('No "html" field on tweetTypeData')
-            }
-
-            return tweetContent(id, docParser(h))
-                .fmap(content => ({ kind: ElementKind.Tweet, content }));
-        }
-
-        case ElementType.EMBED: {
-            const { html: embedHtml } = element.embedTypeData ?? {};
-
-            if (!embedHtml) {
-                return new Err('No html field on embedTypeData')
-            }
-
-            return new Ok({ kind: ElementKind.Embed, html: embedHtml });
-        }
-
-        case ElementType.INSTAGRAM: {
-            const { html: instagramHtml } = element.instagramTypeData ?? {};
-
-            if (!instagramHtml) {
-                return new Err('No html field on instagramTypeData')
-            }
-
-            return new Ok({ kind: ElementKind.Instagram, html: instagramHtml });
-        }
-
-        case ElementType.AUDIO: {
-            const { html: audioHtml } = element.audioTypeData ?? {};
-
-            if (!audioHtml) {
-                return new Err('No html field on audioTypeData')
-            }
-
-            return parseIframe(docParser)(audioHtml, ElementKind.Audio);
-        }
-
-        case ElementType.VIDEO: {
-            const { html: videoHtml } = element.videoTypeData ?? {};
-
-            if (!videoHtml) {
-                return new Err('No html field on videoTypeData')
-            }
-
-            return parseIframe(docParser)(videoHtml, ElementKind.Video);
-        }
-
-        default:
-            return new Err(`I'm afraid I don't understand the element I was given: ${element.type}`);
-    }
-
-}
-
-type Elements = BlockElement[] | undefined;
-
-const parseElements =
-    (docParser: DocParser) => (elements: Elements): Result<string, BodyElement>[] => {
-        if (!elements) {
-            return [new Err('No body elements available')];
-        }
-        return elements.map(parseElement(docParser));
-    }
-
-const capiDateTimeToDate = (date: CapiDateTime | undefined): Option<Date> => {
-    // Thrift definitions define some dates as CapiDateTime but CAPI returns strings
-    try {
-        if (date) {
-            return new Some(new Date(date.iso8601));
-        }
-
-        return new None();
-    } catch(e) {
-        logger.error("Unable to convert date from CAPI", e);
-        return new None();
-    }
-}
-
-const parseBlock = (docParser: DocParser) => (block: Block): LiveBlock =>
-    ({
-        id: block.id,
-        isKeyEvent: block?.attributes?.keyEvent ?? false,
-        title: block?.title ?? "",
-        firstPublished: capiDateTimeToDate(block?.firstPublishedDate),
-        lastModified: capiDateTimeToDate(block?.lastModifiedDate),
-        body: parseElements(docParser)(block.elements),
-    })
-
-const parseBlocks = (docParser: DocParser) => (blocks: Block[]): LiveBlock[] =>
-    blocks.map(parseBlock(docParser));
 
 // The main image for the page is meant to be shown as showcase.
 function isShowcaseImage(content: Content): boolean {
@@ -379,7 +124,7 @@ const itemFields = (docParser: DocParser, content: Content): ItemFields =>
         standfirst: fromNullable(content?.fields?.standfirst).fmap(docParser),
         byline: content?.fields?.byline ?? "",
         bylineHtml: fromNullable(content?.fields?.bylineHtml).fmap(docParser),
-        publishDate: capiDateTimeToDate(content.webPublicationDate),
+        publishDate: maybeCapiDate(content.webPublicationDate),
         mainImage: articleMainImage(content).andThen(parseImage(docParser)),
         contributors: articleContributors(content),
         series: articleSeries(content),
@@ -444,7 +189,7 @@ const fromCapiLiveBlog = (docParser: DocParser) => (content: Content): Liveblog 
 
     return {
         design: Design.Live,
-        blocks: parseBlocks(docParser)(body),
+        blocks: parseLiveBlocks(docParser)(body),
         totalBodyBlocks: content.blocks?.totalBodyBlocks ?? body.length,
         ...itemFields(docParser, content),
     };
@@ -532,11 +277,6 @@ export {
     Liveblog,
     Review,
     Standard,
-    LiveBlock,
-    ElementKind,
-    BodyElement,
-    Audio,
-    Video,
     fromCapi,
     fromCapiLiveBlog,
     getFormat,

--- a/src/liveBlock.ts
+++ b/src/liveBlock.ts
@@ -1,0 +1,48 @@
+// ----- Imports ----- //
+
+import { IBlock as Block } from 'mapiThriftModels/Block';
+import { Option } from 'types/option';
+import { Result } from 'types/result';
+import DocParser from 'types/docParser';
+import { BodyElement, parseElements } from 'bodyElement';
+import { maybeCapiDate } from 'capi';
+
+
+// ----- Types ----- //
+
+type Body =
+    Result<string, BodyElement>[];
+
+type LiveBlock = {
+    id: string;
+    isKeyEvent: boolean;
+    title: string;
+    firstPublished: Option<Date>;
+    lastModified: Option<Date>;
+    body: Body;
+}
+
+
+// ----- Functions ----- //
+
+const parse = (docParser: DocParser) => (block: Block): LiveBlock =>
+    ({
+        id: block.id,
+        isKeyEvent: block?.attributes?.keyEvent ?? false,
+        title: block?.title ?? "",
+        firstPublished: maybeCapiDate(block?.firstPublishedDate),
+        lastModified: maybeCapiDate(block?.lastModifiedDate),
+        body: parseElements(docParser)(block.elements),
+    })
+
+const parseLiveBlocks = (docParser: DocParser) => (blocks: Block[]): LiveBlock[] =>
+    blocks.map(parse(docParser));
+
+
+// ----- Exports ----- //
+
+export {
+    Body,
+    LiveBlock,
+    parseLiveBlocks,
+};

--- a/src/liveBlock.ts
+++ b/src/liveBlock.ts
@@ -2,16 +2,12 @@
 
 import { IBlock as Block } from 'mapiThriftModels/Block';
 import { Option } from 'types/option';
-import { Result } from 'types/result';
 import DocParser from 'types/docParser';
-import { BodyElement, parseElements } from 'bodyElement';
+import { Body, parseElements } from 'bodyElement';
 import { maybeCapiDate } from 'capi';
 
 
 // ----- Types ----- //
-
-type Body =
-    Result<string, BodyElement>[];
 
 type LiveBlock = {
     id: string;
@@ -42,7 +38,6 @@ const parseLiveBlocks = (docParser: DocParser) => (blocks: Block[]): LiveBlock[]
 // ----- Exports ----- //
 
 export {
-    Body,
     LiveBlock,
     parseLiveBlocks,
 };

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -3,7 +3,7 @@ import { JSDOM } from 'jsdom';
 import { Pillar } from 'format';
 import { ReactNode } from 'react';
 import { compose } from 'lib';
-import { BodyElement, ElementKind } from 'item';
+import { BodyElement, ElementKind } from 'bodyElement';
 import { Role } from 'image';
 import { configure, shallow } from 'enzyme';
 import { None, Some } from 'types/option';

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -8,7 +8,7 @@ import { Option, fromNullable, Some, None } from 'types/option';
 import { basePx, icons, darkModeCss } from 'styles';
 import { getPillarStyles } from 'pillarStyles';
 import { Format } from 'format';
-import { ElementKind, BodyElement } from 'item';
+import { ElementKind, BodyElement } from 'bodyElement';
 import { Role, BodyImageProps } from 'image';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { remSpace } from '@guardian/src-foundations';

--- a/src/types/docParser.ts
+++ b/src/types/docParser.ts
@@ -1,0 +1,8 @@
+// ----- Type ----- //
+
+type DocParser = (html: string) => DocumentFragment;
+
+
+// ----- Exports ----- //
+
+export default DocParser;


### PR DESCRIPTION
## Why are you doing this?

The `Item` module is quite large and unfocused. This splits out some of the data types into more tightly focused modules of their own.

These changes will help to enable some upcoming work on the liveblog API.

## Changes

- Created `bodyElement` module
- Created `liveBlock` module
- Created `docParser` module to house the `DocParser` type
- Migrated the CAPI date parser to the `capi` module
- Updated imports
