### PR TITLE
Snyk On A Schedule - GitHub Actions

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 10 * * *'
 
 jobs:
   snyk:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 10 * * *'
+    - cron: '0 10 * * 1-5'
 
 jobs:
   snyk:


### PR DESCRIPTION
## Why are you doing this?

Schedules Snyk to run every day at 10am UTC. This is an experiment to see how this works for us, and what the alerting is like.

If this works well we might consider using this _instead_ of the PR check. Reported failures are often for dependencies also present in `master` (due to a new issue in the Snyk database) rather than PR changes.

**Note:** For an example of the Snyk check failing for PRs with no dependency changes, see the checks on _this_ PR.

## Changes

- Added a schedule trigger for Snyk every day at 10am UTC
