### PR TITLE
Snyk Monitor With GitHub Actions

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,24 +1,25 @@
 name: Snyk
 
 on:
-  pull_request:
-    branches:
-      - master
   schedule:
     - cron: '0 9 * * 1-5'
 
 jobs:
   snyk:
-
     runs-on: ubuntu-latest
+    timeout-minutes: 3
 
     strategy:
       matrix:
         node-version: [12.x]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Run Snyk to check for vulnerabilities
       uses: snyk/actions/node@master
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        SNYK_ORG: ${{ secrets.SNYK_ORG }}
+      with:
+        command: monitor
+        args: --org=${SNYK_ORG} --project-name=apps-rendering


### PR DESCRIPTION
## Why are you doing this?

Making use of GitHub Actions to run [`snyk monitor`](https://support.snyk.io/hc/en-us/articles/360003919937-Getting-started-with-the-CLI), which will update our dashboard. This brings our setup into line with recent [changes on MAPI](https://github.com/guardian/mobile-apps-api/pull/1591).

It solves a problem where Snyk would report issues against a PR even when there were no alterations to dependencies. In these cases it's more accurate to treat this as a problem on `master` and act accordingly.

**Note:** @webb04 this probably covers the changes in #309.

## Changes

- Removed Snyk from PR checks, now runs on schedule
- Used checkout action v2
- Used monitor with org and project
- Set timeout
