### PR TITLE
Editorial Palette

### DIFF
--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -10,7 +10,8 @@ import { Format, Display, Design } from '@guardian/types/Format';
 import { Item } from 'item';
 import { wideContentWidth, articleWidthStyles } from 'styles';
 import StarRating from 'components/starRating';
-import { headlineFontColour, headlineBackgroundColour, border } from 'editorialPalette';
+import { border } from 'editorialPalette';
+import { headlineFontColour, headlineBackgroundColour } from 'editorialStyles';
 
 
 // ----- Component ----- //

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -11,7 +11,7 @@ import { Item } from 'item';
 import { wideContentWidth, articleWidthStyles } from 'styles';
 import StarRating from 'components/starRating';
 import { border } from 'editorialPalette';
-import { headlineFontColour, headlineBackgroundColour } from 'editorialStyles';
+import { headlineTextColour, headlineBackgroundColour } from 'editorialStyles';
 
 
 // ----- Component ----- //
@@ -22,7 +22,7 @@ interface Props {
 
 const styles = (format: Format): SerializedStyles => css`
     ${headline.medium()}
-    ${headlineFontColour(format)}
+    ${headlineTextColour(format)}
     ${headlineBackgroundColour(format)}
     padding-bottom: ${remSpace[9]};
     margin: 0;

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -62,7 +62,7 @@ const analysisStyles = (format: Format): SerializedStyles => css`
     ${headline.medium({ lineHeight: 'regular', fontWeight: 'light' })}
 
     span {
-        box-shadow: inset 0 -0.1rem ${border(format).light};
+        box-shadow: inset 0 -0.1rem ${border.primary(format)};
         padding-bottom: 0.2rem;
     }
 `;

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -3,15 +3,14 @@
 import React, { ReactElement } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import { background, neutral, text } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 import { between, from } from '@guardian/src-foundations/mq';
-import { Display, Design } from '@guardian/types/Format';
+import { Format, Display, Design } from '@guardian/types/Format';
 
 import { Item } from 'item';
-import { darkModeCss as darkMode, wideContentWidth, articleWidthStyles } from 'styles';
-import { getPillarStyles, PillarStyles } from 'pillarStyles';
+import { wideContentWidth, articleWidthStyles } from 'styles';
 import StarRating from 'components/starRating';
+import { headlineFontColour, headlineBackgroundColour, border } from 'editorialPalette';
 
 
 // ----- Component ----- //
@@ -20,26 +19,18 @@ interface Props {
     item: Item;
 }
 
-const darkStyles = darkMode`
-    background: ${background.inverse};
-    color: ${neutral[86]};
-`;
-
-const styles = css`
+const styles = (format: Format): SerializedStyles => css`
     ${headline.medium()}
+    ${headlineFontColour(format)}
+    ${headlineBackgroundColour(format)}
     padding-bottom: ${remSpace[9]};
-    color: ${text.primary};
     margin: 0;
 
     ${articleWidthStyles}
-
-    ${darkStyles}
 `;
 
 const immersiveStyles = css`
     ${headline.medium({ fontWeight: 'bold' })}
-    background-color: ${neutral[7]};
-    color: ${neutral[100]};
     font-weight: 700;
     padding: ${remSpace[1]} ${remSpace[2]} ${remSpace[6]} ${remSpace[2]};
     margin: calc(100vh - 5rem) 0 0;
@@ -64,67 +55,52 @@ const immersiveStyles = css`
             width: ${wideContentWidth}px;
         }
     }
-
-    ${darkStyles}
 `;
 
-const analysisStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
-    ${styles}
+const analysisStyles = (format: Format): SerializedStyles => css`
     ${headline.medium({ lineHeight: 'regular', fontWeight: 'light' })}
 
     span {
-        box-shadow: inset 0 -0.1rem ${kicker};
+        box-shadow: inset 0 -0.1rem ${border(format).light};
         padding-bottom: 0.2rem;
     }
 `;
 
-const mediaStyles = css `
-    ${styles}
-    color: ${neutral[100]};
+const mediaStyles = css`
     ${headline.medium({ fontWeight: 'medium' })}
-    
-    ${darkMode`
-        color: ${neutral[86]};
-    `}
 `
 
-const featureStyles = ({ featureHeadline }: PillarStyles): SerializedStyles => css`
-    ${styles}
+const featureStyles = css`
     ${headline.medium({ fontWeight: 'bold' })}
-    color: ${featureHeadline};
 `;
 
 const commentStyles = css`
-    ${styles}
     ${headline.medium({ fontWeight: 'light' })}
     padding-bottom: ${remSpace[1]};
 `;
 
 const advertisementFeatureStyles = css`
-    ${styles}
     ${textSans.xxxlarge({ lineHeight: 'regular' })}}
 `;
 
-const getStyles = (item: Item): SerializedStyles => {
-    const pillarStyles = getPillarStyles(item.pillar);
-
-    if (item.display === Display.Immersive) {
-        return immersiveStyles;
+const getStyles = (format: Format): SerializedStyles => {
+    if (format.display === Display.Immersive) {
+        return css(styles(format), immersiveStyles);
     }
 
-    switch (item.design) {
+    switch (format.design) {
         case Design.Analysis:
-            return analysisStyles(pillarStyles);
+            return css(styles(format), analysisStyles(format));
         case Design.Feature:
-            return featureStyles(pillarStyles);
+            return css(styles(format), featureStyles);
         case Design.Comment:
-            return commentStyles;
+            return css(styles(format), commentStyles);
         case Design.Media:
-            return mediaStyles;
+            return css(styles(format), mediaStyles);
         case Design.AdvertisementFeature:
-            return advertisementFeatureStyles;
+            return css(styles(format), advertisementFeatureStyles);
         default:
-            return styles;
+            return styles(format);
     }
 }
 

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -1,0 +1,111 @@
+// ----- Imports ----- //
+
+import { SerializedStyles, css } from '@emotion/core';
+import {
+    text,
+    background,
+    neutral,
+    news,
+    opinion,
+    sport,
+    culture,
+    lifestyle,
+} from '@guardian/src-foundations/palette';
+import { Format, Design, Display, Pillar } from '@guardian/types/Format';
+
+import { compose } from 'lib';
+
+
+// ----- Types ----- //
+
+interface Colour {
+    light: string;
+    dark: string;
+}
+
+
+// ----- Functions ----- //
+
+const headlineFont = (format: Format): Colour => {
+    const light = text.primary;
+    const dark = neutral[86];
+
+    if (format.display === Display.Immersive || format.design === Design.Media) {
+        return ({ light: neutral[100], dark });
+    }
+
+    if (format.design === Design.Feature) {
+        switch (format.pillar) {
+            case Pillar.Opinion:
+                return ({ light: opinion[300], dark });
+            case Pillar.Sport:
+                return ({ light: sport[300], dark });
+            case Pillar.Culture:
+                return ({ light: culture[300], dark });
+            case Pillar.Lifestyle:
+                return ({ light: lifestyle[300], dark });
+            case Pillar.News:
+            default:
+                return ({ light: news[300], dark });
+        }
+    }
+
+    return { light, dark };
+}
+
+const headlineBackground = (format: Format): Colour => {
+    const light = background.primary;
+    const dark = background.inverse;
+
+    if (format.display === Display.Immersive) {
+        return ({ light: neutral[7], dark });
+    }
+
+    return { light, dark };
+}
+
+const border = (format: Format): Colour => {
+    switch (format.pillar) {
+        case Pillar.Opinion:
+            return ({ light: opinion[400], dark: opinion[400] });
+        case Pillar.Sport:
+            return ({ light: sport[400], dark: sport[400] });
+        case Pillar.Culture:
+            return ({ light: culture[400], dark: culture[400] });
+        case Pillar.Lifestyle:
+            return ({ light: lifestyle[400], dark: lifestyle[400] });
+        case Pillar.News:
+        default:
+            return ({ light: news[400], dark: news[400] });
+    }
+}
+
+const fontColour = (colour: Colour): SerializedStyles =>
+    css`
+        color: ${colour.light};
+
+        @media (prefers-color-scheme: dark) {
+            color: ${colour.dark};
+        }
+    `;
+
+const backgroundColour = (colour: Colour): SerializedStyles =>
+    css`
+        background-color: ${colour.light};
+
+        @media (prefers-color-scheme: dark) {
+            background-color: ${colour.dark};
+        }
+    `;
+
+const headlineFontColour = compose(fontColour, headlineFont);
+const headlineBackgroundColour = compose(backgroundColour, headlineBackground);
+
+
+// ----- Exports ----- //
+
+export {
+    headlineFontColour,
+    headlineBackgroundColour,
+    border,
+};

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -21,7 +21,7 @@ interface Colour {
 }
 
 interface Palette {
-    headlineFont: Colour;
+    headlineText: Colour;
     headlineBackground: Colour;
     border: Colour;
 }
@@ -29,7 +29,7 @@ interface Palette {
 
 // ----- Functions ----- //
 
-const headlineFont = (format: Format): Colour => {
+const headlineText = (format: Format): Colour => {
     const light = text.primary;
     const dark = neutral[86];
 
@@ -85,7 +85,7 @@ const border = (format: Format): Colour => {
 
 const palette = (format: Format): Palette =>
     ({
-        headlineFont: headlineFont(format),
+        headlineText: headlineText(format),
         headlineBackground: headlineBackground(format),
         border: border(format),
     });
@@ -95,7 +95,7 @@ const palette = (format: Format): Palette =>
 
 export {
     Colour,
-    headlineFont,
+    headlineText,
     headlineBackground,
     border,
     palette,

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 
-import { SerializedStyles, css } from '@emotion/core';
 import {
     text,
     background,
@@ -13,14 +12,18 @@ import {
 } from '@guardian/src-foundations/palette';
 import { Format, Design, Display, Pillar } from '@guardian/types/Format';
 
-import { compose } from 'lib';
-
 
 // ----- Types ----- //
 
 interface Colour {
     light: string;
     dark: string;
+}
+
+interface Palette {
+    headlineFont: Colour;
+    headlineBackground: Colour;
+    border: Colour;
 }
 
 
@@ -80,32 +83,20 @@ const border = (format: Format): Colour => {
     }
 }
 
-const fontColour = (colour: Colour): SerializedStyles =>
-    css`
-        color: ${colour.light};
-
-        @media (prefers-color-scheme: dark) {
-            color: ${colour.dark};
-        }
-    `;
-
-const backgroundColour = (colour: Colour): SerializedStyles =>
-    css`
-        background-color: ${colour.light};
-
-        @media (prefers-color-scheme: dark) {
-            background-color: ${colour.dark};
-        }
-    `;
-
-const headlineFontColour = compose(fontColour, headlineFont);
-const headlineBackgroundColour = compose(backgroundColour, headlineBackground);
+const palette = (format: Format): Palette =>
+    ({
+        headlineFont: headlineFont(format),
+        headlineBackground: headlineBackground(format),
+        border: border(format),
+    });
 
 
 // ----- Exports ----- //
 
 export {
-    headlineFontColour,
-    headlineBackgroundColour,
+    Colour,
+    headlineFont,
+    headlineBackground,
     border,
+    palette,
 };

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -19,16 +19,16 @@ type Colour = string;
 
 interface Palette {
     text: {
-        headlinePrimary: string;
-        headlineInverse: string;
+        headlinePrimary: Colour;
+        headlineInverse: Colour;
     };
     background: {
-        headlinePrimary: string;
-        headlineInverse: string;
+        headlinePrimary: Colour;
+        headlineInverse: Colour;
     };
     border: {
-        primary: string;
-        inverse: string;
+        primary: Colour;
+        inverse: Colour;
     };
 }
 

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
 
 import {
-    text,
-    background,
+    text as coreText,
+    background as coreBackground,
     neutral,
     news,
     opinion,
@@ -15,79 +15,114 @@ import { Format, Design, Display, Pillar } from '@guardian/types/Format';
 
 // ----- Types ----- //
 
-interface Colour {
-    light: string;
-    dark: string;
-}
+type Colour = string;
 
 interface Palette {
-    headlineText: Colour;
-    headlineBackground: Colour;
-    border: Colour;
+    text: {
+        headlinePrimary: string;
+        headlineInverse: string;
+    };
+    background: {
+        headlinePrimary: string;
+        headlineInverse: string;
+    };
+    border: {
+        primary: string;
+        inverse: string;
+    };
 }
 
 
 // ----- Functions ----- //
 
-const headlineText = (format: Format): Colour => {
-    const light = text.primary;
-    const dark = neutral[86];
-
+const textHeadlinePrimary = (format: Format): Colour => {
     if (format.display === Display.Immersive || format.design === Design.Media) {
-        return ({ light: neutral[100], dark });
+        return neutral[100];
     }
 
     if (format.design === Design.Feature) {
         switch (format.pillar) {
             case Pillar.Opinion:
-                return ({ light: opinion[300], dark });
+                return opinion[300];
             case Pillar.Sport:
-                return ({ light: sport[300], dark });
+                return sport[300];
             case Pillar.Culture:
-                return ({ light: culture[300], dark });
+                return culture[300];
             case Pillar.Lifestyle:
-                return ({ light: lifestyle[300], dark });
+                return lifestyle[300];
             case Pillar.News:
             default:
-                return ({ light: news[300], dark });
+                return news[300];
         }
     }
 
-    return { light, dark };
+    return coreText.primary;
 }
 
-const headlineBackground = (format: Format): Colour => {
-    const light = background.primary;
-    const dark = background.inverse;
+const textHeadlineInverse = (_: Format): Colour =>
+    neutral[86];
 
+const backgroundHeadlinePrimary = (format: Format): Colour => {
     if (format.display === Display.Immersive) {
-        return ({ light: neutral[7], dark });
+        return neutral[7];
     }
 
-    return { light, dark };
+    return coreBackground.primary;
 }
 
-const border = (format: Format): Colour => {
+const backgroundHeadlineInverse = (_: Format): Colour =>
+    coreBackground.inverse;
+
+const borderPrimary = (format: Format): Colour => {
     switch (format.pillar) {
         case Pillar.Opinion:
-            return ({ light: opinion[400], dark: opinion[400] });
+            return opinion[400];
         case Pillar.Sport:
-            return ({ light: sport[400], dark: sport[400] });
+            return sport[400];
         case Pillar.Culture:
-            return ({ light: culture[400], dark: culture[400] });
+            return culture[400];
         case Pillar.Lifestyle:
-            return ({ light: lifestyle[400], dark: lifestyle[400] });
+            return lifestyle[400];
         case Pillar.News:
         default:
-            return ({ light: news[400], dark: news[400] });
+            return news[400];
     }
 }
+
+const borderInverse = borderPrimary;
+
+
+// ----- API ----- //
+
+const text = {
+    headlinePrimary: textHeadlinePrimary,
+    headlineInverse: textHeadlineInverse,
+};
+
+const background = {
+    headlinePrimary: backgroundHeadlinePrimary,
+    headlineInverse: backgroundHeadlineInverse,
+};
+
+const border = {
+    primary: borderPrimary,
+    inverse: borderInverse,
+};
 
 const palette = (format: Format): Palette =>
     ({
-        headlineText: headlineText(format),
-        headlineBackground: headlineBackground(format),
-        border: border(format),
+        text: {
+            headlinePrimary: text.headlinePrimary(format),
+            headlineInverse: text.headlineInverse(format),
+        },
+        background: {
+            headlinePrimary: background.headlinePrimary(format),
+            headlineInverse: background.headlineInverse(format),
+        },
+        border: {
+            primary: border.primary(format),
+            inverse: border.inverse(format),
+        },
     });
 
 
@@ -95,8 +130,8 @@ const palette = (format: Format): Palette =>
 
 export {
     Colour,
-    headlineText,
-    headlineBackground,
+    text,
+    background,
     border,
     palette,
 };

--- a/src/editorialStyles.ts
+++ b/src/editorialStyles.ts
@@ -1,0 +1,38 @@
+// ----- Imports ----- //
+
+import { SerializedStyles, css } from '@emotion/core';
+
+import { compose } from 'lib';
+import { Colour, headlineFont, headlineBackground } from 'editorialPalette';
+
+
+// ----- Functions ----- //
+
+const fontColour = (colour: Colour): SerializedStyles =>
+    css`
+        color: ${colour.light};
+
+        @media (prefers-color-scheme: dark) {
+            color: ${colour.dark};
+        }
+    `;
+
+const backgroundColour = (colour: Colour): SerializedStyles =>
+    css`
+        background-color: ${colour.light};
+
+        @media (prefers-color-scheme: dark) {
+            background-color: ${colour.dark};
+        }
+    `;
+
+const headlineFontColour = compose(fontColour, headlineFont);
+const headlineBackgroundColour = compose(backgroundColour, headlineBackground);
+
+
+// ----- Exports ----- //
+
+export {
+    headlineFontColour,
+    headlineBackgroundColour,
+};

--- a/src/editorialStyles.ts
+++ b/src/editorialStyles.ts
@@ -3,12 +3,12 @@
 import { SerializedStyles, css } from '@emotion/core';
 
 import { compose } from 'lib';
-import { Colour, headlineFont, headlineBackground } from 'editorialPalette';
+import { Colour, headlineText, headlineBackground } from 'editorialPalette';
 
 
 // ----- Functions ----- //
 
-const fontColour = (colour: Colour): SerializedStyles =>
+const textColour = (colour: Colour): SerializedStyles =>
     css`
         color: ${colour.light};
 
@@ -26,13 +26,13 @@ const backgroundColour = (colour: Colour): SerializedStyles =>
         }
     `;
 
-const headlineFontColour = compose(fontColour, headlineFont);
+const headlineTextColour = compose(textColour, headlineText);
 const headlineBackgroundColour = compose(backgroundColour, headlineBackground);
 
 
 // ----- Exports ----- //
 
 export {
-    headlineFontColour,
+    headlineTextColour,
     headlineBackgroundColour,
 };

--- a/src/editorialStyles.ts
+++ b/src/editorialStyles.ts
@@ -1,33 +1,35 @@
 // ----- Imports ----- //
 
 import { SerializedStyles, css } from '@emotion/core';
+import { Format } from '@guardian/types/Format';
 
-import { compose } from 'lib';
-import { Colour, headlineText, headlineBackground } from 'editorialPalette';
+import { Colour, text, background } from 'editorialPalette';
 
 
 // ----- Functions ----- //
 
-const textColour = (colour: Colour): SerializedStyles =>
+const textColour = (light: Colour, dark: Colour): SerializedStyles =>
     css`
-        color: ${colour.light};
+        color: ${light};
 
         @media (prefers-color-scheme: dark) {
-            color: ${colour.dark};
+            color: ${dark};
         }
     `;
 
-const backgroundColour = (colour: Colour): SerializedStyles =>
+const backgroundColour = (light: Colour, dark: Colour): SerializedStyles =>
     css`
-        background-color: ${colour.light};
+        background-color: ${light};
 
         @media (prefers-color-scheme: dark) {
-            background-color: ${colour.dark};
+            background-color: ${dark};
         }
     `;
 
-const headlineTextColour = compose(textColour, headlineText);
-const headlineBackgroundColour = compose(backgroundColour, headlineBackground);
+const headlineTextColour = (format: Format): SerializedStyles =>
+    textColour(text.headlinePrimary(format), text.headlineInverse(format));
+const headlineBackgroundColour = (format: Format): SerializedStyles =>
+    backgroundColour(background.headlinePrimary(format), background.headlineInverse(format));
 
 
 // ----- Exports ----- //


### PR DESCRIPTION
## Why are you doing this?

A speculative PR based on our conversation about an editorial colour palette. I'm not sure about the API here so I'd appreciate some feedback 🙂

This creates some simple functions to lookup headline font and background colours, and the border colour based on the `Format` type. I've also added some functions to generate the next level above this, i.e. CSS declarations for font and background colour based on the `Format` type.

## Changes

- Created editorialPalette module
- Functions to get headlineFont, headlineBackground and border colours
- Functions to apply color and background declarations
- Applied new palette functions to `Headline` component
