### PR TITLE
AR-18: Remove span from anchor component

### DIFF
--- a/src/components/anchor.stories.tsx
+++ b/src/components/anchor.stories.tsx
@@ -25,7 +25,7 @@ const Default: FC = () =>
         }}
         href={link()}
     >
-        <span>{copy()}</span>
+        {copy()}
     </Anchor>;
 
 


### PR DESCRIPTION
## Why are you doing this?
Removing the `<span>` as it isn't needed

@JamieB-gu sorry I only read your comment after I had merged
