### PR TITLE
Use 'npm ci' For GitHub Actions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,8 +9,7 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: 12
-            - run: |
-                  npm i
+            - run: npm ci
             - uses: chromaui/action@v1
               with:
                   appCode: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         node-version: 12
     - name: install
-      run: npm install
+      run: npm ci
     - name: lint
       run: npm run lint
     - name: test


### PR DESCRIPTION
## Why are you doing this?

Supposedly faster and won't alter `package-lock.json`. Documentation found [here](https://docs.npmjs.com/cli/ci.html).

FYI @gtrufitt @oliverlloyd @liywjl @SiAdcock 

## Changes

- Updated validation job to use `npm ci`
- Updated Chromatic job to use `npm ci`
