### PR TITLE
Parser Converts Image URLs

### DIFF
--- a/src/ads.test.ts
+++ b/src/ads.test.ts
@@ -24,7 +24,7 @@ const generateParas = (paras: number): BodyElement =>
     textElement(Array(paras).fill('<p>foo</p>'));
 
 const render = (element: BodyElement): ReactNode[] =>
-    renderAll({})(mockFormat, [element]);
+    renderAll(mockFormat, [element]);
 
 const renderParagraphs = compose(render, generateParas);
 

--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -5,7 +5,7 @@ import { IAtoms as Atoms } from 'mapiThriftModels/Atoms';
 import { ElementType } from 'mapiThriftModels/ElementType';
 import { Option, fromNullable } from 'types/option';
 import { Result, Err, Ok } from 'types/result';
-import DocParser from 'types/docParser';
+import { Context, DocParser } from 'types/parserContext';
 import { Image as ImageData, parseImage } from 'image';
 
 
@@ -116,7 +116,7 @@ const parseIframe = (docParser: DocParser) =>
         });
 }
 
-const parse = (docParser: DocParser, atoms?: Atoms) =>
+const parse = (context: Context, atoms?: Atoms) =>
     (element: BlockElement): Result<string, BodyElement> => {
     switch (element.type) {
 
@@ -127,11 +127,11 @@ const parse = (docParser: DocParser, atoms?: Atoms) =>
                 return new Err('No html field on textTypeData');
             }
 
-            return new Ok({ kind: ElementKind.Text, doc: docParser(html) });
+            return new Ok({ kind: ElementKind.Text, doc: context.docParser(html) });
         }
 
         case ElementType.IMAGE:
-            return parseImage(docParser)(element)
+            return parseImage(context)(element)
                 .fmap<Result<string, Image>>(image => new Ok({
                     kind: ElementKind.Image,
                     ...image
@@ -183,7 +183,7 @@ const parse = (docParser: DocParser, atoms?: Atoms) =>
                 return new Err('No "html" field on tweetTypeData')
             }
 
-            return tweetContent(id, docParser(h))
+            return tweetContent(id, context.docParser(h))
                 .fmap(content => ({ kind: ElementKind.Tweet, content }));
         }
 
@@ -214,7 +214,7 @@ const parse = (docParser: DocParser, atoms?: Atoms) =>
                 return new Err('No html field on audioTypeData')
             }
 
-            return parseIframe(docParser)(audioHtml, ElementKind.Audio);
+            return parseIframe(context.docParser)(audioHtml, ElementKind.Audio);
         }
 
         case ElementType.VIDEO: {
@@ -224,7 +224,7 @@ const parse = (docParser: DocParser, atoms?: Atoms) =>
                 return new Err('No html field on videoTypeData')
             }
 
-            return parseIframe(docParser)(videoHtml, ElementKind.Video);
+            return parseIframe(context.docParser)(videoHtml, ElementKind.Video);
         }
 
         case ElementType.CONTENTATOM: {
@@ -255,12 +255,12 @@ const parse = (docParser: DocParser, atoms?: Atoms) =>
 
 }
 
-const parseElements = (docParser: DocParser, atoms?: Atoms) =>
+const parseElements = (context: Context, atoms?: Atoms) =>
     (elements: Elements): Result<string, BodyElement>[] => {
         if (!elements) {
             return [new Err('No body elements available')];
         }
-        return elements.map(parse(docParser, atoms));
+        return elements.map(parse(context, atoms));
     }
 
 

--- a/src/client/liveblog.ts
+++ b/src/client/liveblog.ts
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 
-
 import setup from 'client/setup';
 import { fromCapiLiveBlog, getFormat } from 'item';
 import ReactDOM from 'react-dom';
@@ -8,15 +7,13 @@ import LiveblogBody from 'components/liveblog/body';
 import { createElement as h } from 'react';
 import { Content } from 'mapiThriftModels';
 import { parse } from './parser';
-import { ImageMappings } from 'components/shared/page';
+
 
 // ----- Run ----- //
 
 declare global {
     interface Window {
-        __INITIAL__DATA__: Content & {
-            imageMappings: ImageMappings;
-        };
+        __INITIAL__DATA__: Content;
     }
 }
 
@@ -32,12 +29,14 @@ try {
     const hydrationProps = JSON.parse(document.getElementById('hydrationProps')?.textContent ?? "");
 
     if (hydrationProps) {
-        const item = fromCapiLiveBlog(browserParser)(hydrationProps);
+        const item = fromCapiLiveBlog({
+            docParser: browserParser,
+            salt: 'mockSalt',
+        })(hydrationProps);
         const { blocks, totalBodyBlocks } = item;
 
-        const { imageMappings } = hydrationProps;
         ReactDOM.hydrate(
-            h(LiveblogBody, { format: getFormat(item), blocks, imageMappings, totalBodyBlocks }),
+            h(LiveblogBody, { format: getFormat(item), blocks, totalBodyBlocks }),
             document.querySelector('#blocks'),
         );
     }

--- a/src/components/advertisementFeature/article.tsx
+++ b/src/components/advertisementFeature/article.tsx
@@ -14,7 +14,6 @@ import Metadata from 'components/metadata';
 import { darkModeCss, articleWidthStyles } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { Standard, getFormat } from 'item';
-import { ImageMappings } from 'components/shared/page';
 
 
 // ----- Styles ----- //
@@ -41,18 +40,16 @@ const BorderStyles = css`
 // ----- Component ----- //
 
 interface Props {
-    imageMappings: ImageMappings;
     item: Standard;
     children: ReactNode[];
 }
 
-const AdvertisementFeature = ({ imageMappings, item, children }: Props): JSX.Element => {
+const AdvertisementFeature = ({ item, children }: Props): JSX.Element => {
     return <main css={[Styles, DarkStyles]}>
         <article css={BorderStyles}>
             <header>
                 <HeaderImage
                     image={item.mainImage}
-                    imageMappings={imageMappings}
                     format={getFormat(item)}
                 />
                 <div css={articleWidthStyles}>
@@ -63,7 +60,7 @@ const AdvertisementFeature = ({ imageMappings, item, children }: Props): JSX.Ele
                 </div>
                 <Keyline {...item} />
                 <section css={articleWidthStyles}>
-                    <Metadata imageMappings={imageMappings} item={item} />
+                    <Metadata item={item} />
                 </section>
             </header>
             <Body className={[articleWidthStyles]}>

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -1,28 +1,22 @@
 // ----- Imports ----- //
 
-import React, { FC } from 'react';
+import React, { FC, ReactElement } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 
-import { srcsetWithWidths, src } from 'image';
 import { Contributor, isSingleContributor } from 'contributor';
 import { Format } from 'format';
 import { getPillarStyles } from 'pillarStyles';
-import { ImageMappings } from 'components/shared/page';
 
 
 // ----- Setup ----- //
 
 const dimensions = '4rem';
 
-const srcset = srcsetWithWidths([32, 64, 128, 192, 256]);
-const defaultSrcWidth = 64;
-
 
 // ----- Component ----- //
 
 interface Props extends Format {
     contributors: Contributor[];
-    imageMappings: ImageMappings;
     className?: SerializedStyles;
 }
 
@@ -40,22 +34,22 @@ const getStyles = ({ pillar }: Format): SerializedStyles => {
     return styles(colours.inverted);
 }
 
-const Avatar: FC<Props> = ({ contributors, imageMappings, className, ...format }: Props) => {
+const Avatar: FC<Props> = ({ contributors, className, ...format }: Props) => {
     const [contributor] = contributors;
 
-    if (isSingleContributor(contributors) && contributor.bylineLargeImageUrl !== undefined) {
-        return (
-            <img
-                css={[getStyles(format), className]}
-                srcSet={srcset(contributor.bylineLargeImageUrl, imageMappings)}
-                alt={contributor.webTitle}
-                sizes={dimensions}
-                src={src(imageMappings, contributor.bylineLargeImageUrl, defaultSrcWidth)}
-            />
-        );
+    if (!isSingleContributor(contributors)) {
+        return null;
     }
 
-    return null;
+    return contributor.image.fmap<ReactElement | null>(image =>
+        <img
+            css={[getStyles(format), className]}
+            srcSet={image.srcset}
+            alt={contributor.name}
+            sizes={dimensions}
+            src={image.src}
+        />
+    ).withDefault(null);
 }
 
 

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -37,11 +37,10 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     `}
 `;
 
-const BodyImage: FC<BodyImageProps> = ({ image, imageMappings, children }: BodyImageProps) =>
+const BodyImage: FC<BodyImageProps> = ({ image, children }: BodyImageProps) =>
     <figure css={styles}>
         <Img
             image={image}
-            imageMappings={imageMappings}
             sizes={sizes}
             className={imgStyles(image.width, image.height)}
         />

--- a/src/components/bodyImageHalfWidth.tsx
+++ b/src/components/bodyImageHalfWidth.tsx
@@ -32,11 +32,10 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     width: 100%;
 `;
 
-const BodyImageHalfWidth: FC<Props> = ({ image, imageMappings }: Props) =>
+const BodyImageHalfWidth: FC<Props> = ({ image }: Props) =>
     <figure css={styles} className="halfWidth">
         <Img
             image={image}
-            imageMappings={imageMappings}
             sizes={size}
             className={imgStyles(image.width, image.height)}
         />

--- a/src/components/bodyImageThumbnail.tsx
+++ b/src/components/bodyImageThumbnail.tsx
@@ -32,11 +32,10 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     height: calc(${size} * ${height / width});
 `;
 
-const BodyImageThumbnail: FC<Props> = ({ image, imageMappings, children }: Props) =>
+const BodyImageThumbnail: FC<Props> = ({ image, children }: Props) =>
     <figure css={styles}>
         <Img
             image={image}
-            imageMappings={imageMappings}
             sizes={size}
             className={imgStyles(image.width, image.height)}
         />

--- a/src/components/follow.stories.tsx
+++ b/src/components/follow.stories.tsx
@@ -6,6 +6,7 @@ import { withKnobs } from '@storybook/addon-knobs';
 import Follow from './follow';
 import { Pillar, Design, Display } from 'format';
 import { selectPillar } from 'storybookHelpers';
+import { None } from 'types/option';
 
 
 // ----- Stories ----- //
@@ -16,7 +17,8 @@ const Default: FC = () =>
             {
                 id: 'profile/janesmith',
                 apiUrl: 'janesmith.com',
-                webTitle: 'Jane Smith',
+                name: 'Jane Smith',
+                image: new None(),
             }
         ]}
         pillar={selectPillar(Pillar.News)}

--- a/src/components/follow.test.tsx
+++ b/src/components/follow.test.tsx
@@ -6,6 +6,8 @@ import Adapter from 'enzyme-adapter-react-16';
 
 import Follow from './follow';
 import { Pillar, Design, Display } from 'format';
+import { None } from 'types/option';
+import { Contributor } from 'contributor';
 
 
 // ----- Setup ----- //
@@ -23,11 +25,12 @@ const followFormat = {
 
 describe('Follow component renders as expected', () => {
     it('Displays title correctly', () => {
-        const contributors = [
+        const contributors: Contributor[] = [
             {
                 apiUrl: "https://mapi.co.uk/test",
-                webTitle: "George Monbiot",
+                name: "George Monbiot",
                 id: "test",
+                image: new None(),
             },
         ];
         const follow = shallow(
@@ -38,8 +41,8 @@ describe('Follow component renders as expected', () => {
     })
 
     it('Renders null if no apiUrl', () => {
-        const contributors = [
-            { webTitle: "George Monbiot", id: "test", apiUrl: "" },
+        const contributors: Contributor[] = [
+            { name: "George Monbiot", id: "test", apiUrl: "", image: new None() },
         ];
         const follow = shallow(
             <Follow contributors={contributors} {...followFormat} />
@@ -49,16 +52,18 @@ describe('Follow component renders as expected', () => {
     })
 
     it('Renders null if more than one contributor', () => {
-        const contributors = [
+        const contributors: Contributor[] = [
             {
-                webTitle: "Contributor 1",
+                name: "Contributor 1",
                 apiUrl: "https://mapi.co.uk/test",
                 id: "test",
+                image: new None(),
             },
             {
-                webTitle: "Contributor 2",
+                name: "Contributor 2",
                 apiUrl: "https://mapi.co.uk/test",
                 id: "test",
+                image: new None(),
             },
         ];
         const follow = shallow(

--- a/src/components/follow.tsx
+++ b/src/components/follow.tsx
@@ -49,7 +49,7 @@ function Follow({ contributors, ...format }: Props): JSX.Element | null {
         return (
             <button className="js-follow" css={getStyles(format)} data-id={contributor.id}>
                 <span className="js-status">Follow </span>
-                { contributor.webTitle }
+                { contributor.name }
             </button>
         );
     }

--- a/src/components/headerImage.test.tsx
+++ b/src/components/headerImage.test.tsx
@@ -26,7 +26,7 @@ describe('HeaderImage component renders as expected', () => {
             display: Display.Standard,
         }
         const headerImage = shallow(
-            <HeaderImage image={image} imageMappings={{}} format={format} />
+            <HeaderImage image={image} format={format} />
         )
 
         expect(headerImage.html()).toBe(null);

--- a/src/components/headerImage.tsx
+++ b/src/components/headerImage.tsx
@@ -10,7 +10,6 @@ import { wideContentWidth } from 'styles';
 import { Option } from 'types/option';
 import { Image } from 'image';
 import Img from 'components/img';
-import { ImageMappings } from 'components/shared/page';
 import { Format, Display, Design } from 'format';
 
 
@@ -113,18 +112,16 @@ const getSizes = ({ display }: Format, image: Image): string => {
 
 interface Props {
     image: Option<Image>;
-    imageMappings: ImageMappings;
     className?: SerializedStyles;
     format: Format;
 }
 
-const HeaderImage: FC<Props> = ({ className, image, imageMappings, format }) =>
+const HeaderImage: FC<Props> = ({ className, image, format }) =>
     image.fmap<ReactElement | null>(imageData =>
         <figure css={[getStyles(format), className]} aria-labelledby={captionId}>
             <Img
                 image={imageData}
                 sizes={getSizes(format, imageData)}
-                imageMappings={imageMappings}
                 className={getImgStyles(format, imageData)}
             />
             <Caption format={format} image={imageData} />

--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -4,8 +4,7 @@ import { FC } from 'react';
 import { jsx as styledH, SerializedStyles, css } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 
-import { ImageMappings } from 'components/shared/page';
-import { Image, srcset, src } from 'image';
+import { Image } from 'image';
 import { darkModeCss } from 'styles';
 
 
@@ -13,7 +12,6 @@ import { darkModeCss } from 'styles';
 
 interface Props {
     image: Image;
-    imageMappings: ImageMappings;
     sizes: string;
     className?: SerializedStyles;
 }
@@ -26,11 +24,11 @@ const styles = css`
     `}
 `;
 
-const Img: FC<Props> = ({ image, sizes, imageMappings, className }) =>
+const Img: FC<Props> = ({ image, sizes, className }) =>
     styledH('img', {
         sizes,
-        srcSet: srcset(image.src, imageMappings),
-        src: src(imageMappings, image.src, 500),
+        srcSet: image.srcset,
+        src: image.src,
         alt: image.alt.withDefault(''),
         className: 'js-launch-slideshow',
         css: [styles, className],

--- a/src/components/liveblog/article.tsx
+++ b/src/components/liveblog/article.tsx
@@ -14,7 +14,6 @@ import { neutral, background } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Liveblog, getFormat } from 'item';
-import { ImageMappings } from 'components/shared/page';
 
 const LiveblogArticleStyles: SerializedStyles = css`
     background: ${neutral[97]};
@@ -40,10 +39,9 @@ const headerImageStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
 
 interface LiveblogArticleProps {
     item: Liveblog;
-    imageMappings: ImageMappings;
 }
 
-const LiveblogArticle = ({ item, imageMappings }: LiveblogArticleProps): JSX.Element => {
+const LiveblogArticle = ({ item }: LiveblogArticleProps): JSX.Element => {
     const format = getFormat(item);
 
     return (
@@ -52,11 +50,10 @@ const LiveblogArticle = ({ item, imageMappings }: LiveblogArticleProps): JSX.Ele
                 <LiveblogSeries series={item.series} pillar={item.pillar} />
                 <LiveblogHeadline headline={item.headline} pillar={item.pillar} />
                 <LiveblogStandfirst standfirst={item.standfirst} format={format} />
-                <Metadata item={item} imageMappings={imageMappings} />
+                <Metadata item={item} />
                 <div css={headerImageStyles(getPillarStyles(item.pillar))}>
                     <HeaderImage
                         image={item.mainImage}
-                        imageMappings={imageMappings}
                         format={format}
                     />
                 </div>
@@ -64,7 +61,6 @@ const LiveblogArticle = ({ item, imageMappings }: LiveblogArticleProps): JSX.Ele
                 <LiveblogBody
                     blocks={item.blocks}
                     format={format}
-                    imageMappings={imageMappings}
                     totalBodyBlocks={item.totalBodyBlocks}
                 />
                 <Tags tags={item.tags} background={neutral[93]} />

--- a/src/components/liveblog/avatar.test.tsx
+++ b/src/components/liveblog/avatar.test.tsx
@@ -2,49 +2,37 @@ import React from 'react';
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Avatar from 'components/liveblog/avatar';
+import { Contributor } from 'contributor';
+import { None, Some } from 'types/option';
 
 configure({ adapter: new Adapter() });
 
 describe('Avatar component renders as expected', () => {
+    const contributors: Contributor[] = [{
+        name: "Web Title",
+        id: "test",
+        apiUrl: 'test',
+        image: new Some({
+            src: '',
+            srcset: '',
+        }),
+    }]
     it('Adds correct alt attribute', () => {
-        const contributors = [{
-            bylineLargeImageUrl: "https://mapi.co.uk/test",
-            webTitle: "Web Title",
-            id: "test",
-            apiUrl: 'test',
-        }]
-        const avatar = shallow(<Avatar contributors={contributors} bgColour="" imageMappings={{}} />);
+        const avatar = shallow(<Avatar contributors={contributors} bgColour="" />);
         expect(avatar.find('img').prop('alt')).toBe("Web Title")
     })
 
     it('Uses background colour prop', () => {
-        const contributors = [{
-            bylineLargeImageUrl: "https://mapi.co.uk/test",
-            webTitle: "Web Title",
-            id: "test",
-            apiUrl: 'test',
-        }];
-        const avatar = shallow(<Avatar contributors={contributors} bgColour="pink" imageMappings={{}} />);
+        const avatar = shallow(<Avatar contributors={contributors} bgColour="pink" />);
         expect(avatar.props().css.styles).toContain("background-color: pink")
     })
 
-    it('Generates correct image url', () => {
-        const contributors = [{
-            bylineLargeImageUrl: "https://mapi.co.uk/test",
-            webTitle: "Web Title",
-            id: "test",
-            apiUrl: 'test',
-        }]
-        const avatar = shallow(<Avatar contributors={contributors} bgColour="" imageMappings={{ "/test": "SALT" }}/>);
-        expect(avatar.find('img').prop('src')).toBe("https://i.guim.co.uk/img/mapi/test?width=204&quality=85&fit=bounds&sig-ignores-params=true&s=SALT")
-    })
-
     it('Renders null if more than one contributor', () => {
-        const contributors = [
-            { webTitle: "Contributor 1", id: "test", apiUrl: 'test', },
-            { webTitle: "Contributor 2", id: "test", apiUrl: 'test', }
+        const contributors: Contributor[] = [
+            { name: "Contributor 1", id: "test", apiUrl: 'test', image: new None() },
+            { name: "Contributor 2", id: "test", apiUrl: 'test', image: new None() },
         ]
-        const avatar = shallow(<Avatar contributors={contributors} bgColour="" imageMappings={{}} />);
+        const avatar = shallow(<Avatar contributors={contributors} bgColour="" />);
         expect(avatar.html()).toBe(null)
     })
 });

--- a/src/components/liveblog/avatar.tsx
+++ b/src/components/liveblog/avatar.tsx
@@ -1,20 +1,18 @@
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 
 import { Contributor, isSingleContributor } from 'contributor';
-import { src } from 'image';
-import { ImageMappings } from 'components/shared/page';
 
 
 // ----- Styles ----- //
 
-const imageWidth = 68;
+const imageWidth = '4rem';
 
 const AvatarStyles = (bgColour: string): SerializedStyles => css`
-    width: ${imageWidth}px;
-    height: ${imageWidth}px;
+    width: ${imageWidth};
+    height: ${imageWidth};
     background-color: ${bgColour};
     border-radius: 100%;
     float: left;
@@ -35,23 +33,25 @@ const AvatarStyles = (bgColour: string): SerializedStyles => css`
 interface AvatarProps {
     contributors: Contributor[];
     bgColour: string;
-    imageMappings: ImageMappings;
 }
 
-function Avatar({ contributors, bgColour, imageMappings }: AvatarProps): JSX.Element | null {
+function Avatar({ contributors, bgColour }: AvatarProps): JSX.Element | null {
     const [contributor] = contributors;
 
-    if (isSingleContributor(contributors) && contributor.bylineLargeImageUrl) {
-        const imgSrc = src(imageMappings, contributor.bylineLargeImageUrl, imageWidth*3);
-        return (
-            <div css={AvatarStyles(bgColour)}>
-                <img src={imgSrc} alt={contributor.webTitle}/>
-            </div>
-        );
+    if (!isSingleContributor(contributors)) {
+        return null;
     }
-    
-    return null;
 
+    return contributor.image.fmap<ReactElement | null>(image =>
+        <div css={AvatarStyles(bgColour)}>
+            <img
+                srcSet={image.srcset}
+                src={image.src}
+                alt={contributor.name}
+                sizes={imageWidth}
+            />
+        </div>
+    ).withDefault(null);
 }
 
 

--- a/src/components/liveblog/body.tsx
+++ b/src/components/liveblog/body.tsx
@@ -8,7 +8,6 @@ import { renderAll } from 'renderer';
 import { partition } from 'types/result';
 import { BufferedTransport, CompactProtocol } from '@creditkarma/thrift-server-core';
 import { Blocks } from 'mapiThriftModels';
-import { ImageMappings } from 'components/shared/page';
 import { remSpace } from '@guardian/src-foundations';
 
 const LiveBodyStyles = css`
@@ -27,7 +26,6 @@ interface LiveblogBodyProps {
     format: Format;
     blocks: LiveBlock[];
     totalBodyBlocks: number;
-    imageMappings: ImageMappings;
 }
 
 async function loadMoreBlocks(): Promise<void> {
@@ -45,7 +43,7 @@ const LoadMore = ({ total, pillar }: { total: number; pillar: Pillar }): JSX.Ele
         : null;
 
 const LiveblogBody = (props: LiveblogBodyProps): JSX.Element => {
-    const { format, blocks: initialBlocks, imageMappings, totalBodyBlocks } = props;
+    const { format, blocks: initialBlocks, totalBodyBlocks } = props;
     const [blocks] = useState(initialBlocks);
 
     return (
@@ -59,7 +57,7 @@ const LiveblogBody = (props: LiveblogBodyProps): JSX.Element => {
                         title={block.title}
                         firstPublishedDate={block.firstPublished}
                         lastModifiedDate={block.lastModified}>
-                            <>{ renderAll(imageMappings)(format, partition(block.body).oks) }</>
+                            <>{ renderAll(format, partition(block.body).oks) }</>
                         </LiveblogBlock>
                 })
             }

--- a/src/components/liveblog/metadata.tsx
+++ b/src/components/liveblog/metadata.tsx
@@ -11,7 +11,6 @@ import { CommentCount } from './commentCount';
 import { Liveblog, getFormat } from 'item';
 import { renderText } from 'renderer';
 import Dateline from 'components/dateline';
-import { ImageMappings } from 'components/shared/page';
 
 const styles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
     background: ${liveblogBackground};
@@ -69,10 +68,9 @@ const commentCount = ({ liveblogBackground }: PillarStyles): SerializedStyles =>
 
 interface Props {
     item: Liveblog;
-    imageMappings: ImageMappings;
 }
 
-const Metadata = ({ item, imageMappings}: Props): JSX.Element => {
+const Metadata = ({ item }: Props): JSX.Element => {
     const pillarStyles = getPillarStyles(item.pillar);
 
     const byline = item.bylineHtml.fmap<ReactNode>(html =>
@@ -88,7 +86,6 @@ const Metadata = ({ item, imageMappings}: Props): JSX.Element => {
                         <Avatar
                             contributors={item.contributors}
                             bgColour={pillarStyles.featureHeadline}
-                            imageMappings={imageMappings}
                         />
                         <div className="author">
                             { byline }

--- a/src/components/media/article.tsx
+++ b/src/components/media/article.tsx
@@ -14,7 +14,7 @@ import Tags from 'components/media/tags';
 import { articleWidthStyles } from 'styles';
 import { Item, getFormat } from 'item';
 import Headline from 'components/headline';
-import { ImageMappings } from "../shared/page";
+
 
 // ----- Styles ----- //
 
@@ -35,18 +35,16 @@ const BorderStyles = css`
 // ----- Component ----- //
 
 interface Props {
-    imageMappings: ImageMappings;
     item: Item;
     children: ReactNode[];
 }
 
-const Media = ({ imageMappings, item, children }: Props): JSX.Element =>
+const Media = ({ item, children }: Props): JSX.Element =>
      <main css={[Styles]}>
         <article css={BorderStyles}>
             <header>
                 <HeaderImage
                     image={item.mainImage}
-                    imageMappings={imageMappings}
                     format={getFormat(item)}
                 />
                 <div css={articleWidthStyles}>

--- a/src/components/metadata.tsx
+++ b/src/components/metadata.tsx
@@ -9,7 +9,6 @@ import { Item } from 'item';
 import Dateline from 'components/dateline';
 import Follow from 'components/follow';
 import CommentCount from 'components/commentCount';
-import { ImageMappings } from 'components/shared/page';
 import Avatar from 'components/avatar';
 import Byline from 'components/byline';
 
@@ -18,7 +17,6 @@ import Byline from 'components/byline';
 
 interface Props {
     item: Item;
-    imageMappings: ImageMappings;
 }
 
 const styles = css`
@@ -43,9 +41,9 @@ const avatarStyles = css`
     margin-top: ${remSpace[1]};
 `;
 
-const MetadataWithByline: FC<Props> = ({ item, imageMappings }: Props) =>
+const MetadataWithByline: FC<Props> = ({ item }: Props) =>
     <div css={css(styles, withBylineStyles)}>
-        <Avatar className={avatarStyles} imageMappings={imageMappings} {...item} />
+        <Avatar className={avatarStyles} {...item} />
         <div css={css(textStyles, withBylineTextStyles)}>
             <Byline {...item} />
             <Dateline date={item.publishDate} />

--- a/src/components/opinion/article.tsx
+++ b/src/components/opinion/article.tsx
@@ -15,7 +15,6 @@ import Cutout from 'components/opinion/cutout';
 import { darkModeCss, articleWidthStyles, basePx } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { Comment, getFormat } from 'item';
-import { ImageMappings } from 'components/shared/page';
 import Byline from 'components/byline';
 import Metadata from 'components/metadata';
 
@@ -57,12 +56,11 @@ const topBorder = css`
 // ----- Component ----- //
 
 interface Props {
-    imageMappings: ImageMappings;
     item: Comment;
     children: ReactNode[];
 }
 
-const Opinion = ({ imageMappings, item, children }: Props): JSX.Element =>
+const Opinion = ({ item, children }: Props): JSX.Element =>
     <main css={[Styles, DarkStyles]}>
         <article css={BorderStyles}>
             <header>
@@ -73,7 +71,6 @@ const Opinion = ({ imageMappings, item, children }: Props): JSX.Element =>
                 </div>
                 <Cutout 
                     contributors={item.contributors}
-                    imageMappings={imageMappings}
                     className={articleWidthStyles}
                 />
                 <Keyline {...item} />
@@ -82,12 +79,11 @@ const Opinion = ({ imageMappings, item, children }: Props): JSX.Element =>
                 </div>
 
                 <section css={[articleWidthStyles, topBorder]}>
-                    <Metadata item={item} imageMappings={imageMappings} />
+                    <Metadata item={item} />
                 </section>
 
                 <HeaderImage
                     image={item.mainImage}
-                    imageMappings={imageMappings}
                     format={getFormat(item)}
                 />
             </header>

--- a/src/components/opinion/cutout.tsx
+++ b/src/components/opinion/cutout.tsx
@@ -1,25 +1,18 @@
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 
 import { Contributor, isSingleContributor } from 'contributor';
-import { src } from 'image';
-import { ImageMappings } from 'components/shared/page';
-
-
-// ----- Constants ----- //
-
-const imageWidth = 100;
 
 
 // ----- Styles ----- //
 
-const Styles = css`
+const styles = css`
     position: relative;
 `;
 
-const ImageStyles = css`
+const imageStyles = css`
     position: absolute;
     height: 160px;
     right: 0;
@@ -31,24 +24,27 @@ const ImageStyles = css`
 
 interface Props {
     contributors: Contributor[];
-    imageMappings: ImageMappings;
     className: SerializedStyles;
 }
 
-const Cutout = ({ contributors, imageMappings, className }: Props): JSX.Element | null => {
+const Cutout = ({ contributors, className }: Props): JSX.Element | null => {
     const [contributor] = contributors;
 
-    if (isSingleContributor(contributors) && contributor.bylineLargeImageUrl) {
-        const imgSrc = src(imageMappings, contributor.bylineLargeImageUrl, imageWidth*3);
-        return (
-            <div css={[className, Styles]}>
-                <img css={ImageStyles} src={imgSrc} alt={contributor.webTitle}/>
-            </div>
-        );
+    if (!isSingleContributor(contributors)) {
+        return null;
     }
-    
-    return null;
 
+    return contributor.image.fmap<ReactElement | null>(image =>
+        <div css={[className, styles]}>
+            <img
+                css={imageStyles}
+                srcSet={image.srcset}
+                src={image.src}
+                alt={contributor.name}
+                sizes="6rem"
+            />
+        </div>
+    ).withDefault(null);
 }
 
 

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -17,16 +17,10 @@ import { partition } from 'types/result';
 import { getAdPlaceholderInserter } from 'ads';
 import { fromCapi, getFormat } from 'item';
 import { ElementKind } from 'bodyElement';
-import { sign } from 'image';
-import {
-    ElementType,
-    TagType,
-    ITag as Tag,
-    IBlock as Block,
-    IBlockElement as BlockElement
-} from 'mapiThriftModels';
+import { IBlock as Block } from 'mapiThriftModels';
 import { Design, Display } from 'format';
 import Interactive from 'components/interactive/article';
+
 
 // ----- Components ----- //
 
@@ -78,47 +72,6 @@ interface ElementWithResources {
     hydrationProps: {};
 }
 
-export interface ImageMappings {
-    [key: string]: string;
-}
-
-const mappingsWithUrl = (mappings: ImageMappings, url: string, salt: string): ImageMappings => {
-    const { pathname } = new URL(url);
-    return { ...mappings, [pathname]: sign(salt, pathname) }
-};
-
-const getContributorMappings = (tags: Tag[], salt: string): ImageMappings => tags
-    .filter(tag => tag.type === TagType.CONTRIBUTOR)
-    .reduce((mappings, { bylineLargeImageUrl }) =>
-        bylineLargeImageUrl
-            ? mappingsWithUrl(mappings, bylineLargeImageUrl, salt)
-            : mappings
-    , {});
-
-const bodyBlocks = (capi: Content): Block[] =>
-    capi.blocks?.body ?? [];
-
-const mainBlocks = (capi: Content): Block[] =>
-    capi.blocks?.main !== undefined ? [capi.blocks.main] : [];
-
-const getImageMappings = (imageSalt: string, capi: Content): ImageMappings => {
-    const blocks = [...bodyBlocks(capi), ...mainBlocks(capi)];
-
-    const blockMappings = blocks.flatMap(block => block.elements)
-        .filter((element: BlockElement) => element.type === ElementType.IMAGE)
-        .reduce((mappings, elem) => {
-            const asset = elem.assets.find(asset => asset.typeData?.isMaster);
-
-            if (asset !== undefined && asset.file !== undefined) {
-                return mappingsWithUrl(mappings, asset.file, imageSalt);
-            }
-
-            return mappings;
-        }, {});
-
-        return { ...blockMappings, ...getContributorMappings(capi.tags, imageSalt) }
-};
-
 const filterBlocks = (block: Block): Block => {
     const { createdBy, lastModifiedBy, ...blocks } = block;
     return blocks;
@@ -148,9 +101,11 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
 
     const insertAdPlaceholders = getAdPlaceholderInserter(capi.fields?.shouldHideAdverts ?? false);
 
-    const item = fromCapi(JSDOM.fragment.bind(null))(capi);
+    const item = fromCapi({
+        docParser: JSDOM.fragment.bind(null),
+        salt: imageSalt,
+    })(capi);
     const format = getFormat(item);
-    const imageMappings = getImageMappings(imageSalt, capi);
 
     const articleScript = getAssetLocation('article.js');
     const liveblogScript = getAssetLocation('liveblog.js');
@@ -170,11 +125,11 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
     if (item.design === Design.Comment) {
         const commentBody = partition(item.body).oks;
         const commentContent =
-            insertAdPlaceholders(renderAll(imageMappings)(format, commentBody));
+            insertAdPlaceholders(renderAll(format, commentBody));
 
         return { element: (
             <WithScript src={articleScript}>
-                <Opinion imageMappings={imageMappings} item={item}>
+                <Opinion item={item}>
                     {commentContent}
                 </Opinion>
             </WithScript>
@@ -184,18 +139,18 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
     if (item.design === Design.Live) {
         return { element: (
             <WithScript src={liveblogScript}>
-                <LiveblogArticle item={item} imageMappings={imageMappings} />
+                <LiveblogArticle item={item} />
             </WithScript>
-        ), resources: [liveblogScript], hydrationProps: { ...liveblogProps(capi), imageMappings } };
+        ), resources: [liveblogScript], hydrationProps: { ...liveblogProps(capi) } };
     }
 
     if (item.design === Design.Media) {
         const body = partition(item.body).oks.filter(elem => elem.kind === ElementKind.Image);
         const mediaContent =
-            insertAdPlaceholders(renderAll(imageMappings)(format, body));
+            insertAdPlaceholders(renderAll(format, body));
         return { element: (
                 <WithScript src={mediaScript}>
-                    <Media imageMappings={imageMappings} item={item}>
+                    <Media item={item}>
                         {mediaContent}
                     </Media>
                 </WithScript>
@@ -210,11 +165,11 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
         item.design === Design.Interactive
     ) {
         const body = partition(item.body).oks;
-        const content = insertAdPlaceholders(renderAll(imageMappings)(format, body));
+        const content = insertAdPlaceholders(renderAll(format, body));
 
         return { element: (
             <WithScript src={articleScript}>
-                <Standard imageMappings={imageMappings} item={item}>
+                <Standard item={item}>
                     {content}
                 </Standard>
             </WithScript>
@@ -223,10 +178,10 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
 
     if (item.design === Design.AdvertisementFeature) {
         const body = partition(item.body).oks;
-        const content = insertAdPlaceholders(renderAll(imageMappings)(format, body));
+        const content = insertAdPlaceholders(renderAll(format, body));
 
         return { element: (
-            <AdvertisementFeature imageMappings={imageMappings} item={item}>
+            <AdvertisementFeature item={item}>
                 {content}
             </AdvertisementFeature>
         ), resources: [], hydrationProps: {} };

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -14,7 +14,6 @@ import Tags from 'components/shared/tags';
 import { darkModeCss, articleWidthStyles } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { Standard, Review, getFormat, Item } from 'item';
-import { ImageMappings } from 'components/shared/page';
 import Metadata from 'components/metadata';
 import { getPillarStyles } from 'pillarStyles';
 import { Display } from '@guardian/types/Format';
@@ -73,12 +72,11 @@ const itemStyles = (item: Item): SerializedStyles => {
 // ----- Component ----- //
 
 interface Props {
-    imageMappings: ImageMappings;
     item: Standard | Review;
     children: ReactNode[];
 }
 
-const Standard = ({ imageMappings, item, children }: Props): JSX.Element => {
+const Standard = ({ item, children }: Props): JSX.Element => {
     // client side code won't render an Epic if there's an element with this id
     const epicContainer = item.shouldHideReaderRevenue
         ? <div id="epic-container"></div>
@@ -89,7 +87,6 @@ const Standard = ({ imageMappings, item, children }: Props): JSX.Element => {
             <header>
                 <HeaderImage
                     image={item.mainImage}
-                    imageMappings={imageMappings}
                     format={getFormat(item)}
                 />
                 <Series item={item} />
@@ -99,7 +96,7 @@ const Standard = ({ imageMappings, item, children }: Props): JSX.Element => {
                 </div>
                 <Keyline {...item} />
                 <section css={articleWidthStyles}>
-                    <Metadata imageMappings={imageMappings} item={item} />
+                    <Metadata item={item} />
                 </section>
             </header>
             <Body className={[articleWidthStyles, itemStyles(item)]}>

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -1,17 +1,41 @@
+// ----- Imports ----- //
+
+import { Option, fromNullable } from 'types/option';
+import { IContent as Content } from 'mapiThriftModels';
+import { articleContributors } from 'capi';
+import { srcsetWithWidths, src } from 'image';
+
+
 // ------ Types ----- //
 
 type Contributor = {
     id: string;
     apiUrl: string;
-    webTitle: string;
-    bylineLargeImageUrl?: string;
+    name: string;
+    image: Option<{
+        srcset: string;
+        src: string;
+    }>;
 }
 
 
 // ----- Functions ----- //
 
+const contributorSrcset = srcsetWithWidths([32, 64, 128, 192, 256]);
+
 const isSingleContributor = (cs: Contributor[]): boolean =>
     cs.length === 1
+
+const parseContributors = (salt: string, content: Content): Contributor[] =>
+    articleContributors(content).map(contributor => ({
+        id: contributor.id,
+        apiUrl: contributor.apiUrl,
+        name: contributor.webTitle,
+        image: fromNullable(contributor.bylineLargeImageUrl).fmap(url => ({
+            srcset: contributorSrcset(url, salt),
+            src: src(salt, url, 64),
+        })),
+    }));
 
 
 // ----- Exports ----- //
@@ -19,4 +43,5 @@ const isSingleContributor = (cs: Contributor[]): boolean =>
 export {
     Contributor,
     isSingleContributor,
+    parseContributors,
 }

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -23,7 +23,7 @@ const imageBlock: BlockElement = {
     type: ElementType.IMAGE,
     assets: [{
         type: AssetType.IMAGE,
-        file: 'url',
+        file: 'http://gu.com/url',
         typeData: {
             isMaster: true,
             width: 5,
@@ -35,6 +35,7 @@ const imageBlock: BlockElement = {
 
 const image: Image = {
     src: '',
+    srcset: '',
     alt: new None(),
     width: 0,
     height: 0,
@@ -49,13 +50,19 @@ const image: Image = {
 
 describe('image', () => {
     test('includes credit when displayCredit is true', () => {
-        const parsed = parseImage(JSDOM.fragment)(imageBlock);
+        const parsed = parseImage({
+            docParser: JSDOM.fragment,
+            salt: 'mockSalt',
+        })(imageBlock);
 
         expect(parsed.withDefault(image).credit.withDefault('')).toBe('Credit');
     });
 
     test('does not include credit when displayCredit is false', () => {
-        const parsed = parseImage(JSDOM.fragment)({
+        const parsed = parseImage({
+            docParser: JSDOM.fragment,
+            salt: 'mockSalt',
+        })({
             ...imageBlock,
             imageTypeData: {
                 ...imageData,

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -177,7 +177,7 @@ const articleContentWithImageWithoutFile = articleContentWith({
     }
 })
 
-const f = fromCapi(JSDOM.fragment);
+const f = fromCapi({ docParser: JSDOM.fragment, salt: 'mockSalt' });
 
 const getFirstBody = (item: Review | Standard) =>
     item.body[0].toOption().withDefault({ kind: ElementKind.Interactive, url: '' });

--- a/src/liveBlock.ts
+++ b/src/liveBlock.ts
@@ -2,7 +2,7 @@
 
 import { IBlock as Block } from 'mapiThriftModels/Block';
 import { Option } from 'types/option';
-import DocParser from 'types/docParser';
+import { Context } from 'types/parserContext';
 import { Body, parseElements } from 'bodyElement';
 import { maybeCapiDate } from 'capi';
 
@@ -21,18 +21,18 @@ type LiveBlock = {
 
 // ----- Functions ----- //
 
-const parse = (docParser: DocParser) => (block: Block): LiveBlock =>
+const parse = (context: Context) => (block: Block): LiveBlock =>
     ({
         id: block.id,
         isKeyEvent: block?.attributes?.keyEvent ?? false,
         title: block?.title ?? "",
         firstPublished: maybeCapiDate(block?.firstPublishedDate),
         lastModified: maybeCapiDate(block?.lastModifiedDate),
-        body: parseElements(docParser)(block.elements),
+        body: parseElements(context)(block.elements),
     })
 
-const parseLiveBlocks = (docParser: DocParser) => (blocks: Block[]): LiveBlock[] =>
-    blocks.map(parse(docParser));
+const parseLiveBlocks = (context: Context) => (blocks: Block[]): LiveBlock[] =>
+    blocks.map(parse(context));
 
 
 // ----- Exports ----- //

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -31,6 +31,7 @@ const imageElement = (): BodyElement =>
     ({
         kind: ElementKind.Image,
         src: 'https://gu.com/img.png',
+        srcset: '',
         alt: new Some("alt tag"),
         caption: new Some(JSDOM.fragment('this caption contains <em>html</em>')),
         nativeCaption: new Some('caption'),
@@ -109,13 +110,13 @@ const atomElement = (): BodyElement =>
     })
 
 const render = (element: BodyElement): ReactNode[] =>
-    renderAll({})(mockFormat, [element]);
+    renderAll(mockFormat, [element]);
 
 const renderWithoutStyles = (element: BodyElement): ReactNode[] =>
     renderAllWithoutStyles(mockFormat, [element]);
 
 const renderCaption = (element: BodyElement): ReactNode[] =>
-    renderAll({})(mockFormat, [element]);
+    renderAll(mockFormat, [element]);
 
 const renderTextElement = compose(render, textElement);
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -12,7 +12,6 @@ import { ElementKind, BodyElement } from 'bodyElement';
 import { Role, BodyImageProps } from 'image';
 import { body, headline, textSans } from '@guardian/src-foundations/typography';
 import { remSpace } from '@guardian/src-foundations';
-import { ImageMappings } from 'components/shared/page';
 import Audio from 'components/audio';
 import Video from 'components/video';
 import Paragraph from 'components/paragraph';
@@ -363,7 +362,7 @@ const imageComponentFromRole = (role: Role): FC<BodyImageProps> => {
     }
 }
 
-const render = (format: Format, imageMappings: ImageMappings, excludeStyles = false) =>
+const render = (format: Format, excludeStyles = false) =>
     (element: BodyElement, key: number): ReactNode => {
     switch (element.kind) {
 
@@ -382,7 +381,7 @@ const render = (format: Format, imageMappings: ImageMappings, excludeStyles = fa
                 ? h(FigCaption, { format, caption, credit })
                 : null;
 
-            return h(ImageComponent, { image: element, imageMappings }, figcaption);
+            return h(ImageComponent, { image: element }, figcaption);
         }
 
         case ElementKind.Pullquote:
@@ -431,12 +430,12 @@ const render = (format: Format, imageMappings: ImageMappings, excludeStyles = fa
     }
 };
 
-const renderAll = (imageMappings: ImageMappings) =>
-    (format: Format, elements: BodyElement[]): ReactNode[] =>
-        elements.map(render(format, imageMappings));
+const renderAll = (format: Format, elements: BodyElement[]): ReactNode[] =>
+    elements.map(render(format));
 
 const renderAllWithoutStyles = (format: Format, elements: BodyElement[]): ReactNode[] =>
-        elements.map(render(format, {}, true));
+    elements.map(render(format, true));
+
 
 // ----- Exports ----- //
 

--- a/src/types/parserContext.ts
+++ b/src/types/parserContext.ts
@@ -2,7 +2,15 @@
 
 type DocParser = (html: string) => DocumentFragment;
 
+type Context = {
+    docParser: DocParser;
+    salt: string;
+}
+
 
 // ----- Exports ----- //
 
-export default DocParser;
+export {
+    Context,
+    DocParser,
+};


### PR DESCRIPTION
## Why are you doing this?

This is the groundwork for some further changes coming in later PRs. I've split the work up in this way in an attempt not to change too much at once, as this results in very large PRs. This follows on in turn from some other work in #288, #303 and #322.

In brief, this PR:

- Paves the way for the upcoming liveblog API
- Enables some work to allow storybook stories with images
- Should allow us to drop `sig-ignores-params`, which is the source of some complex VCL in Fastly and a potential cause of cache-splitting

A big part of this PR is a conceptual shift in the way we handle image URLs. Currently we're passing the URLs CAPI provides us all the way through to the components, and letting them handle re-writing them into image resizer URLs. With these changes the _parser_ will now handle translating CAPI image URLs into image resizer URLs. The components will now take these formatted URLs and focus on building them into markup. This follows from the principle that the parsing step exists to translate data from the structure provided by CAPI into a structure that best fits our rendering code.

**Note:** In the interests of keeping this PR as small as possible (it's still not _that_ small) I've opted to temporarily break liveblog hydration rather than implement a big chunk of the new liveblog API to keep it working. This will be fixed when that work appears in a forthcoming PR.

FYI @oliverlloyd @gtrufitt @philmcmahon 

## Changes

- Parser now produces Image Resizer URLs
- Removed `ImageMappings`
- Used `Context` to wrap `DocParser` and `salt`
- Contributor module now handle parsing of `Contributor`s from CAPI
- Temporarily breaks liveblog hydration with mock salt
