### PR TITLE
add blockquote component with styles

### DIFF
--- a/src/components/blockquote.tsx
+++ b/src/components/blockquote.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import React, { FC, ReactNode } from 'react';
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import { Format } from '@guardian/types/Format';
 import { icons, darkModeCss } from 'styles';
 import { getPillarStyles } from 'pillarStyles';
@@ -16,7 +16,7 @@ interface Props {
     format: Format;
 }
 
-const styles = (format: Format) => css`
+const styles = (format: Format): SerializedStyles => css`
     font-style: italic;
     position: relative;
     margin: ${remSpace[4]} 0 ${remSpace[9]} 0;

--- a/src/components/blockquote.tsx
+++ b/src/components/blockquote.tsx
@@ -6,6 +6,7 @@ import { Format } from '@guardian/types/Format';
 import { icons, darkModeCss } from 'styles';
 import { getPillarStyles } from 'pillarStyles';
 import { neutral } from '@guardian/src-foundations/palette';
+import { remSpace } from '@guardian/src-foundations';
 
 
 // ----- Component ----- //
@@ -18,7 +19,7 @@ interface Props {
 const styles = (format: Format) => css`
     font-style: italic;
     position: relative;
-    margin: ${remSpace[4]} 0 ${remSpace[8]} 0;
+    margin: ${remSpace[4]} 0 ${remSpace[9]} 0;
     padding: 0 ${remSpace[6]};
 
     &::before {

--- a/src/components/blockquote.tsx
+++ b/src/components/blockquote.tsx
@@ -18,8 +18,8 @@ interface Props {
 const styles = (format: Format) => css`
     font-style: italic;
     position: relative;
-    margin: 1rem 0 2rem 0;
-    padding: 0 1.5rem;
+    margin: ${remSpace[4]} 0 ${remSpace[8]} 0;
+    padding: 0 ${remSpace[6]};
 
     &::before {
         ${icons}

--- a/src/components/blockquote.tsx
+++ b/src/components/blockquote.tsx
@@ -1,0 +1,49 @@
+// ----- Imports ----- //
+
+import React, { FC, ReactNode } from 'react';
+import { css } from '@emotion/core';
+import { Format } from '@guardian/types/Format';
+import { icons, darkModeCss } from 'styles';
+import { getPillarStyles } from 'pillarStyles';
+import { neutral } from '@guardian/src-foundations/palette';
+
+
+// ----- Component ----- //
+
+interface Props {
+    children?: ReactNode;
+    format: Format;
+}
+
+const styles = (format: Format) => css`
+    font-style: italic;
+    position: relative;
+    margin: 1rem 0 2rem 0;
+    padding: 0 1.5rem;
+
+    &::before {
+        ${icons}
+        font-style: normal;
+        font-size: 2.5rem;
+        content: '\\e11c';
+        color: ${getPillarStyles(format.pillar).kicker};
+    }
+
+    ${darkModeCss`
+        &::before {
+            color: ${neutral[86]};
+        }
+    `}
+`;
+
+
+
+const Blockquote: FC<Props> = ({ children, format }: Props) =>
+    <blockquote css={styles(format)}>
+        {children}
+    </blockquote>
+
+
+// ----- Exports ----- //
+
+export default Blockquote;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -22,6 +22,7 @@ import BodyImageHalfWidth from 'components/bodyImageHalfWidth';
 import Anchor from 'components/anchor';
 import InteractiveAtom from 'components/atoms/interactiveAtom';
 import { Design } from '@guardian/types/Format';
+import Blockquote from 'components/blockquote';
 
 // ----- Renderer ----- //
 
@@ -202,7 +203,7 @@ const textElement = (format: Format) => (node: Node, key: number): ReactNode => 
                 ? h(HorizontalRule, null, null)
                 : styledH('h2', { css: HeadingTwoStyles(format), key }, children );
         case 'BLOCKQUOTE':
-            return h('blockquote', { key }, children);
+            return h(Blockquote, { key, format }, children);
         case 'STRONG':
             return h('strong', { key }, children);
         case 'EM':


### PR DESCRIPTION
## Why are you doing this?

The current apps and dotcom have some specific blockquote styles to make them stand out. We can convert the icon to an SVG when the existing ticket gets picked up.

## Screenshots

| Before | After light mode | After dark mode |
| --- | --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/82461613-8ab20480-9ab2-11ea-8253-86c142a2c283.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82461662-97cef380-9ab2-11ea-911c-0d4af082b470.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82461707-a3221f00-9ab2-11ea-9b00-abb398f6c2b2.png" width="300px" /> |

