### PR TITLE
use object fit to keep aspect ratio of images

### DIFF
--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -26,7 +26,8 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     background: ${neutral[97]};
     display: block;
     width: 100%;
- 
+    object-fit: cover;
+
     ${from.phablet} {
         height: calc(620px * ${height / width});
     }


### PR DESCRIPTION
Recommended by lighthouse best practices audit.
Would be good to try out the latest audits in version 6 https://web.dev/lighthouse-whats-new-6.0/.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/82471463-a3c0b280-9abe-11ea-9607-6be801bc9efd.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82471471-a6230c80-9abe-11ea-9d13-b0bdff5363e8.png" width="300px" /> |
