### PR TITLE
Liveblog Updates Endpoint

### DIFF
--- a/src/components/atoms/interactiveAtom.tsx
+++ b/src/components/atoms/interactiveAtom.tsx
@@ -3,12 +3,13 @@ import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Format } from '@guardian/types/Format';
 import { getPillarStyles, PillarStyles } from 'pillarStyles';
+import { Option } from 'types/option';
 
 
 export interface InteractiveAtomProps {
     html: string;
     styles: string;
-    js?: string;
+    js: Option<string>;
     format: Format;
 }
 
@@ -26,8 +27,11 @@ const InteractiveAtom: FC<InteractiveAtomProps> = (props: InteractiveAtomProps):
     const { html, styles, js, format } = props;
     const pillarStyles = getPillarStyles(format.pillar);
     const style = h('style', { dangerouslySetInnerHTML: { __html: styles } });
-    const script = js ? h('script', { dangerouslySetInnerHTML: { __html: js } }) : null;
+    const script = js.fmap<ReactElement | null>(jsString =>
+        h('script', { dangerouslySetInnerHTML: { __html: jsString } }),
+    ).withDefault(null);
     const markup = styledH('figure', { css: InteractiveAtomStyles(pillarStyles), dangerouslySetInnerHTML: { __html: html } });
+
     return <>
         {style}
         {script}

--- a/src/date.ts
+++ b/src/date.ts
@@ -91,4 +91,5 @@ const format = (date: Date): string =>
 export {
     makeRelativeDate,
     format as formatDate,
+    isValidDate,
 }

--- a/src/item.ts
+++ b/src/item.ts
@@ -13,7 +13,7 @@ import {
 } from 'mapiThriftModels';
 import { Format, Pillar, Design, Display } from 'format';
 import { Image as ImageData, parseImage } from 'image';
-import { LiveBlock, parseLiveBlocks } from 'liveBlock';
+import { LiveBlock, parseMany as parseLiveBlocks } from 'liveBlock';
 import { Body, parseElements } from 'bodyElement';
 import { Context } from 'types/parserContext';
 import { Contributor, parseContributors } from 'contributor';
@@ -195,7 +195,7 @@ const fromCapiLiveBlog = (context: Context) => (content: Content): Liveblog => {
 
     return {
         design: Design.Live,
-        blocks: parseLiveBlocks(context)(body),
+        blocks: parseLiveBlocks(body)(context),
         totalBodyBlocks: content.blocks?.totalBodyBlocks ?? body.length,
         ...itemFields(context, content),
     };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,10 +4,16 @@ const compose = <A, B, C>(f: (_b: B) => C, g: (_a: A) => B) => (a: A): C => f(g(
 
 const identity = <A>(a: A): A => a;
 
+// The nodeType for ELEMENT_NODE has the value 1.
+function isElement(node: Node): node is Element {
+    return node.nodeType === 1;
+}
+
 
 // ----- Exports ----- //
 
 export {
     compose,
     identity,
+    isElement,
 };

--- a/src/liveBlock.ts
+++ b/src/liveBlock.ts
@@ -71,9 +71,9 @@ const filterBlocks = (filterFunc: (block: Block) => boolean) => (content: Conten
 
 const blocksSince =
     (getDate: (block: Block) => CapiDateTime | undefined) =>
-    (since: number): (content: Content) => (context: Context) => LiveBlock[] =>
+    (since: Date): (content: Content) => (context: Context) => LiveBlock[] =>
 {
-    const isRecent = compose(moreRecentThan(new Date(since)), getDate);
+    const isRecent = compose(moreRecentThan(since), getDate);
 
     return compose(parseMany, filterBlocks(isRecent));
 }

--- a/src/liveBlock.ts
+++ b/src/liveBlock.ts
@@ -1,10 +1,19 @@
 // ----- Imports ----- //
 
 import { IBlock as Block } from 'mapiThriftModels/Block';
-import { Option } from 'types/option';
+import { ICapiDateTime as CapiDateTime } from 'mapiThriftModels/CapiDateTime';
+import { IContent as Content } from 'mapiThriftModels/Content';
+import { Option, toSerialisable as optionToSerialisable } from 'types/option';
 import { Context } from 'types/parserContext';
-import { Body, parseElements } from 'bodyElement';
+import JsonSerialisable from 'types/jsonSerialisable';
+import {
+    Body,
+    parseElements,
+    toSerialisable as bodyElementToSerialisable,
+} from 'bodyElement';
 import { maybeCapiDate } from 'capi';
+import { partition } from 'types/result';
+import { compose } from 'lib';
 
 
 // ----- Types ----- //
@@ -21,6 +30,26 @@ type LiveBlock = {
 
 // ----- Functions ----- //
 
+const serialiseLiveBlock = ({
+    id,
+    isKeyEvent,
+    title,
+    firstPublished,
+    lastModified,
+    body,
+}: LiveBlock): JsonSerialisable =>
+    ({
+        id,
+        isKeyEvent,
+        title,
+        firstPublished: optionToSerialisable(firstPublished),
+        lastModified: optionToSerialisable(lastModified),
+        body: partition(body).oks.map(bodyElementToSerialisable),
+    });
+
+const toSerialisable = (blocks: LiveBlock[]): JsonSerialisable =>
+    blocks.map(serialiseLiveBlock);
+
 const parse = (context: Context) => (block: Block): LiveBlock =>
     ({
         id: block.id,
@@ -31,13 +60,38 @@ const parse = (context: Context) => (block: Block): LiveBlock =>
         body: parseElements(context)(block.elements),
     })
 
-const parseLiveBlocks = (context: Context) => (blocks: Block[]): LiveBlock[] =>
-    blocks.map(parse(context));
+const parseMany = (blocks: Block[]): (context: Context) => LiveBlock[] =>
+    (context: Context): LiveBlock[] => blocks.map(parse(context));
+
+const moreRecentThan = (since: Date) => (capiDate: CapiDateTime | undefined): boolean =>
+    maybeCapiDate(capiDate).fmap(date => date > since).withDefault(false);
+
+const filterBlocks = (filterFunc: (block: Block) => boolean) => (content: Content): Block[] =>
+    content.blocks?.body?.filter(filterFunc) ?? [];
+
+const blocksSince =
+    (getDate: (block: Block) => CapiDateTime | undefined) =>
+    (since: number): (content: Content) => (context: Context) => LiveBlock[] =>
+{
+    const isRecent = compose(moreRecentThan(new Date(since)), getDate);
+
+    return compose(parseMany, filterBlocks(isRecent));
+}
+
+const newBlocksSince = blocksSince(block => block.firstPublishedDate);
+const updatedBlocksSince = blocksSince(block => block.lastModifiedDate);
+
+const recentBlocks = (num: number) => (content: Content): (context: Context) => LiveBlock[] =>
+    parseMany((content.blocks?.body ?? []).slice(0, num));
 
 
 // ----- Exports ----- //
 
 export {
     LiveBlock,
-    parseLiveBlocks,
+    parseMany,
+    newBlocksSince,
+    updatedBlocksSince,
+    toSerialisable,
+    recentBlocks,
 };

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -107,7 +107,7 @@ const atomElement = (): BodyElement =>
         kind: ElementKind.InteractiveAtom,
         css: "main { background: yellow; }",
         html: "<main>Some content</main>",
-        js: "console.log('init')"
+        js: new Some("console.log('init')"),
     })
 
 const render = (element: BodyElement): ReactNode[] =>

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -23,13 +23,10 @@ import Anchor from 'components/anchor';
 import InteractiveAtom from 'components/atoms/interactiveAtom';
 import { Design } from '@guardian/types/Format';
 import Blockquote from 'components/blockquote';
+import { isElement } from 'lib';
+
 
 // ----- Renderer ----- //
-
-// The nodeType for ELEMENT_NODE has the value 1.
-function isElement(node: Node): node is Element {
-    return node.nodeType === 1;
-}
 
 const getAttrs = (node: Node): Option<NamedNodeMap> =>
     isElement(node) ? new Some(node.attributes) : new None();

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -459,7 +459,7 @@ const render = (format: Format, excludeStyles = false) =>
                         <body>
                             ${html}
                             <script>
-                                ${js}
+                                ${js.withDefault('')}
                                 function resize() {
                                     window.frameElement.height = document.body.offsetHeight;
                                 }

--- a/src/server/paramParser.ts
+++ b/src/server/paramParser.ts
@@ -1,3 +1,8 @@
+// ----- Imports ----- //
+
+import { isValidDate } from 'date';
+
+
 // ----- Types ----- //
 
 enum Param {
@@ -21,12 +26,12 @@ type QueryParam<A> = {
 // Disabled because the point of this function is to convert the `any`
 // provided by Express to a stricter type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function parseNumber(param: any): QueryParam<number> {
+function parseDate(param: any): QueryParam<Date> {
     if (param === undefined) {
         return { kind: Param.None };
     }
-    const num = Number(param);
-    return isNaN(num) ? { kind: Param.Valid, value: num } : { kind: Param.Invalid };
+    const date = new Date(param);
+    return isValidDate(date) ? { kind: Param.Valid, value: date } : { kind: Param.Invalid };
 }
 
 
@@ -34,5 +39,5 @@ function parseNumber(param: any): QueryParam<number> {
 
 export {
     Param,
-    parseNumber,
+    parseDate,
 };

--- a/src/server/paramParser.ts
+++ b/src/server/paramParser.ts
@@ -1,0 +1,38 @@
+// ----- Types ----- //
+
+enum Param {
+    None,
+    Valid,
+    Invalid,
+}
+
+type QueryParam<A> = {
+    kind: Param.None;
+} | {
+    kind: Param.Invalid;
+} | {
+    kind: Param.Valid;
+    value: A;
+}
+
+
+// ----- Functions ----- //
+
+// Disabled because the point of this function is to convert the `any`
+// provided by Express to a stricter type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseNumber(param: any): QueryParam<number> {
+    if (param === undefined) {
+        return { kind: Param.None };
+    }
+    const num = Number(param);
+    return isNaN(num) ? { kind: Param.Valid, value: num } : { kind: Param.Invalid };
+}
+
+
+// ----- Exports ----- //
+
+export {
+    Param,
+    parseNumber,
+};

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -26,7 +26,7 @@ import {
     newBlocksSince,
     updatedBlocksSince,
     recentBlocks,
-    toSerialisable as serialiseLiveBlock,
+    toSerialisable as serialiseLiveBlocks,
 } from 'liveBlock';
 import { JSDOM } from 'jsdom';
 import JsonSerialisable from 'types/jsonSerialisable';
@@ -149,12 +149,12 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
 }
 
 const liveBlockUpdates = (since: number, content: Content, context: Context): LiveUpdates => ({
-    newBlocks: serialiseLiveBlock(newBlocksSince(since)(content)(context)),
-    updatedBlocks: serialiseLiveBlock(updatedBlocksSince(since)(content)(context)),
+    newBlocks: serialiseLiveBlocks(newBlocksSince(since)(content)(context)),
+    updatedBlocks: serialiseLiveBlocks(updatedBlocksSince(since)(content)(context)),
 });
 
 const recentLiveBlocks = (content: Content, context: Context): LiveUpdates => ({
-    newBlocks: serialiseLiveBlock(recentBlocks(10)(content)(context)),
+    newBlocks: serialiseLiveBlocks(recentBlocks(10)(content)(context)),
     updatedBlocks: [],
 });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -30,7 +30,7 @@ import {
 } from 'liveBlock';
 import { JSDOM } from 'jsdom';
 import JsonSerialisable from 'types/jsonSerialisable';
-import { parseNumber, Param } from 'server/paramParser';
+import { parseDate, Param } from 'server/paramParser';
 import { Context } from 'types/parserContext';
 
 
@@ -148,7 +148,7 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
     }
 }
 
-const liveBlockUpdates = (since: number, content: Content, context: Context): LiveUpdates => ({
+const liveBlockUpdates = (since: Date, content: Content, context: Context): LiveUpdates => ({
     newBlocks: serialiseLiveBlocks(newBlocksSince(since)(content)(context)),
     updatedBlocks: serialiseLiveBlocks(updatedBlocksSince(since)(content)(context)),
 });
@@ -162,7 +162,7 @@ async function liveBlocks(req: Request, res: ExpressResponse): Promise<void> {
     try {
         const articleId = req.params.articleId || defaultId;
         const imageSalt = await getConfigValue<string>('apis.img.salt');
-        const since = parseNumber(req.query.since);
+        const since = parseDate(req.query.since);
 
         if (since.kind === Param.Invalid) {
             logger.warn(`I couldn't get liveblog updates for: ${articleId}, I didn't understand this timestamp: ${since}`);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -21,6 +21,25 @@ import { response } from './liveblogResponse';
 import { mapiDecoder, capiDecoder, errorDecoder } from 'server/decoders';
 import { Result, Ok, Err } from 'types/result';
 import { IContent as Content } from 'mapiThriftModels/Content';
+import { ContentType } from 'mapiThriftModels/ContentType';
+import {
+    newBlocksSince,
+    updatedBlocksSince,
+    recentBlocks,
+    toSerialisable as serialiseLiveBlock,
+} from 'liveBlock';
+import { JSDOM } from 'jsdom';
+import JsonSerialisable from 'types/jsonSerialisable';
+import { parseNumber, Param } from 'server/paramParser';
+import { Context } from 'types/parserContext';
+
+
+// ----- Types ----- //
+
+interface LiveUpdates {
+    newBlocks: JsonSerialisable;
+    updatedBlocks: JsonSerialisable;
+}
 
 
 // ----- Setup ----- //
@@ -29,6 +48,7 @@ const getAssetLocation: (assetName: string) => string = getMappedAssetLocation()
 const defaultId =
     'cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked';
 const port = 3040;
+const docParser = JSDOM.fragment.bind(null);
 
 
 // ----- Functions ----- //
@@ -128,6 +148,50 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
     }
 }
 
+const liveBlockUpdates = (since: number, content: Content, context: Context): LiveUpdates => ({
+    newBlocks: serialiseLiveBlock(newBlocksSince(since)(content)(context)),
+    updatedBlocks: serialiseLiveBlock(updatedBlocksSince(since)(content)(context)),
+});
+
+const recentLiveBlocks = (content: Content, context: Context): LiveUpdates => ({
+    newBlocks: serialiseLiveBlock(recentBlocks(10)(content)(context)),
+    updatedBlocks: [],
+});
+
+async function liveBlocks(req: Request, res: ExpressResponse): Promise<void> {
+    try {
+        const articleId = req.params.articleId || defaultId;
+        const imageSalt = await getConfigValue<string>('apis.img.salt');
+        const since = parseNumber(req.query.since);
+
+        if (since.kind === Param.Invalid) {
+            logger.warn(`I couldn't get liveblog updates for: ${articleId}, I didn't understand this timestamp: ${since}`);
+            return res.sendStatus(400).end();
+        }
+
+        const capiContent = await askCapiFor(articleId);
+
+        capiContent.either(
+            errorStatus => { res.sendStatus(errorStatus) },
+            content => {
+                const context = { salt: imageSalt, docParser };
+
+                if (content.type !== ContentType.LIVEBLOG) {
+                    logger.warn(`I was asked to provide updates on something that wasn't a liveblog: ${articleId}`);
+                    res.sendStatus(400);
+                } else if (since.kind === Param.None) {
+                    res.status(200).json(recentLiveBlocks(content, context));
+                } else {
+                    res.status(200).json(liveBlockUpdates(since.value, content, context));
+                }
+            },
+        );
+    } catch (e) {
+        logger.error(`This error occurred`, e);
+        res.sendStatus(500);
+    }
+}
+
 
 // ----- App ----- //
 
@@ -143,6 +207,8 @@ app.use(bodyParser.raw({ limit: '50mb' }));
 app.use('/assets', express.static(path.resolve(__dirname, '../assets')));
 app.use('/assets', express.static(path.resolve(__dirname, '../dist/assets')));
 app.use(compression());
+
+app.get('/:articleId(*)/live-blocks', liveBlocks);
 
 app.all('*', (request, response, next) => {
     const start = Date.now();

--- a/src/types/jsonSerialisable.ts
+++ b/src/types/jsonSerialisable.ts
@@ -1,0 +1,17 @@
+// ----- Type ----- //
+
+type JsonSerialisable
+    = string
+    | boolean
+    | number
+    | null
+    | undefined
+    | Date
+    | JsonSerialisable[]
+    | { [k: string]: JsonSerialisable }
+    ;
+
+
+// ----- Exports ----- //
+
+export default JsonSerialisable;

--- a/src/types/option.ts
+++ b/src/types/option.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { Monad } from './monad';
+import { identity } from 'lib';
 
 
 // ----- Classes ----- //
@@ -108,6 +109,15 @@ type Option<A> = Some<A> | None<A>;
 const fromNullable = <A>(a: A | null | undefined): Option<A> =>
     a === null || a === undefined ? new None() : new Some(a);
 
+// ----- Serialisation ----- //
+
+/**
+ * Transforms Option into a type that JSON.stringify understands
+ * @param opt The option to be made serialisable
+ */
+const toSerialisable = <A>(opt: Option<A>): A | null =>
+    opt.fmap<A | null>(identity).withDefault(null);
+
 
 // ----- Exports ----- //
 
@@ -116,4 +126,5 @@ export {
     Some,
     None,
     fromNullable,
+    toSerialisable,
 };


### PR DESCRIPTION
## Why are you doing this?

This adds an endpoint for retrieving liveblog updates, at `/<articleId>/live-blocks`, with a JSON response of the form:

```ts
type LiveUpdates = {
    newBlocks: LiveBlock[];
    updatedBlocks: LiveBlock[];
}
```

Currently the endpoint will only work for `GET` requests in local development; I haven't added a `POST` equivalent for MAPI to hit yet. The client also hasn't been updated to use this endpoint. Both of these changes will come in later PRs.

FYI @oliverlloyd @gtrufitt 

## Changes

- Introduced `JsonSerialisable` type
- Added converter to make `BodyElement` `JsonSerialisable`
- Migrated `isElement` to `lib` for reuse
- Added converter to make `LiveBlock` `JsonSerialisable`
- Added functions to `liveBlock` to retrieve recent updates
- Made JS in `InteractiveAtom` an `Option`
- Added module for parsing query params sent to server
- Added server endpoint for new and updated liveblog blocks
- Added converter to make `Option` `JsonSerialisable`
