### PR TITLE
style tweaks for immersive articles

### DIFF
--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -81,7 +81,9 @@ const captionElement = (format: Format) => (node: Node, key: number): ReactNode 
     const children = Array.from(node.childNodes).map(captionElement(format));
     switch (node.nodeName) {
         case 'STRONG':
-            return <h2 css={captionHeadingStyles} key={key}>{children}</h2>;
+            return (format.design === Design.Media)
+                ? <h2 css={captionHeadingStyles} key={key}>{children}</h2>
+                : <>{children}</>
         case 'BR':
             return null;
         case 'EM':

--- a/src/components/headerImage.tsx
+++ b/src/components/headerImage.tsx
@@ -74,7 +74,7 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
 
 const immersiveImgStyles = css`
     display: block;
-    height: 100vh;
+    height: 80vh;
     object-fit: cover;
     width: 100vw;
 `;

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -34,7 +34,7 @@ const immersiveStyles = css`
     ${headline.medium({ fontWeight: 'bold' })}
     font-weight: 700;
     padding: ${remSpace[1]} ${remSpace[2]} ${remSpace[6]} ${remSpace[2]};
-    margin: calc(100vh - 5rem) 0 0;
+    margin: calc(80vh - 5rem) 0 0;
     position: relative;
     display: inline-block;
 
@@ -44,12 +44,13 @@ const immersiveStyles = css`
 
     ${from.desktop} {
         ${headline.xlarge({ fontWeight: 'bold' })}
-        margin-top: calc(100vh - 7rem);
+        margin-top: calc(80vh - 7rem);
     }
 
     ${from.wide} {
         width: 100%;
         margin-left: calc(((100% - ${wideContentWidth}px) / 2) - ${remSpace[2]});
+        padding-left: ${remSpace[2]};
 
         span {
             display: block;

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -37,6 +37,8 @@ const immersiveStyles = css`
     margin: calc(80vh - 5rem) 0 0;
     position: relative;
     display: inline-block;
+    min-height: 112px;
+    box-sizing: border-box;
 
     ${between.phablet.and.wide} {
         width: ${wideContentWidth}px;

--- a/src/components/series.tsx
+++ b/src/components/series.tsx
@@ -25,11 +25,11 @@ const immersiveStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     position: absolute;
     left: 0;
     transform: translateY(-100%);
-    margin-top: calc(100vh - 5rem);
+    margin-top: calc(80vh - 5rem);
     display: inline-block;
 
     ${from.desktop} {
-        margin-top: calc(100vh - 7rem);
+        margin-top: calc(80vh - 7rem);
     }
 
     ${from.wide} {

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -54,7 +54,7 @@ const thinHeadline = css`
 
 const immersive: SerializedStyles = css`
     ${styles}
-    ${headline.xsmall({ fontWeight: 'light' })}
+    ${headline.xxsmall({ fontWeight: 'light' })}
     margin-top: ${remSpace[3]};
 `;
 
@@ -110,7 +110,7 @@ function content(standfirst: DocumentFragment, item: Item): ReactNode {
             <>
                 {rendered}
                 <address>
-                    <p>By {renderText(byline, format)}</p>
+                    <p>By {renderStandfirstText(byline, format)}</p>
                 </address>
             </>
         ).withDefault(rendered);

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -54,7 +54,7 @@ const thinHeadline = css`
 
 const immersive: SerializedStyles = css`
     ${styles}
-    ${headline.xxsmall({ fontWeight: 'light' })}
+    ${headline.xsmall({ fontWeight: 'light' })}
     margin-top: ${remSpace[3]};
 `;
 

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -7,7 +7,7 @@ import { background, neutral, text } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 
 import { Item, getFormat } from 'item';
-import { renderText, renderStandfirstText } from 'renderer';
+import { renderStandfirstText } from 'renderer';
 import { darkModeCss as darkMode } from 'styles';
 import { Display, Design } from 'format';
 

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -65,6 +65,8 @@ const textHeadlineInverse = (_: Format): Colour =>
 const backgroundHeadlinePrimary = (format: Format): Colour => {
     if (format.display === Display.Immersive) {
         return neutral[7];
+    } else if (format.pillar === Pillar.Opinion) {
+        return opinion[800];
     }
 
     return coreBackground.primary;


### PR DESCRIPTION
## Changes

- Opinion colour for Opinion headline
- Only use heading caption styles for media articles
- Immersive headline left padding on wide breakpoint
- Reduce height of header image so that the bottom navbar doesn't block the top of the headline
- Reduce immersive standfirst font size slightly and use `renderStandfirstText`
- Add min height to immersive headlines to handle short headlines

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/82557506-c3f67d00-9b63-11ea-9416-5360c948ca6e.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82557580-e1c3e200-9b63-11ea-982e-4bf9f5c53182.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/82557598-eab4b380-9b63-11ea-8906-d6d9b5c5b1df.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82557650-028c3780-9b64-11ea-997f-3e636fc2a739.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/82557706-23548d00-9b64-11ea-922f-6dc2114ba580.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82557731-2fd8e580-9b64-11ea-8687-78a0343f00a5.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/82557745-39624d80-9b64-11ea-9e4b-887c6469d505.PNG" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82557899-79c1cb80-9b64-11ea-8e3c-ced32212219b.PNG" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/82557993-ae358780-9b64-11ea-92ff-c1cc5741d83b.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82558010-b8578600-9b64-11ea-9367-7f0d26ea16e5.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/82899726-5d9e9f80-9f53-11ea-9852-5d5fa010eab7.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11618797/82899760-68f1cb00-9f53-11ea-97e4-2bf54b64a732.png" width="300" /> |

