### PR TITLE
Remove Redundant Interface Field

### DIFF
--- a/src/item.ts
+++ b/src/item.ts
@@ -62,7 +62,6 @@ interface Interactive extends Fields {
 interface Standard extends Fields {
     design: Exclude<Design, Design.Live | Design.Review | Design.Comment>;
     body: Body;
-    shouldHideReaderRevenue: boolean;
 }
 
 type Item


### PR DESCRIPTION
## Why are you doing this?

This interface extends the `Fields` interface above, which already includes the `shouldHideReaderRevenue` property.

## Changes

- Removed duplicate `shouldHideReaderRevenue` field
