### PR TITLE
wrap related content in anchor

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -298,23 +298,17 @@ const richLinkWidth = '8.75rem';
 const richLinkStyles = css`
     background: ${neutral[97]};
     padding: ${basePx(1)};
+    text-decoration: none;
+    border-bottom: none;
+    color: ${neutral[7]};
 
     h1 {
         margin: ${basePx(0, 0, 2, 0)};
-        font-size: 1rem;
-    }
-
-    p {
-        margin: ${basePx(1, 0)};
+        font-size: ${remSpace[4]};
     }
 
     span {
         display: none;
-    }
-
-    a {
-        text-decoration: none;
-        border-bottom: none;
     }
 
     float: left;
@@ -329,18 +323,18 @@ const richLinkStyles = css`
     ${darkModeCss`
         background-color: ${neutral[20]};
         color: ${neutral[60]};
-        a {
+
+        h1 {
             color: ${neutral[60]};
-            border-bottom: 0.0625rem solid ${neutral[60]};
+            border-bottom: none;
         }
     `}
 `;
 
-const RichLink = (props: { url: string; linkText: string; format: Format }): ReactElement =>
-    styledH('aside', { css: richLinkStyles },
-        h('h1', null, props.linkText),
-        h(Anchor, { href: props.url, format: props.format }, 'Read more'),
-    );
+const RichLink = (props: { url: string; linkText: string; }): ReactElement =>
+    styledH('a', { href: props.url, css: richLinkStyles },
+        styledH('aside', null, [h('h1', null, props.linkText), 'Read more'])
+    )
 
 const Interactive = (props: { url: string; title?: string }): ReactElement => {
     const styles = css`
@@ -401,7 +395,7 @@ const render = (format: Format, excludeStyles = false) =>
         case ElementKind.RichLink: {
             const { url, linkText } = element;
 
-            return h(RichLink, { url, linkText, format, key });
+            return h(RichLink, { url, linkText, key });
         }
 
         case ElementKind.Interactive:

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -331,10 +331,10 @@ const richLinkStyles = css`
     `}
 `;
 
-const RichLink = (props: { url: string; linkText: string; }): ReactElement =>
+const RichLink = (props: { url: string; linkText: string }): ReactElement =>
     styledH('a', { href: props.url, css: richLinkStyles },
         styledH('aside', null, [h('h1', null, props.linkText), 'Read more'])
-    )
+    );
 
 const Interactive = (props: { url: string; title?: string }): ReactElement => {
     const styles = css`

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -313,17 +313,16 @@ const richLinkWidth = '8.75rem';
 const richLinkStyles = css`
     background: ${neutral[97]};
     padding: ${basePx(1)};
-    text-decoration: none;
-    border-bottom: none;
-    color: ${neutral[7]};
 
-    h1 {
-        margin: ${basePx(0, 0, 2, 0)};
-        font-size: ${remSpace[4]};
-    }
+    a {
+        display:inline-block;
+        text-decoration: none;
+        color: ${neutral[7]};
 
-    span {
-        display: none;
+        h1 {
+            margin: ${basePx(0, 0, 2, 0)};
+            ${body.medium({ fontWeight: 'bold' })}
+        }
     }
 
     float: left;
@@ -339,16 +338,15 @@ const richLinkStyles = css`
         background-color: ${neutral[20]};
         color: ${neutral[60]};
 
-        h1 {
+        a, h1 {
             color: ${neutral[60]};
-            border-bottom: none;
         }
     `}
 `;
 
 const RichLink = (props: { url: string; linkText: string }): ReactElement =>
-    styledH('a', { href: props.url, css: richLinkStyles },
-        styledH('aside', null, [h('h1', null, props.linkText), 'Read more'])
+    styledH('aside', { css: richLinkStyles },
+        styledH('a', { href: props.url }, [h('h1', null, props.linkText), 'Read more'])
     );
 
 const Interactive = (props: { url: string; title?: string }): ReactElement => {


### PR DESCRIPTION
- Makes whole grey box linkable
- Removes kicker colour on link (closer to current apps) as the related content may be a different pillar to the current article @benwuersching

<img width="169" alt="Screen Shot 2020-05-26 at 11 53 54" src="https://user-images.githubusercontent.com/11618797/82892722-e31c5280-9f47-11ea-887c-88d09cf0c727.png">

