### PR TITLE
add cite to blockquote

### DIFF
--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -54,6 +54,14 @@ const pullquoteElement = (): BodyElement =>
         attribution: new None()
     })
 
+
+const pullquoteWithAttributionElement = (): BodyElement =>
+    ({
+        kind: ElementKind.Pullquote,
+        quote: "quote",
+        attribution: new Some('attribution')
+    })
+
 const richLinkElement = (): BodyElement =>
     ({
         kind: ElementKind.RichLink,
@@ -190,6 +198,12 @@ describe('Renders different types of elements', () => {
         const nodes = render(pullquoteElement())
         const pullquote = shallow(nodes.flat()[0]);
         expect(pullquote.html()).toContain('<blockquote><p>quote</p></blockquote>');
+    })
+
+    test('ElementKind.Pullquote with attribution', () => {
+        const nodes = render(pullquoteWithAttributionElement())
+        const pullquote = shallow(nodes.flat()[0]);
+        expect(pullquote.html()).toContain('<blockquote><p>quote</p><cite>attribution</cite></blockquote>');
     })
 
     test('ElementKind.RichLink', () => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -257,7 +257,7 @@ const pullquoteStyles = (colour: string): SerializedStyles => css`
     }
 
     p {
-        margin: 1em 0;
+        margin: ${remSpace[4]} 0 ${remSpace[2]} 0;
 
         &::before {
             ${icons}
@@ -283,15 +283,19 @@ const pullquoteStyles = (colour: string): SerializedStyles => css`
 type PullquoteProps = {
     quote: string;
     format: Format;
+    attribution: Option<string>;
 };
 
-const Pullquote: FC<PullquoteProps> = ({ quote, format }: PullquoteProps) =>
-    styledH('aside',
+const Pullquote: FC<PullquoteProps> = ({ quote, attribution, format }: PullquoteProps) => {
+    const children = attribution
+        .fmap(attribution => ([h('p', null, quote), h('cite', null, attribution)]))
+        .withDefault([h('p', null, quote)])
+
+    return styledH('aside',
         { css: pullquoteStyles(getPillarStyles(format.pillar).kicker) },
-        h('blockquote', null,
-            h('p', null, quote)
-        ),
+        h('blockquote', null, children)
     );
+}
 
 const richLinkWidth = '8.75rem';
 
@@ -395,8 +399,10 @@ const render = (format: Format, excludeStyles = false) =>
             return h(ImageComponent, { image: element }, figcaption);
         }
 
-        case ElementKind.Pullquote:
-            return h(Pullquote, { quote: element.quote, format, key });
+        case ElementKind.Pullquote: {
+            const { quote, attribution } = element;
+            return h(Pullquote, { quote, attribution, format, key });
+        }
 
         case ElementKind.RichLink: {
             const { url, linkText } = element;


### PR DESCRIPTION
## Changes

- We were missing the attribution on blockquotes

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/82903399-cc322c00-9f58-11ea-8ab3-ccc31ef1464d.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82903421-d48a6700-9f58-11ea-8412-4576b39ba095.png" width="300px" /> |
