### PR TITLE
add white background and padding to interactive atoms and embeds in dark mode

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -432,7 +432,13 @@ const render = (format: Format, excludeStyles = false) =>
                 },
             };
 
-            const figureCss = css`margin ${remSpace[4]} 0`;
+            const figureCss = css`
+                margin ${remSpace[4]} 0;
+                ${darkModeCss`
+                    background: white;
+                    padding: ${remSpace[2]};
+                `}
+            `;
             const captionStyles = css`
                 ${textSans.xsmall()}
                 color: ${textColour.supporting};
@@ -469,6 +475,10 @@ const render = (format: Format, excludeStyles = false) =>
                             <style>
                                 ${pageFonts}
                                 ${styles}
+                                body {
+                                    background: white !important;
+                                    padding: ${remSpace[2]} !important;
+                                }
                             </style>
                         </head>
                         <body>


### PR DESCRIPTION
This is the current behaviour in dark mode apps. There must be some JavaScript setting inline padding styles for some interactive atoms, so I've needed to use `!important` there.

## Changes

- Adds a white background to interactive atoms on standard articles (not type: Interactive) in dark mode
- Adds white background to embeds in dark mode
- adds .5rem padding to these elements in dark mode

## Screenshots

| Embed | Interactive atom on standard article |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/82997295-19b4a480-9ffe-11ea-90b5-3b38228511ad.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/82997322-20431c00-9ffe-11ea-83b4-97fbd782e440.png" width="300px" /> |

Dark mode is now supported in both Android and iOS live apps. This fallback ensures embeds and interactive atoms are readable, but it would be nicer if they had dark mode styles to blend into the page better.

The article pages in apps-rendering are currently not used in production but they should be fairly soon. I would be interested in hearing whether people are ok with these fallbacks or if we can better support this content in apps-rendering (the new mobile apps article templates) 

@pixelsquid @tinius @seanclarkeguardian @superfrank @mchv @JamieB-gu 
