### PR TITLE
Live Blocks On Client

### DIFF
--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -134,6 +134,9 @@ function toSerialisable(elem: BodyElement): JsonSerialisable {
     }
 }
 
+// Disabled because the point of this function is to convert the `any`
+// provided by JSON.parse to a stricter type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fromSerialisable = (docParser: DocParser) => (elem: any): BodyElement => {
     switch (elem.kind) {
         case ElementKind.Text:

--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -134,6 +134,32 @@ function toSerialisable(elem: BodyElement): JsonSerialisable {
     }
 }
 
+const fromSerialisable = (docParser: DocParser) => (elem: any): BodyElement => {
+    switch (elem.kind) {
+        case ElementKind.Text:
+            return { ...elem, doc: docParser(elem.doc) };
+        case ElementKind.Image:
+            return {
+                ...elem,
+                alt: fromNullable(elem.alt),
+                caption: fromNullable(elem.caption).fmap(docParser),
+                credit: fromNullable(elem.credit),
+                nativeCaption: fromNullable(elem.nativeCaption),
+                role: fromNullable(elem.role),
+            };
+        case ElementKind.Pullquote:
+            return { ...elem, attribution: fromNullable(elem.attribution) };
+        case ElementKind.Tweet:
+            return { ...elem, content: docParser(elem.content) };
+        case ElementKind.InteractiveAtom:
+            return { ...elem, js: fromNullable(elem.js) };
+        case ElementKind.Embed:
+            return { ...elem, alt: fromNullable(elem.alt) };
+        default:
+            return elem;
+    }
+}
+
 const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, NodeList> => {
     const blockquote = doc.querySelector('blockquote');
 
@@ -319,4 +345,5 @@ export {
     Body,
     parseElements,
     toSerialisable,
+    fromSerialisable,
 };

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -4,8 +4,9 @@ import { IContent as Content} from 'mapiThriftModels/Content';
 import { ITag as Tag } from 'mapiThriftModels/Tag';
 import { IBlockElement} from 'mapiThriftModels/BlockElement';
 import { ElementType } from 'mapiThriftModels/ElementType';
-import { Option, fromNullable, Some, None } from 'types/option';
+import { Option, fromNullable } from 'types/option';
 import { TagType, ContentType, ICapiDateTime as CapiDateTime } from 'mapiThriftModels';
+import { fromString as dateFromString } from 'date';
 
 
 // ----- Lookups ----- //
@@ -88,14 +89,9 @@ const capiEndpoint = (articleId: string, key: string): string => {
     return `https://content.guardianapis.com/${articleId}?${params.toString()}`;
 }
 
-const capiDateTimeToDate = (date: CapiDateTime): Option<Date> => {
+const capiDateTimeToDate = (date: CapiDateTime): Option<Date> =>
     // Thrift definitions define some dates as CapiDateTime but CAPI returns strings
-    try {
-        return new Some(new Date(date.iso8601));
-    } catch(e) {
-        return new None();
-    }
-}
+    dateFromString(date.iso8601);
 
 const maybeCapiDate = (date: CapiDateTime | undefined): Option<Date> =>
     fromNullable(date).andThen(capiDateTimeToDate);

--- a/src/client/liveblog.ts
+++ b/src/client/liveblog.ts
@@ -1,45 +1,50 @@
 // ----- Imports ----- //
 
-import setup from 'client/setup';
-import { fromCapiLiveBlog, getFormat } from 'item';
 import ReactDOM from 'react-dom';
-import LiveblogBody from 'components/liveblog/body';
 import { createElement as h } from 'react';
-import { Content } from 'mapiThriftModels';
-import { parse } from './parser';
+import { Format, Design, Display, Pillar } from '@guardian/types/Format';
+
+import setup from 'client/setup';
+import { fromSerialisable } from 'liveBlock';
+import { parse } from 'client/parser';
+import LiveblogBody from 'components/liveblog/body';
+
+
+// ----- Setup ----- //
+
+const domParser = new DOMParser();
+
+const format: Format = {
+    design: Design.Live,
+    display: Display.Standard,
+    pillar: Pillar.News,
+}
+
+
+// ----- Functions ----- //
+
+const docParser = (html: string): DocumentFragment =>
+    parse(domParser)(html)
+        .toOption()
+        .withDefault(new DocumentFragment());
+
+const deserialise = fromSerialisable(docParser);
 
 
 // ----- Run ----- //
 
-declare global {
-    interface Window {
-        __INITIAL__DATA__: Content;
-    }
-}
-
+// Set up interactives, Twitter embeds etc.
 setup();
 
-const browserParser = (html: string): DocumentFragment =>
-    parse(new DOMParser())(html)
-        .toOption()
-        .withDefault(new DocumentFragment())
+// Load the initial group of blocks.
+fetch(`${window.location}/live-blocks`)
+    .then(res => res.json())
+    .then(({ newBlocks }) => {
+        const blocks = deserialise(newBlocks);
 
-
-try {
-    const hydrationProps = JSON.parse(document.getElementById('hydrationProps')?.textContent ?? "");
-
-    if (hydrationProps) {
-        const item = fromCapiLiveBlog({
-            docParser: browserParser,
-            salt: 'mockSalt',
-        })(hydrationProps);
-        const { blocks, totalBodyBlocks } = item;
-
-        ReactDOM.hydrate(
-            h(LiveblogBody, { format: getFormat(item), blocks, totalBodyBlocks }),
-            document.querySelector('#blocks'),
+        ReactDOM.render(
+            h(LiveblogBody, { format, blocks, totalBodyBlocks: 20 }),
+            document.getElementById('blocks'),
         );
-    }
-} catch (e) {
-    console.error(`Unable to hydrate LiveblogBody: ${e}`)
-}
+    })
+    .catch(err => console.warn(`I couldn't load any live blocks because: ${err}`));

--- a/src/components/liveblog/article.tsx
+++ b/src/components/liveblog/article.tsx
@@ -58,11 +58,13 @@ const LiveblogArticle = ({ item }: LiveblogArticleProps): JSX.Element => {
                     />
                 </div>
                 <LiveblogKeyEvents blocks={item.blocks} pillar={item.pillar} />
-                <LiveblogBody
-                    blocks={item.blocks}
-                    format={format}
-                    totalBodyBlocks={item.totalBodyBlocks}
-                />
+                <article id="blocks">
+                    <LiveblogBody
+                        blocks={item.blocks}
+                        format={format}
+                        totalBodyBlocks={item.totalBodyBlocks}
+                    />
+                </article>
                 <Tags tags={item.tags} background={neutral[93]} />
             </div>
         </main>

--- a/src/components/liveblog/body.tsx
+++ b/src/components/liveblog/body.tsx
@@ -1,26 +1,10 @@
 import React, { useState } from 'react';
 import LiveblogBlock from './block';
 import LiveblogLoadMore from './loadMore';
-import { css } from '@emotion/core'
 import { Pillar, Format } from 'format';
 import { LiveBlock } from 'liveBlock';
 import { renderAll } from 'renderer';
 import { partition } from 'types/result';
-import { BufferedTransport, CompactProtocol } from '@creditkarma/thrift-server-core';
-import { Blocks } from 'mapiThriftModels';
-import { remSpace } from '@guardian/src-foundations';
-
-const LiveBodyStyles = css`
-    .rich-link,
-    .element-membership {
-        width: calc(100% - 16px);
-        margin: 1em 0;
-    }
-
-    figure {
-        margin: ${remSpace[4]} 0;
-    }
-`;
 
 interface LiveblogBodyProps {
     format: Format;
@@ -28,18 +12,9 @@ interface LiveblogBodyProps {
     totalBodyBlocks: number;
 }
 
-async function loadMoreBlocks(): Promise<void> {
-    const response = await fetch('?date=2020-03-09T11%3A11%3A49Z&filter=newer');
-    const buffer = Buffer.from(await response.arrayBuffer());
-    const transport = new BufferedTransport(buffer);
-    const protocol = new CompactProtocol(transport);
-    const blocks: Blocks = Blocks.read(protocol);
-    console.log(blocks);
-}
-
 const LoadMore = ({ total, pillar }: { total: number; pillar: Pillar }): JSX.Element | null =>
     total > 7
-        ? <LiveblogLoadMore onLoadMore={loadMoreBlocks} pillar={pillar}/>
+        ? <LiveblogLoadMore onLoadMore={() => Promise.resolve()} pillar={pillar}/>
         : null;
 
 const LiveblogBody = (props: LiveblogBodyProps): JSX.Element => {
@@ -47,7 +22,7 @@ const LiveblogBody = (props: LiveblogBodyProps): JSX.Element => {
     const [blocks] = useState(initialBlocks);
 
     return (
-        <article id="blocks" css={LiveBodyStyles}>
+        <>
             {
                 blocks.map((block: LiveBlock) => {
                     return <LiveblogBlock
@@ -62,7 +37,7 @@ const LiveblogBody = (props: LiveblogBodyProps): JSX.Element => {
                 })
             }
             <LoadMore total={totalBodyBlocks} pillar={format.pillar}/>
-        </article>
+        </>
     );
 
 }

--- a/src/components/liveblog/body.tsx
+++ b/src/components/liveblog/body.tsx
@@ -14,7 +14,7 @@ interface LiveblogBodyProps {
 
 const LoadMore = ({ total, pillar }: { total: number; pillar: Pillar }): JSX.Element | null =>
     total > 7
-        ? <LiveblogLoadMore onLoadMore={() => Promise.resolve()} pillar={pillar}/>
+        ? <LiveblogLoadMore onLoadMore={(): Promise<void> => Promise.resolve()} pillar={pillar}/>
         : null;
 
 const LiveblogBody = (props: LiveblogBodyProps): JSX.Element => {

--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -15,7 +15,6 @@ import { partition } from 'types/result';
 import { getAdPlaceholderInserter } from 'ads';
 import { fromCapi, getFormat } from 'item';
 import { ElementKind } from 'bodyElement';
-import { IBlock as Block } from 'mapiThriftModels';
 import { Design, Display } from 'format';
 import Interactive from 'components/interactive/article';
 import { pageFonts } from 'styles';
@@ -44,27 +43,7 @@ interface BodyProps {
 interface ElementWithResources {
     element: React.ReactElement;
     resources: string[];
-    hydrationProps: {};
 }
-
-const filterBlocks = (block: Block): Block => {
-    const { createdBy, lastModifiedBy, ...blocks } = block;
-    return blocks;
-};
-
-const liveblogProps = (capi: Content): Content => {
-    const { id, type, webTitle, webUrl, apiUrl, fields, tags, references, isHosted, blocks } = capi;
-    return {
-        id, type, webTitle, webUrl, apiUrl, fields, references, isHosted,
-        tags: tags.map(({ type, webTitle, webUrl, id, references, apiUrl }) =>
-            ({ type, webTitle, webUrl, id, references, apiUrl })),
-        blocks: {
-            totalBodyBlocks: blocks?.totalBodyBlocks,
-            main: blocks?.main ? filterBlocks(blocks?.main) : undefined,
-            body: blocks?.body ? blocks.body.map(filterBlocks) : undefined
-        }
-    }
-};
 
 const WithScript = (props: { src: string; children: ReactNode }): ReactElement =>
     <>
@@ -94,7 +73,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
             <Interactive>
                 {interactiveContent}
             </Interactive>
-        ), resources: [], hydrationProps: {} };
+        ), resources: [] };
     }
 
     if (item.design === Design.Comment) {
@@ -108,7 +87,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
                     {commentContent}
                 </Opinion>
             </WithScript>
-        ), resources: [articleScript], hydrationProps: {} };
+        ), resources: [articleScript] };
     }
 
     if (item.design === Design.Live) {
@@ -116,7 +95,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
             <WithScript src={liveblogScript}>
                 <LiveblogArticle item={item} />
             </WithScript>
-        ), resources: [liveblogScript], hydrationProps: { ...liveblogProps(capi) } };
+        ), resources: [liveblogScript] };
     }
 
     if (item.design === Design.Media) {
@@ -129,7 +108,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
                         {mediaContent}
                     </Media>
                 </WithScript>
-            ), resources: [mediaScript], hydrationProps: {} };
+            ), resources: [mediaScript] };
     }
 
     if (
@@ -148,7 +127,7 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
                     {content}
                 </Standard>
             </WithScript>
-        ), resources: [articleScript], hydrationProps: {} };
+        ), resources: [articleScript] };
     }
 
     if (item.design === Design.AdvertisementFeature) {
@@ -159,11 +138,11 @@ function ArticleBody({ capi, imageSalt, getAssetLocation }: BodyProps): ElementW
             <AdvertisementFeature item={item}>
                 {content}
             </AdvertisementFeature>
-        ), resources: [], hydrationProps: {} };
+        ), resources: [] };
     }
 
     const element = <p>Content format not implemented yet</p>;
-    return { element, resources: [], hydrationProps: {} };
+    return { element, resources: [] };
 }
 
 interface Props {
@@ -180,7 +159,6 @@ function Page({ content, imageSalt, getAssetLocation }: Props): ElementWithResou
     const {
         element,
         resources,
-        hydrationProps
     } = ArticleBody({ imageSalt, capi: content, getAssetLocation });
 
     return { element: (
@@ -196,7 +174,7 @@ function Page({ content, imageSalt, getAssetLocation }: Props): ElementWithResou
                 { twitterScript }
             </body>
         </html>
-    ), resources, hydrationProps };
+    ), resources };
 }
 
 

--- a/src/date.ts
+++ b/src/date.ts
@@ -1,3 +1,8 @@
+// ----- Imports ----- //
+
+import { Option, Some, None } from 'types/option';
+
+
 // ----- Setup ----- //
 
 const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -85,6 +90,14 @@ const time = (date: Date): string =>
 const format = (date: Date): string =>
     `${day(date)} ${date.getUTCDate()} ${month(date)} ${date.getUTCFullYear()} ${time(date)} UTC`;
 
+function fromString(date: string): Option<Date> {
+    try {
+        return new Some(new Date(date));
+    } catch(e) {
+        return new None();
+    }
+}
+
 
 // ----- Exports ----- //
 
@@ -92,4 +105,5 @@ export {
     makeRelativeDate,
     format as formatDate,
     isValidDate,
+    fromString,
 }

--- a/src/liveBlock.ts
+++ b/src/liveBlock.ts
@@ -49,6 +49,9 @@ const serialiseLiveBlock = ({
         body: partition(body).oks.map(bodyElementToSerialisable),
     });
 
+// Disabled because the point of these functions is to convert the `any`
+// provided by JSON.parse to a stricter type
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const deserialiseLiveBlock = (docParser: DocParser) => ({
     id,
     isKeyEvent,
@@ -71,6 +74,8 @@ const toSerialisable = (blocks: LiveBlock[]): JsonSerialisable =>
 
 const fromSerialisable = (docParser: DocParser) => (blocks: any): LiveBlock[] =>
     blocks.map(deserialiseLiveBlock(docParser));
+
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 const parse = (context: Context) => (block: Block): LiveBlock =>
     ({

--- a/src/liveBlock.ts
+++ b/src/liveBlock.ts
@@ -3,17 +3,19 @@
 import { IBlock as Block } from 'mapiThriftModels/Block';
 import { ICapiDateTime as CapiDateTime } from 'mapiThriftModels/CapiDateTime';
 import { IContent as Content } from 'mapiThriftModels/Content';
-import { Option, toSerialisable as optionToSerialisable } from 'types/option';
-import { Context } from 'types/parserContext';
+import { Option, toSerialisable as optionToSerialisable, fromNullable } from 'types/option';
+import { Context, DocParser } from 'types/parserContext';
 import JsonSerialisable from 'types/jsonSerialisable';
 import {
     Body,
     parseElements,
     toSerialisable as bodyElementToSerialisable,
+    fromSerialisable as bodyElementFromSerialisable,
 } from 'bodyElement';
 import { maybeCapiDate } from 'capi';
-import { partition } from 'types/result';
+import { partition, Ok } from 'types/result';
 import { compose } from 'lib';
+import { fromString as dateFromString } from 'date';
 
 
 // ----- Types ----- //
@@ -47,8 +49,28 @@ const serialiseLiveBlock = ({
         body: partition(body).oks.map(bodyElementToSerialisable),
     });
 
+const deserialiseLiveBlock = (docParser: DocParser) => ({
+    id,
+    isKeyEvent,
+    title,
+    firstPublished,
+    lastModified,
+    body,
+}: any): LiveBlock =>
+    ({
+        id,
+        isKeyEvent,
+        title,
+        firstPublished: fromNullable(firstPublished).andThen(dateFromString),
+        lastModified: fromNullable(lastModified).andThen(dateFromString),
+        body: body.map((elem: any) => new Ok(bodyElementFromSerialisable(docParser)(elem))),
+    });
+
 const toSerialisable = (blocks: LiveBlock[]): JsonSerialisable =>
     blocks.map(serialiseLiveBlock);
+
+const fromSerialisable = (docParser: DocParser) => (blocks: any): LiveBlock[] =>
+    blocks.map(deserialiseLiveBlock(docParser));
 
 const parse = (context: Context) => (block: Block): LiveBlock =>
     ({
@@ -92,6 +114,7 @@ export {
     parseMany,
     newBlocksSince,
     updatedBlocksSince,
-    toSerialisable,
     recentBlocks,
+    toSerialisable,
+    fromSerialisable,
 };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -132,12 +132,10 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
                 const {
                     resources,
                     element,
-                    hydrationProps,
                 } = Page({ content, imageSalt, getAssetLocation });
                 res.set('Link', getPrefetchHeader(resources));
                 res.write('<!DOCTYPE html>');
                 res.write('<meta charset="UTF-8" />');
-                res.write(`<script id="hydrationProps" type="application/json">${JSON.stringify(hydrationProps)}</script>`);
                 res.write(renderToString(element));
                 res.end();
             },
@@ -154,7 +152,7 @@ const liveBlockUpdates = (since: Date, content: Content, context: Context): Live
 });
 
 const recentLiveBlocks = (content: Content, context: Context): LiveUpdates => ({
-    newBlocks: serialiseLiveBlocks(recentBlocks(10)(content)(context)),
+    newBlocks: serialiseLiveBlocks(recentBlocks(7)(content)(context)),
     updatedBlocks: [],
 });
 
@@ -208,8 +206,6 @@ app.use('/assets', express.static(path.resolve(__dirname, '../assets')));
 app.use('/assets', express.static(path.resolve(__dirname, '../dist/assets')));
 app.use(compression());
 
-app.get('/:articleId(*)/live-blocks', liveBlocks);
-
 app.all('*', (request, response, next) => {
     const start = Date.now();
 
@@ -220,6 +216,8 @@ app.all('*', (request, response, next) => {
 
     next();
 });
+
+app.get('/:articleId(*)/live-blocks', liveBlocks);
 
 app.get('/healthcheck', (_req, res) => res.send("Ok"));
 


### PR DESCRIPTION
## Why are you doing this?

This begins the work to request new live blocks on the client. These changes are quite contained: on page load the JS will make a request to get the most recent 7 blocks (which matches what the server has rendered for the page). It will then put the liveblog body under the control of client-side React, using the blocks retrieved as the data.

This is a follow-on from #335, and fixes the client-side rendering that was temporarily disabled in that PR. It also temporarily removes client-side hydration, hardcoding the `Format` and total blocks for now. A fix for *this* will come in a further PR; it requires some restructuring that would balloon the size of these changes.

**Note:** I'm not particularly happy with the conversions from JSON applied here; they create the potential for runtime errors due to the `any` return type of `JSON.parse`. In theory it should be fine because we control both sides of the API, but I still think we could do better. This isn't the highest priority right now, but I may look into this again down the line. One alternative would be to use Thrift, but that may cause a big spike in the bundle size.

## Changes

- Added a deserialiser for `BodyElement`
- Introduced new `fromString` function for `date` module
- Added a deserialiser for `LiveBlock`
- Rewrote liveblog client script to load initial blocks
- Temporarily hardcoded `Format` and total blocks for liveblog client
- Fixed bug where blocks article element was duplicated
- Temporarily removed hydration props
