### PR TITLE
Change fontSize.css URL

### DIFF
--- a/src/components/shared/page.tsx
+++ b/src/components/shared/page.tsx
@@ -189,7 +189,7 @@ function Page({ content, imageSalt, getAssetLocation }: Props): ElementWithResou
                 <title>{content.id}</title>
                 <meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
                 <meta name="viewport" content="initial-scale=1, maximum-scale=5" />
-                <link rel="stylesheet" href="native://fontSize.css" />
+                <link rel="stylesheet" href="https://localhost/fontSize.css" />
             </head>
             <body>
                 { element }


### PR DESCRIPTION
## Why are you doing this?

Because the current URL (`native://fontSize.css`) caused mixed content errors/warnings in the web console and the request may be blocked depending on the security policy.

Changing it to `https://` should allow it to go ahead and be intercepted in the native layer.

## Changes

- The URL used to load the base font size stylesheet.