### PR TITLE
use font display swap

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -168,6 +168,7 @@ export const fontFace = (
     ${style.fmap((s: string) => `font-style: ${s};`).withDefault('')}
     ${weight.fmap((w: number | string) => `font-weight: ${w};`).withDefault('')}
     src: url('${url}');
+    font-display: swap;
   }
 `;
 


### PR DESCRIPTION
## Why are you doing this?

This is the only suggestion from lighthouse to reach 100% performance.

It will display system fonts until our fonts have loaded.