### PR TITLE
format byline links

### DIFF
--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -103,11 +103,18 @@ const getAnchorStyles = (format: Format): SerializedStyles => {
     }
 }
 
+const getProfileLink = (node: Node): string => {
+    const href = getHref(node).withDefault('');
+    return href.startsWith('profile/')
+        ? `https://www.theguardian.com/${href}`
+        : href
+}
+
 const toReact = (format: Format) => (node: Node): ReactNode => {
     switch (node.nodeName) {
         case 'A':
             return (
-                <a href={getHref(node).withDefault('')} css={getAnchorStyles(format)}>
+                <a href={getProfileLink(node)} css={getAnchorStyles(format)}>
                     {node.textContent ?? ''}
                 </a>
             );


### PR DESCRIPTION
`bylineHtml` only provides us with a relative profile url. Changing to the absolute path ensures iOS and Android can correctly link to profile pages.