### PR TITLE
use opinion background for all comment designs

### DIFF
--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -65,7 +65,7 @@ const textHeadlineInverse = (_: Format): Colour =>
 const backgroundHeadlinePrimary = (format: Format): Colour => {
     if (format.display === Display.Immersive) {
         return neutral[7];
-    } else if (format.pillar === Pillar.Opinion) {
+    } else if (format.design === Design.Comment) {
         return opinion[800];
     }
 

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -67,6 +67,8 @@ const backgroundHeadlinePrimary = (format: Format): Colour => {
         return neutral[7];
     } else if (format.design === Design.Comment) {
         return opinion[800];
+    } else if (format.design === Design.Media) {
+        return coreBackground.inverse;
     }
 
     return coreBackground.primary;


### PR DESCRIPTION
## Why are you doing this?
This matches the logic in `page.tsx`

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/83250488-18bb7880-a1a0-11ea-974d-b4bd557aa29c.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/83250645-61733180-a1a0-11ea-96f6-c3de4538501d.png" width="300px" /> |

