### PR TITLE
remove font display swap

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -168,7 +168,6 @@ export const fontFace = (
     ${style.fmap((s: string) => `font-style: ${s};`).withDefault('')}
     ${weight.fmap((w: number | string) => `font-weight: ${w};`).withDefault('')}
     src: url('${url}');
-    font-display: swap;
   }
 `;
 


### PR DESCRIPTION
## Why are you doing this?
This may improve performance slightly but there is a noticeable jump on every article load.

If we cache fonts and pre-warm the cache this shouldn't be necessary.

There's other options too but I think they'll still cause layout jumps for most pages https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
