### PR TITLE
Add Content Security Policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4548,8 +4548,7 @@
     "@emotion/utils": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-      "dev": true
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
     },
     "@emotion/weak-memoize": {
       "version": "0.2.5",
@@ -9604,6 +9603,17 @@
         }
       }
     },
+    "create-emotion-server": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/create-emotion-server/-/create-emotion-server-10.0.27.tgz",
+      "integrity": "sha512-1EbZgdjiho9ue1BSTpAez8SIdfbTXomtz0bg+LPOEvf/5OV7xqCGJaoSCDCB+y7kZ73hwoEhLsoPmqKSGIQMXg==",
+      "requires": {
+        "@emotion/utils": "0.11.3",
+        "html-tokenize": "^2.0.0",
+        "multipipe": "^1.0.2",
+        "through": "^2.3.8"
+      }
+    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -10248,6 +10258,14 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
     },
     "duplexify": {
       "version": "3.7.1",
@@ -13411,6 +13429,68 @@
               "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
               "dev": true
             }
+          }
+        }
+      }
+    },
+    "html-tokenize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
+      "integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
+      "requires": {
+        "buffer-from": "~0.1.1",
+        "inherits": "~2.0.1",
+        "minimist": "~1.2.5",
+        "readable-stream": "~1.0.27-1",
+        "through2": "~0.4.1"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+          "requires": {
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
+          }
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "requires": {
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -16801,6 +16881,15 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
+    },
+    "multipipe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+      "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+      "requires": {
+        "duplexer2": "^0.1.2",
+        "object-assign": "^4.1.0"
+      }
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -21824,8 +21913,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "aws-sdk": "^2.604.0",
     "babel-jest": "^25.4.0",
     "compression": "^1.7.4",
+    "create-emotion-server": "^10.0.27",
     "emotion": "^10.0.27",
     "express": "^4.17.1",
     "jsdom": "^15.2.1",

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -29,7 +29,7 @@ const extractInteractiveAssets = (elements: BodyElement[]): Assets =>
                 styles: [ ...styles, elem.css ],
                 scripts: elem.js.fmap(js => [ ...scripts, js ]).withDefault(scripts),
             };
-        };
+        }
 
         return { scripts, styles };
     }, { scripts: [], styles: [] });

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -1,0 +1,73 @@
+// ----- Imports ----- //
+
+import { createHash } from 'crypto';
+import { Design } from '@guardian/types/Format';
+
+import { BodyElement, ElementKind } from 'bodyElement';
+import { partition, Result } from 'types/result';
+import { Item } from 'item';
+import { compose } from 'lib';
+
+
+// ----- Types ----- //
+
+interface Assets {
+    scripts: string[];
+    styles: string[];
+}
+
+
+// ----- Functions ----- //
+
+const assetHash = (asset: string): string =>
+    createHash('sha256').update(asset).digest('base64');
+
+const extractInteractiveAssets = (elements: BodyElement[]): Assets =>
+    elements.reduce<Assets>(({ scripts, styles }, elem) => {
+        if (elem.kind === ElementKind.InteractiveAtom) {
+            return {
+                styles: [ ...styles, elem.css ],
+                scripts: elem.js.fmap(js => [ ...scripts, js ]).withDefault(scripts),
+            };
+        };
+
+        return { scripts, styles };
+    }, { scripts: [], styles: [] });
+
+const getElements = (item: Item): Result<string, BodyElement>[] =>
+    item.design === Design.Live ? item.blocks.flatMap(block => block.body) : item.body;
+
+const getValidElements = (item: Item): BodyElement[] =>
+    partition(getElements(item)).oks;
+
+const interactiveAssets = compose(extractInteractiveAssets, getValidElements);
+
+const assetHashes = (assets: string[]): string =>
+    assets.map(asset => `'sha256-${assetHash(asset)}'`).join(' ');
+
+const buildCsp = ({ styles, scripts }: Assets, twitter: boolean): string => `
+    default-src 'self';
+    style-src ${assetHashes(styles)} https://interactive.guim.co.uk ${twitter ? 'https://platform.twitter.com' : ''};
+    img-src 'self' https://i.guim.co.uk ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:' : ''};
+    script-src 'self' ${assetHashes(scripts)} https://interactive.guim.co.uk ${twitter ? 'https://platform.twitter.com https://cdn.syndication.twimg.com' : ''};
+    frame-src ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com' : ''};
+    font-src 'self' https://interactive.guim.co.uk;
+    connect-src 'self' https://interactive.guim.co.uk
+`.trim();
+
+function csp(item: Item, additionalAssets: Assets, twitter: boolean): string {
+    const interactives = interactiveAssets(item);
+    const assets = {
+        styles: [ ...interactives.styles, ...additionalAssets.styles ],
+        scripts: [ ...interactives.scripts, ...additionalAssets.scripts ],
+    };
+
+    return buildCsp(assets, twitter);
+}
+
+
+// ----- Exports ----- //
+
+export {
+    csp,
+};

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,7 +7,6 @@ import express, {
     Response as ExpressResponse,
 } from 'express';
 import compression from 'compression';
-import { renderToString } from 'react-dom/server';
 import bodyParser from 'body-parser';
 import fetch, { Response } from 'node-fetch';
 
@@ -108,7 +107,7 @@ async function serveArticlePost(
         const { html, clientScript } = page(imageSalt, content, getAssetLocation);
         res.set('Link', getPrefetchHeader(clientScript.fmap(toArray).withDefault([])));
         res.write('<!DOCTYPE html>');
-        res.write(renderToString(html));
+        res.write(html);
         res.end();
     } catch (e) {
         logger.error(`This error occurred`, e);
@@ -133,7 +132,7 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
                 res.set('Link', getPrefetchHeader(clientScript.fmap(toArray).withDefault([])));
                 res.write('<!DOCTYPE html>');
                 res.write('<meta charset="UTF-8" />');
-                res.write(renderToString(html));
+                res.write(html);
                 res.end();
             },
         )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,6 +103,7 @@ const clientConfig = {
         media: 'client/media.ts',
     },
     target: 'web',
+    devtool: 'inline-cheap-source-map',
     output: {
         path: path.resolve(__dirname, 'dist/assets'),
         filename: '[name].js',
@@ -149,6 +150,7 @@ const clientConfigProduction = {
     ...clientConfig,
     name: 'clientProduction',
     mode: 'production',
+    devtool: false,
     plugins: [
         new ManifestPlugin(),
     ],


### PR DESCRIPTION
## Why are you doing this?

CSP's are important for security; they limit what resources (scripts, styles, iframes etc.) are accepted by your page. For a more detailed explanation see [this MDN article](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).

This implements a CSP using the `<meta>` tag, as I'm not sure the HTTP header will play well with the way iOS inserts the HTML string into the webview (happy to be told otherwise though @faresite).

There are a few techniques used here:
- I've set [`default-src` to `'self'`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#Example_1), so any resources not explicitly described in the policy will only be accepted from our domain (MAPI)
- The interactives domain is allowed to load styles, scripts and fonts, and make AJAX requests (via [`connect-src`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src))
- Images can be loaded from MAPI or from `i.guim.co.uk` (the Fastly image service)
- If tweets are present on the page then some combination of styles, images, scripts and iframes can be loaded from some combination of the following Twitter domains: `platform.twitter.com`, `syndication.twitter.com`, `pbs.twimg.com` and `cdn.syndication.twimg.com`. Images are also allowed to be loaded from `data:` URLs in this case, because Twitter appear to load some of their SVGs in this way.

If anything I've described above sounds incorrect, or doesn't line up with the way the policy is written please let me know! Likewise with the choice of hashing algorithm/library; I've used `crypto` from Node's standard library, and `sha256` as demonstrated in some of [MDN's examples](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#Unsafe_inline_styles). I went with hashing rather than use of nonces because we'd like to cache this content, and caching would prevent the nonce being request-unique. @adamnfish @katebee @davidfurey 

I've tried to lock this down as much as possible without breaking functionality. That said, this policy is much stricter than it was before so there may one or two things that it breaks, e.g. a stray interactive domain that I'm not aware of. If you spot anything like this, please let me know.

The implementation for extracting Emotion's styles draws from the [Emotion SSR docs](https://emotion.sh/docs/ssr#advanced-approach). DCR do [something similar](https://github.com/guardian/dotcom-rendering/blob/449144470ee68e16402b38bbd6f75f871c5c42db/src/amp/server/document.tsx#L35) for AMP articles.

**Note:** This currently blocks a use of `eval` that exists in the Webpack boilerplate code, which may cause problems for our client-side bundle. I'm looking into this.

FYI @gtrufitt @oliverlloyd @liywjl 

## Changes

- Added `create-emotion-server` as a dependency
- Added a `csp` module to build the CSP from asset hashes
- Added Twitter to CSP only if tweets are present
- Added interactives to CSP
- Extracted Emotion into single style tag for hashing
- Built html doc as string to work with Emotion's `extractCritical`
