### PR TITLE
Image From *.guim.co.uk

### DIFF
--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -48,7 +48,7 @@ const assetHashes = (assets: string[]): string =>
 const buildCsp = ({ styles, scripts }: Assets, twitter: boolean): string => `
     default-src 'self';
     style-src ${assetHashes(styles)} https://interactive.guim.co.uk ${twitter ? 'https://platform.twitter.com' : ''};
-    img-src 'self' https://i.guim.co.uk ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:' : ''};
+    img-src 'self' https://*.guim.co.uk ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:' : ''};
     script-src 'self' ${assetHashes(scripts)} https://interactive.guim.co.uk ${twitter ? 'https://platform.twitter.com https://cdn.syndication.twimg.com' : ''};
     frame-src ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com' : ''};
     font-src 'self' https://interactive.guim.co.uk;


### PR DESCRIPTION
## Why are you doing this?

Updates the CSP to allow images from multiple subdomains of `guim.co.uk`; interactives make use of these, as flagged by @webb04.

## Changes

- Updated CSP to allow images from `https://*.guim.co.uk`

## Screenshots

| Before | After |
| --- | --- |
| ![guim-before](https://user-images.githubusercontent.com/53781962/83628100-e2ab3980-a58f-11ea-9b48-a974ad15523a.png) | ![guim-after](https://user-images.githubusercontent.com/53781962/83628092-dfb04900-a58f-11ea-97c7-b837e11c9469.jpg) |
