### PR TITLE
handle long words and following ul elements

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -104,6 +104,7 @@ const listStyles: SerializedStyles = css`
     list-style: none;
     margin: ${remSpace[2]} 0;
     padding-left: 0;
+    clear: both;
 `;
 
 const listItemStyles: SerializedStyles = css`
@@ -342,6 +343,7 @@ const richLinkStyles = css`
         h1 {
             margin: ${basePx(0, 0, 2, 0)};
             ${headline.xxxsmall({ fontWeight: 'bold' })}
+            hyphens: auto;
         }
     }
 


### PR DESCRIPTION
https://www.theguardian.com/world/2020/jun/03/covid-19-surgisphere-who-world-health-organization-hydroxychloroquine

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/83635107-8d752500-a59b-11ea-8dfe-58baab08317c.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/83635121-949c3300-a59b-11ea-86cb-c6f7f3e87a92.png" width="300px" /> |
