### PR TITLE
Use image component for avatar and cutout images

### DIFF
--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -6,6 +6,8 @@ import { css, SerializedStyles } from '@emotion/core';
 import { Contributor, isSingleContributor } from 'contributor';
 import { Format } from 'format';
 import { getPillarStyles } from 'pillarStyles';
+import Img from './img';
+import { remSpace } from '@guardian/src-foundations';
 
 
 // ----- Setup ----- //
@@ -17,7 +19,6 @@ const dimensions = '4rem';
 
 interface Props extends Format {
     contributors: Contributor[];
-    className?: SerializedStyles;
 }
 
 const styles = (background: string): SerializedStyles => css`
@@ -26,15 +27,16 @@ const styles = (background: string): SerializedStyles => css`
     clip-path: circle(50%);
     object-fit: cover;
     background: ${background};
+    margin-right: ${remSpace[3]};
+    margin-top: ${remSpace[1]};
 `;
 
 const getStyles = ({ pillar }: Format): SerializedStyles => {
     const colours = getPillarStyles(pillar);
-
     return styles(colours.inverted);
 }
 
-const Avatar: FC<Props> = ({ contributors, className, ...format }: Props) => {
+const Avatar: FC<Props> = ({ contributors, ...format }: Props) => {
     const [contributor] = contributors;
 
     if (!isSingleContributor(contributors)) {
@@ -42,12 +44,10 @@ const Avatar: FC<Props> = ({ contributors, className, ...format }: Props) => {
     }
 
     return contributor.image.fmap<ReactElement | null>(image =>
-        <img
-            css={[getStyles(format), className]}
-            srcSet={image.srcset}
-            alt={contributor.name}
+        <Img
+            image={image}
             sizes={dimensions}
-            src={image.src}
+            className={getStyles(format)}
         />
     ).withDefault(null);
 }

--- a/src/components/liveblog/avatar.test.tsx
+++ b/src/components/liveblog/avatar.test.tsx
@@ -15,6 +15,14 @@ describe('Avatar component renders as expected', () => {
         image: new Some({
             src: '',
             srcset: '',
+            dpr2Srcset: '',
+            height: 192,
+            width: 192,
+            credit: new None(),
+            caption: new None(),
+            alt: new None(),
+            role: new None(),
+            nativeCaption: new None()
         }),
     }]
     it('Adds correct alt attribute', () => {

--- a/src/components/metadata.tsx
+++ b/src/components/metadata.tsx
@@ -36,14 +36,9 @@ const withBylineTextStyles = css`
     padding-top: ${remSpace[1]};
 `;
 
-const avatarStyles = css`
-    margin-right: ${remSpace[3]};
-    margin-top: ${remSpace[1]};
-`;
-
 const MetadataWithByline: FC<Props> = ({ item }: Props) =>
     <div css={css(styles, withBylineStyles)}>
-        <Avatar className={avatarStyles} {...item} />
+        <Avatar {...item} />
         <div css={css(textStyles, withBylineTextStyles)}>
             <Byline {...item} />
             <Dateline date={item.publishDate} />

--- a/src/components/opinion/cutout.tsx
+++ b/src/components/opinion/cutout.tsx
@@ -4,6 +4,7 @@ import React, { ReactElement } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 
 import { Contributor, isSingleContributor } from 'contributor';
+import Img from 'components/img';
 
 
 // ----- Styles ----- //
@@ -17,6 +18,7 @@ const imageStyles = css`
     height: 160px;
     right: 0;
     top: -48px;
+    background: none;
 `;
 
 
@@ -34,17 +36,16 @@ const Cutout = ({ contributors, className }: Props): JSX.Element | null => {
         return null;
     }
 
-    return contributor.image.fmap<ReactElement | null>(image =>
-        <div css={[className, styles]}>
-            <img
-                css={imageStyles}
-                srcSet={image.srcset}
-                src={image.src}
-                alt={contributor.name}
-                sizes="6rem"
-            />
-        </div>
-    ).withDefault(null);
+    return contributor.image.fmap<ReactElement | null>(image => {
+        return (
+            <div css={[className, styles]}>
+                <Img
+                    image={image}
+                    sizes={"12rem"}
+                    className={imageStyles}
+                />
+            </div>)
+    }).withDefault(null);
 }
 
 

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -18,7 +18,7 @@ type Contributor = {
 
 // ----- Functions ----- //
 
-const contributorSrcset = srcsetWithWidths([32, 64, 128, 192, 256]);
+const contributorSrcset = srcsetWithWidths([32, 64, 128, 192, 256, 400, 600]);
 
 const isSingleContributor = (cs: Contributor[]): boolean =>
     cs.length === 1

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -1,9 +1,9 @@
 // ----- Imports ----- //
 
-import { Option, fromNullable } from 'types/option';
+import { Option, fromNullable, None } from 'types/option';
 import { IContent as Content } from 'mapiThriftModels';
 import { articleContributors } from 'capi';
-import { srcsetWithWidths, src, Dpr } from 'image';
+import { srcsetWithWidths, src, Dpr, Image } from 'image';
 
 
 // ------ Types ----- //
@@ -12,10 +12,7 @@ type Contributor = {
     id: string;
     apiUrl: string;
     name: string;
-    image: Option<{
-        srcset: string;
-        src: string;
-    }>;
+    image: Option<Image>;
 }
 
 
@@ -34,6 +31,14 @@ const parseContributors = (salt: string, content: Content): Contributor[] =>
         image: fromNullable(contributor.bylineLargeImageUrl).fmap(url => ({
             srcset: contributorSrcset(url, salt, Dpr.One),
             src: src(salt, url, 64, Dpr.One),
+            dpr2Srcset: contributorSrcset(url, salt, Dpr.Two),
+            height: 192,
+            width: 192,
+            credit: new None(),
+            caption: new None(),
+            alt: new None(),
+            role: new None(),
+            nativeCaption: new None()
         })),
     }));
 


### PR DESCRIPTION
## Why are you doing this?

Use the `<Img />` component for cutout and avatar images. This way we can get the benefits of the picture element, the srcset and dpr queries.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/83642359-a59e7180-a5a6-11ea-8165-c7adbe5c5a89.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/83642382-ae8f4300-a5a6-11ea-8f11-856cf353b474.png" width="300px" /> |
