### PR TITLE
Introduce Fixture Module For Item

### DIFF
--- a/src/components/headline.stories.tsx
+++ b/src/components/headline.stories.tsx
@@ -2,40 +2,20 @@
 
 import React, { ReactElement } from 'react';
 import { withKnobs, boolean, radios } from '@storybook/addon-knobs';
+import { Pillar, Display } from '@guardian/types/Format';
 
 import Headline from './headline';
-import { Item } from 'item';
-import { Pillar, Design, Display } from 'format';
-import { None, Some } from 'types/option';
+import {
+    article,
+    analysis,
+    feature,
+    review,
+    advertisementFeature,
+} from 'fixtures/item';
 import { selectPillar } from 'storybookHelpers';
 
 
 // ----- Setup ----- //
-
-const item: Item = {
-    pillar: Pillar.News,
-    design: Design.Article,
-    display: Display.Standard,
-    body: [],
-    headline: 'Reclaimed lakes and giant airports: how Mexico City might have looked',
-    standfirst: new None(),
-    byline: '',
-    bylineHtml: new None(),
-    publishDate: new None(),
-    mainImage: new None(),
-    contributors: [],
-    series: new Some({
-        id: '',
-        type: 0,
-        webTitle: '',
-        webUrl: '',
-        apiUrl: '',
-        references: [],
-    }),
-    commentable: false,
-    tags: [],
-    shouldHideReaderRevenue: false,
-};
 
 const starRating: Record<number, number> = [0, 1, 2, 3, 4, 5];
 
@@ -44,38 +24,34 @@ const starRating: Record<number, number> = [0, 1, 2, 3, 4, 5];
 
 const Default = (): ReactElement =>
     <Headline item={{
-        ...item,
+        ...article,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
     }} />
 
 const Analysis = (): ReactElement =>
     <Headline item={{
-        ...item,
-        design: Design.Analysis,
+        ...analysis,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
         pillar: selectPillar(Pillar.News),
     }} />
 
 const Feature = (): ReactElement =>
     <Headline item={{
-        ...item,
-        design: Design.Feature,
+        ...feature,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
         pillar: selectPillar(Pillar.News),
     }} />
 
 const Review = (): ReactElement =>
     <Headline item={{
-        ...item,
-        design: Design.Review,
+        ...review,
         starRating: radios('Rating', starRating, 3),
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
     }} />
 
 const Labs = (): ReactElement =>
     <Headline item={{
-        ...item,
-        design: Design.AdvertisementFeature,
+        ...advertisementFeature,
         display: Display.Standard,
     }} />
 

--- a/src/components/standfirst.stories.tsx
+++ b/src/components/standfirst.stories.tsx
@@ -2,7 +2,7 @@
 
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import React, { ReactElement } from 'react';
-import { Pillar, Display } from '@guardian/types/format';
+import { Pillar, Display } from '@guardian/types/Format';
 
 import Standfirst from './standfirst';
 import { Option } from 'types/option';

--- a/src/components/standfirst.stories.tsx
+++ b/src/components/standfirst.stories.tsx
@@ -2,11 +2,11 @@
 
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import React, { ReactElement } from 'react';
+import { Pillar, Display } from '@guardian/types/format';
 
 import Standfirst from './standfirst';
-import { Item } from 'item';
-import { Pillar, Design, Display } from 'format';
-import { Option, None, Some } from 'types/option';
+import { Option } from 'types/option';
+import { article, review, feature, comment } from 'fixtures/item';
 import { parse } from 'client/parser';
 import { selectPillar } from 'storybookHelpers';
 
@@ -20,62 +20,37 @@ const standfirst: Option<DocumentFragment> =
     parseStandfirst('<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>')
         .toOption();
 
-const item: Item = {
-    pillar: Pillar.News,
-    design: Design.Article,
-    display: Display.Standard,
-    body: [],
-    headline: 'Reclaimed lakes and giant airports: how Mexico City might have looked',
-    standfirst,
-    byline: '',
-    bylineHtml: new None(),
-    publishDate: new None(),
-    mainImage: new None(),
-    contributors: [],
-    series: new Some({
-        id: '',
-        type: 0,
-        webTitle: '',
-        webUrl: '',
-        apiUrl: '',
-        references: [],
-    }),
-    commentable: false,
-    tags: [],
-    shouldHideReaderRevenue: false,
-};
-
 
 // ----- Stories ----- //
 
 const Default = (): ReactElement =>
     <Standfirst item={{
-        ...item,
+        ...article,
+        standfirst,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
         pillar: selectPillar(Pillar.News),
     }} />
 
 const Review = (): ReactElement =>
     <Standfirst item={{
-        ...item,
-        design: Design.Review,
-        starRating: 4,
+        ...review,
+        standfirst,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
         pillar: selectPillar(Pillar.Culture),
     }} />
 
 const Feature = (): ReactElement =>
     <Standfirst item={{
-        ...item,
-        design: Design.Feature,
+        ...feature,
+        standfirst,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
         pillar: selectPillar(Pillar.Sport),
     }} />
 
 const Comment = (): ReactElement =>
     <Standfirst item={{
-        ...item,
-        design: Design.Comment,
+        ...comment,
+        standfirst,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
         pillar: selectPillar(Pillar.Opinion),
     }} />

--- a/src/components/starRating.stories.tsx
+++ b/src/components/starRating.stories.tsx
@@ -4,37 +4,10 @@ import React, { ReactElement } from 'react';
 import { withKnobs, radios } from '@storybook/addon-knobs';
 
 import StarRating from './starRating';
-import { Item } from 'item';
-import { Pillar, Design, Display } from 'format';
-import { None, Some } from 'types/option';
+import { article, review } from 'fixtures/item';
 
 
 // ----- Setup ----- //
-
-const item: Item = {
-    pillar: Pillar.News,
-    design: Design.Article,
-    display: Display.Standard,
-    body: [],
-    headline: 'Reclaimed lakes and giant airports: how Mexico City might have looked',
-    standfirst: new None(),
-    byline: '',
-    bylineHtml: new None(),
-    publishDate: new None(),
-    mainImage: new None(),
-    contributors: [],
-    series: new Some({
-        id: '',
-        type: 0,
-        webTitle: '',
-        webUrl: '',
-        apiUrl: '',
-        references: [],
-    }),
-    commentable: false,
-    tags: [],
-    shouldHideReaderRevenue: false,
-};
 
 const starRating: Record<number, number> = [0, 1, 2, 3, 4, 5];
 
@@ -43,13 +16,12 @@ const starRating: Record<number, number> = [0, 1, 2, 3, 4, 5];
 
 const Default = (): ReactElement =>
     <StarRating item={{
-        ...item,
-        design: Design.Review,
+        ...review,
         starRating: radios('Rating', starRating, 3),
     }} />
 
 const NotReview = (): ReactElement =>
-    <StarRating item={item} />
+    <StarRating item={article} />
 
 
 // ----- Exports ----- //

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -1,0 +1,77 @@
+// ----- Imports ----- //
+
+import { Pillar, Design, Display } from '@guardian/types/Format';
+
+import { Item, Review } from 'item';
+import { None, Some } from 'types/option';
+import { Image } from 'image';
+
+
+// ----- Fixture ----- //
+
+const fields = {
+    pillar: Pillar.News,
+    display: Display.Standard,
+    body: [],
+    headline: 'Reclaimed lakes and giant airports: how Mexico City might have looked',
+    standfirst: new None<DocumentFragment>(),
+    byline: '',
+    bylineHtml: new None<DocumentFragment>(),
+    publishDate: new None<Date>(),
+    mainImage: new None<Image>(),
+    contributors: [],
+    series: new Some({
+        id: '',
+        type: 0,
+        webTitle: '',
+        webUrl: '',
+        apiUrl: '',
+        references: [],
+    }),
+    commentable: false,
+    tags: [],
+    shouldHideReaderRevenue: false,
+};
+
+const article: Item = {
+    design: Design.Article,
+    ...fields,
+};
+
+const analysis: Item = {
+    design: Design.Analysis,
+    ...fields,
+};
+
+const feature: Item = {
+    design: Design.Feature,
+    ...fields,
+};
+
+const review: Review = {
+    design: Design.Review,
+    starRating: 4,
+    ...fields,
+};
+
+const advertisementFeature: Item = {
+    design: Design.AdvertisementFeature,
+    ...fields,
+};
+
+const comment: Item = {
+    design: Design.Comment,
+    ...fields,
+};
+
+
+// ----- Exports ----- //
+
+export {
+    article,
+    analysis,
+    feature,
+    review,
+    advertisementFeature,
+    comment,
+};


### PR DESCRIPTION
## Why are you doing this?

Reduces duplication in our storybook files. Some inspiration taken from DCR's use of fixture files.

## Changes

- New fixtures file to generate `Item` data structures
- Updated `headline`, `standfirst` and `starRating` to use `Item` fixtures
