### PR TITLE
TS Consistent Filename Casing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "moduleResolution": "node",
         "noUnusedLocals": true,
         "noUnusedParameters": false,
-        "baseUrl": "src/"
+        "baseUrl": "src/",
+        "forceConsistentCasingInFileNames": true
     }
 }


### PR DESCRIPTION
## Why are you doing this?

We've been bitten a few times by macOS's filesystem case insensitivity. This option *should* solve that problem.

See [the docs](https://www.typescriptlang.org/v2/en/tsconfig#forceConsistentCasingInFileNames) for more information.

FYI @oliverlloyd @SiAdcock @jonathonherbert @gtrufitt 

## Changes

- Enabled `forceConsistentCasingInFileNames` in `tsconfig.json`
