### PR TITLE
Remove launch slideshow class from contributor images

### DIFF
--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -38,7 +38,7 @@ const Img: FC<Props> = ({ image, sizes, className }) =>
         styledH('img', {
             src: image.src,
             alt: image.alt.withDefault(''),
-            className: image.launchSlideshow ? 'js-launch-slideshow' : null,
+            className: image.launchSlideshow ? 'js-launch-slideshow' : '',
             css: [styles, className],
             'data-caption': image.nativeCaption.withDefault(''),
             'data-credit': image.credit.withDefault(''),

--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -38,7 +38,7 @@ const Img: FC<Props> = ({ image, sizes, className }) =>
         styledH('img', {
             src: image.src,
             alt: image.alt.withDefault(''),
-            className: 'js-launch-slideshow',
+            className: image.launchSlideshow ? 'js-launch-slideshow' : null,
             css: [styles, className],
             'data-caption': image.nativeCaption.withDefault(''),
             'data-credit': image.credit.withDefault(''),

--- a/src/components/liveblog/avatar.test.tsx
+++ b/src/components/liveblog/avatar.test.tsx
@@ -22,7 +22,8 @@ describe('Avatar component renders as expected', () => {
             caption: new None(),
             alt: new None(),
             role: new None(),
-            nativeCaption: new None()
+            nativeCaption: new None(),
+            launchSlideshow: false
         }),
     }]
     it('Adds correct alt attribute', () => {

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -38,7 +38,8 @@ const parseContributors = (salt: string, content: Content): Contributor[] =>
             caption: new None(),
             alt: new None(),
             role: new None(),
-            nativeCaption: new None()
+            nativeCaption: new None(),
+            launchSlideshow: false
         })),
     }));
 

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -44,6 +44,7 @@ const image: Image = {
     credit: new None(),
     nativeCaption: new None(),
     role: new None(),
+    launchSlideshow: true
 };
 
 

--- a/src/image.ts
+++ b/src/image.ts
@@ -53,6 +53,7 @@ interface Image {
     credit: Option<string>;
     nativeCaption: Option<string>;
     role: Option<Role>;
+    launchSlideshow: boolean;
 }
 
 interface BodyImageProps {
@@ -141,6 +142,7 @@ const parseImage = ({ docParser, salt }: Context) =>
             credit: parseCredit(data?.displayCredit, data?.credit),
             nativeCaption: fromNullable(data?.caption),
             role: parseRole(data?.role),
+            launchSlideshow: true
         });
     });
 };

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -39,7 +39,8 @@ const imageElement = (): BodyElement =>
         credit: new Some('credit'),
         width: 500,
         height: 500,
-        role: new None()
+        role: new None(),
+        launchSlideshow: true
     });
 
 const imageElementWithRole = () =>


### PR DESCRIPTION
## Why are you doing this?

We only want body and header images in the native slideshows.