### PR TITLE
media style fixes

### DIFF
--- a/src/components/media/article.tsx
+++ b/src/components/media/article.tsx
@@ -49,9 +49,10 @@ const Media = ({ item, children }: Props): JSX.Element =>
                 />
                 <div css={articleWidthStyles}>
                     <Series series={item.series} pillar={item.pillar} />
-                    <Headline item={item} />
+                </div>
+                <Headline item={item} />
+                <div css={articleWidthStyles}>
                     <Standfirst item={item} />
-
                 </div>
                 <section>
                     <Byline

--- a/src/components/media/byline.tsx
+++ b/src/components/media/byline.tsx
@@ -6,19 +6,19 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { getPillarStyles, PillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
 import { Option } from 'types/option';
-import Dateline from 'components/dateline';
 import { Item, getFormat } from 'item';
 import { textSans } from "@guardian/src-foundations/typography";
 import { renderText } from "../../renderer";
 import { remSpace } from "@guardian/src-foundations";
+import Dateline from 'components/dateline';
 
 
 // ----- Styles ----- //
 
 const Styles = ({ inverted }: PillarStyles): SerializedStyles => css`
-    
     .author {
         margin: ${remSpace[2]} 0 ${remSpace[3]} 0;
+        color: ${neutral[86]};
 
         .follow, a {
             color: ${inverted};

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -230,7 +230,7 @@ const textElement = (format: Format) => (node: Node, key: number): ReactNode => 
 
 const standfirstTextElement = (format: Format) => (node: Node, key: number): ReactNode => {
     const children = Array.from(node.childNodes).map(standfirstTextElement(format));
-    const colour = getPillarStyles(format.pillar).kicker;
+    const { kicker, inverted } = getPillarStyles(format.pillar);
     switch (node.nodeName) {
         case 'P':
             return h('p', { key }, children);
@@ -239,6 +239,7 @@ const standfirstTextElement = (format: Format) => (node: Node, key: number): Rea
         case 'LI':
             return styledH('li', { css: listItemStyles }, children);
         case 'A': {
+            const colour = format.design === Design.Media ? inverted : kicker;
             const styles = css` color: ${colour}; text-decoration: none`;
             const href = getHref(node).withDefault('');
             return styledH('a', { key, href, css: styles }, children);


### PR DESCRIPTION
## Why are you doing this?

We probably want to reuse some of the parsing logic and components used in article bodies at some stage.

This fixes some current style issues.

## Changes

- Align headline with series and standfirst
- Use white colour in byline

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/84037099-04446080-a996-11ea-9d76-bfa14909a930.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/84037131-0d353200-a996-11ea-8a46-f7a5d7a1f781.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/84053913-8048a380-a9aa-11ea-8126-fbe16820c538.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11618797/84053928-876fb180-a9aa-11ea-8bd2-b0795d3d023f.png" width="300" /> |
 
