### PR TITLE
disable increasing scale

### DIFF
--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -133,7 +133,7 @@ const Head: FC<HeadProps> = ({ webTitle }: HeadProps) =>
     <>
         <title>{webTitle}</title>
         <meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
-        <meta name="viewport" content="initial-scale=1, maximum-scale=5" />
+        <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
         <link rel="stylesheet" href="native://fontSize.css" />
     </>
 


### PR DESCRIPTION
## Why are you doing this?

This is recommended by lighthouse for accessibility but we have other features like text size increasing and galleries (pinch and zoom)

At the moment you can pinch and zoom, this will misalign adverts and other native content.