### PR TITLE
Dark image backgrounds on media pages

### DIFF
--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -48,6 +48,7 @@ const Avatar: FC<Props> = ({ contributors, ...format }: Props) => {
             image={image}
             sizes={dimensions}
             className={getStyles(format)}
+            format={format}
         />
     ).withDefault(null);
 }

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -23,7 +23,6 @@ const styles = css`
 
 const imgStyles = (width: number, height: number): SerializedStyles => css`
     height: calc(100vw * ${height / width});
-    background: ${neutral[97]};
     display: block;
     width: 100%;
     object-fit: cover;
@@ -38,12 +37,13 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     `}
 `;
 
-const BodyImage: FC<BodyImageProps> = ({ image, children }: BodyImageProps) =>
+const BodyImage: FC<BodyImageProps> = ({ image, children, format }: BodyImageProps) =>
     <figure css={styles}>
         <Img
             image={image}
             sizes={sizes}
             className={imgStyles(image.width, image.height)}
+            format={format}
         />
         {children}
     </figure>

--- a/src/components/bodyImageHalfWidth.tsx
+++ b/src/components/bodyImageHalfWidth.tsx
@@ -32,12 +32,13 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     width: 100%;
 `;
 
-const BodyImageHalfWidth: FC<Props> = ({ image }: Props) =>
+const BodyImageHalfWidth: FC<Props> = ({ image, format }: Props) =>
     <figure css={styles} className="halfWidth">
         <Img
             image={image}
             sizes={size}
             className={imgStyles(image.width, image.height)}
+            format={format}
         />
     </figure>;
 

--- a/src/components/bodyImageThumbnail.tsx
+++ b/src/components/bodyImageThumbnail.tsx
@@ -32,12 +32,13 @@ const imgStyles = (width: number, height: number): SerializedStyles => css`
     height: calc(${size} * ${height / width});
 `;
 
-const BodyImageThumbnail: FC<Props> = ({ image, children }: Props) =>
+const BodyImageThumbnail: FC<Props> = ({ image, children, format }: Props) =>
     <figure css={styles}>
         <Img
             image={image}
             sizes={size}
             className={imgStyles(image.width, image.height)}
+            format={format}
         />
         {children}
     </figure>;

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -10,8 +10,8 @@ import { Format, Design } from '@guardian/types/Format';
 import { getPillarStyles } from 'pillarStyles';
 import { Option } from 'types/option';
 import { renderTextElement, getHref } from 'renderer';
-import Anchor from 'components/anchor';
 import { darkModeCss } from 'styles';
+import Anchor from 'components/anchor';
 
 
 // ----- Subcomponents ----- //
@@ -73,7 +73,7 @@ const captionHeadingStyles = css`
     ${headline.xxxsmall()}
     color: ${neutral[86]};
     margin: 0 0 ${remSpace[3]};
-    display: inline;
+    display: block;
 `;
 
 const anchorStyles = css`
@@ -91,7 +91,7 @@ const captionElement = (format: Format) => (node: Node, key: number): ReactNode 
         case 'BR':
             return null;
         case 'EM':
-            return <em css={ textSans.xsmall({ fontStyle: 'italic', fontWeight: 'bold'})} key={key}>{children}</em>
+            return <em css={ css`${textSans.xsmall({ fontStyle: 'italic', fontWeight: 'bold'})}` } key={key}>{children}</em>
         case 'A':
             return (
                 <Anchor

--- a/src/components/headerImage.tsx
+++ b/src/components/headerImage.tsx
@@ -92,8 +92,8 @@ const getStyles = ({ design, display }: Format): SerializedStyles => {
     }
 }
 
-const getImgStyles = ({ display }: Format, image: Image): SerializedStyles => {
-    switch (display) {
+const getImgStyles = (format: Format, image: Image): SerializedStyles => {
+    switch (format.display) {
         case Display.Immersive:
             return immersiveImgStyles;
         default:
@@ -123,6 +123,7 @@ const HeaderImage: FC<Props> = ({ className, image, format }) =>
                 image={imageData}
                 sizes={getSizes(format, imageData)}
                 className={getImgStyles(format, imageData)}
+                format={format}
             />
             <Caption format={format} image={imageData} />
         </figure>

--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -6,6 +6,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 
 import { Image } from 'image';
 import { darkModeCss } from 'styles';
+import { Format, Design } from '@guardian/types/Format';
 
 
 // ----- Component ----- //
@@ -14,17 +15,19 @@ interface Props {
     image: Image;
     sizes: string;
     className?: SerializedStyles;
+    format?: Format;
 }
 
-const styles = css`
-    background-color: ${neutral[97]};
+const styles = (format?: Format): SerializedStyles => css`
+    background-color: ${format?.design === Design.Media ? neutral[20] : neutral[97]};
+
     ${darkModeCss`
         color: ${neutral[60]};
         background-color: ${neutral[20]};
     `}
 `;
 
-const Img: FC<Props> = ({ image, sizes, className }) =>
+const Img: FC<Props> = ({ image, sizes, className, format }) =>
     h('picture', null, [
         h('source', {
             sizes,
@@ -39,7 +42,7 @@ const Img: FC<Props> = ({ image, sizes, className }) =>
             src: image.src,
             alt: image.alt.withDefault(''),
             className: image.launchSlideshow ? 'js-launch-slideshow' : '',
-            css: [styles, className],
+            css: [styles(format), className],
             'data-caption': image.nativeCaption.withDefault(''),
             'data-credit': image.credit.withDefault(''),
         }),

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -64,11 +64,6 @@ const media = css`
         ${headline.xxxsmall({ lineHeight: 'loose' })}
         margin: 0;
     }
-    
-    li:before {
-        height: 0.7rem;
-        width: 0.7rem;
-    }
 `;
 
 const advertisementFeature = css`

--- a/src/image.ts
+++ b/src/image.ts
@@ -6,6 +6,7 @@ import { createHash } from 'crypto';
 import { Option, Some, None, fromNullable } from 'types/option';
 import { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { Context } from 'types/parserContext';
+import { Format } from '@guardian/types/Format';
 
 
 // ----- Setup ----- //
@@ -59,6 +60,7 @@ interface Image {
 interface BodyImageProps {
     image: Image;
     children?: ReactNode;
+    format: Format;
 }
 
 // ----- Functions ----- //

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -433,7 +433,7 @@ const render = (format: Format, excludeStyles = false) =>
                 ? h(FigCaption, { format, caption, credit })
                 : null;
 
-            return h(ImageComponent, { image: element }, figcaption);
+            return h(ImageComponent, { image: element, format }, figcaption);
         }
 
         case ElementKind.Pullquote: {


### PR DESCRIPTION
## Changes

- Pass `format` into image component to use a dark background on media pages
- Reuse bullet point sizes on gallery articles
- Make headers `display: block`

