### PR TITLE
add dpr to image url

### DIFF
--- a/src/image.ts
+++ b/src/image.ts
@@ -78,6 +78,7 @@ function src(salt: string, input: string, width: number, dpr: Dpr): string {
     const params = new URLSearchParams({
         width: width.toString(),
         quality: dpr === Dpr.Two ? lowerQuality.toString() : defaultQuality.toString(),
+        dpr: dpr === Dpr.Two ? "2" : "1",
         fit: 'bounds',
         'sig-ignores-params': 'true',
         s: sign(salt, url.pathname),


### PR DESCRIPTION
## Why are you doing this?

I noticed blurry images even when using `currentSrc` https://github.com/guardian/apps-rendering/pull/381

It looks like we use a lower quality but not a higher dpr. Dotcom use a dpr of 2 and a quality of 85 so should we use that for all of our images?