### PR TITLE
handle another case of linking to author profiles

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -242,7 +242,8 @@ const standfirstTextElement = (format: Format) => (node: Node, key: number): Rea
         case 'A': {
             const colour = format.design === Design.Media ? inverted : kicker;
             const styles = css` color: ${colour}; text-decoration: none`;
-            const href = getHref(node).withDefault('');
+            const url = getHref(node).withDefault('')
+            const href = url.startsWith('profile/') ? `https://www.theguardian.com/${url}` : url
             return styledH('a', { key, href, css: styles }, children);
         }
         default:


### PR DESCRIPTION
## Why are you doing this?

Profile links in immersive standfirsts (bylines can be inside) go to https://mobile.guardianapis.com/profile/steve. If we rewrite the relative links to be absolute dotcom links, the apps can handle them and display the author pages.

This might be a bit brittle, so we could:
- Redirect to dotcom in MAPI
- Add logic on iOS/Android to recognise `/profile/<NAME>` links
- Clean all the html from capi (what happened to sharing the cleaner with dotcom?)

http://localhost:8080/society/2020/jun/11/we-locked-down-a-week-early-the-scottish-care-home-with-no-coronavirus-cases
