### PR TITLE
match standfirst font used on other articles

### DIFF
--- a/src/components/liveblog/headline.tsx
+++ b/src/components/liveblog/headline.tsx
@@ -5,12 +5,13 @@ import LeftColumn from 'components/shared/leftColumn';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
 import { headline } from '@guardian/src-foundations/typography';
+import { remSpace } from '@guardian/src-foundations';
 
 const LiveblogHeadlineStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     background: ${kicker};
     h1 {
         ${headline.medium()};
-        margin: 0;
+        margin: 0 0 ${remSpace[6]} 0;
         color: ${neutral[100]};
     }
 `;

--- a/src/components/liveblog/standfirst.tsx
+++ b/src/components/liveblog/standfirst.tsx
@@ -6,10 +6,15 @@ import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Format } from 'format';
 import { renderText } from 'renderer';
 import { Option } from 'types/option';
+import { headline } from '@guardian/src-foundations/typography';
 
 const StandfirstStyles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
     background: ${liveblogBackground};
     color: ${neutral[97]};
+
+    p, li {
+        ${headline.xxxsmall({ fontWeight: 'bold' })}
+    }
 
     a {
         color: ${neutral[93]};


### PR DESCRIPTION
# Changes

- Use headline font for liveblog standfirsts
- Add margin underneath liveblog headline

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/84642503-7831bc00-aef4-11ea-8267-276b2779c9c2.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/84642521-8089f700-aef4-11ea-8884-360128df87cd.png" width="300px" /> |

