### PR TITLE
remove background colour on thumbnail images

### DIFF
--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -4,9 +4,10 @@ import { createElement as h, FC } from 'react';
 import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 
-import { Image } from 'image';
+import { Image, Role } from 'image';
 import { darkModeCss } from 'styles';
 import { Format, Design } from '@guardian/types/Format';
+import { Option } from 'types/option';
 
 
 // ----- Component ----- //
@@ -18,14 +19,19 @@ interface Props {
     format?: Format;
 }
 
-const styles = (format?: Format): SerializedStyles => css`
-    background-color: ${format?.design === Design.Media ? neutral[20] : neutral[97]};
-
-    ${darkModeCss`
+const styles = (role: Option<Role>, format?: Format): SerializedStyles => {
+    const darkModeStyles = darkModeCss`
         color: ${neutral[60]};
         background-color: ${neutral[20]};
-    `}
-`;
+    `
+
+    return role.fmap(imageRole => imageRole).withDefault(Role.HalfWidth) === Role.Thumbnail
+        ? darkModeStyles
+        : css`
+            background-color: ${format?.design === Design.Media ? neutral[20] : neutral[97]};
+            ${darkModeStyles}
+        `
+}
 
 const Img: FC<Props> = ({ image, sizes, className, format }) =>
     h('picture', null, [
@@ -42,7 +48,7 @@ const Img: FC<Props> = ({ image, sizes, className, format }) =>
             src: image.src,
             alt: image.alt.withDefault(''),
             className: image.launchSlideshow ? 'js-launch-slideshow' : '',
-            css: [styles(format), className],
+            css: [styles(image.role, format), className],
             'data-caption': image.nativeCaption.withDefault(''),
             'data-credit': image.credit.withDefault(''),
         }),

--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -20,16 +20,13 @@ interface Props {
 }
 
 const styles = (role: Option<Role>, format?: Format): SerializedStyles => {
-    const darkModeStyles = darkModeCss`
-        color: ${neutral[60]};
-        background-color: ${neutral[20]};
-    `
-
+    const backgroundColour = format?.design === Design.Media ? neutral[20] : neutral[97];
     return role.fmap(imageRole => imageRole).withDefault(Role.HalfWidth) === Role.Thumbnail
-        ? darkModeStyles
+        ? css`color: ${neutral[60]};`
         : css`
-            background-color: ${format?.design === Design.Media ? neutral[20] : neutral[97]};
-            ${darkModeStyles}
+            background-color: ${backgroundColour};
+            ${darkModeCss`background-color: ${neutral[20]};`}
+            color: ${neutral[60]};
         `
 }
 


### PR DESCRIPTION
## Changes

- Thumbnail images can be round avatars so we shouldn't add a background colour

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/84642813-e8404200-aef4-11ea-823f-011958020e5f.PNG" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/84643106-4bca6f80-aef5-11ea-912a-87210ddad3f9.png" width="300px" /> |
