### PR TITLE
use click rather than touchstart

### DIFF
--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -71,7 +71,7 @@ function topics(): void {
     const topic = getTopic(follow);
 
     if (topic) {
-        follow?.addEventListener('touchstart', topicClick);
+        follow?.addEventListener('click', topicClick);
         notificationsClient.isFollowing(topic).then(following => {
             if (following && status?.textContent) {
                 status.textContent = followingText;

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -59,7 +59,7 @@ function ads(): void {
             insertAds();
             Array.from(document.querySelectorAll('.ad-labels'))
                 .forEach(adLabel => {
-                    adLabel.addEventListener('touchstart', () => {
+                    adLabel.addEventListener('click', () => {
                         acquisitionsClient.launchFrictionScreen();
                     })
                 })

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -105,7 +105,7 @@ export const adStyles = css`
                 line-height: 24px;
 
                 span {
-                    margin-right: 24px;
+                    margin-right: 30px;
                 }
 
                 &::focus, &::hover, &::active {
@@ -116,7 +116,7 @@ export const adStyles = css`
                     padding-left: ${basePx(1)};
                     ${icons}
                     content: "\\e04F";
-                    font-size: 16px;
+                    font-size: 20px;
                     position: absolute;
                     right: 0px;
                     top: -2px;


### PR DESCRIPTION
## Why are you doing this?

Use click instead of touchstart. Touchstart is more performant and fires quicker but it's easy to trigger when scrolling down the article.

If we detect any slowness related to the Bridget APIs we should probably optimise the thrift message handling code on iOS/Android and apps-rendering.
