### PR TITLE
Jest Watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "copy-fonts": "cp -R assets/fonts dist/assets/fonts",
     "test": "jest --verbose",
     "test:coverage": "npm run test; open coverage/index.html",
+    "test:watch": "jest --watch",
     "lint": "node_modules/eslint/bin/eslint.js -c config/.eslintrc.js ./ --ext '.ts,.tsx'",
     "watch:server": "webpack --config webpack.config.js --config-name server --env.watch",
     "watch:client": "webpack-dev-server --config webpack.config.js --config-name client",


### PR DESCRIPTION
## Why are you doing this?

This is pretty handy, saves you running the entire test suite repeatedly whenever you're writing tests 🙂.

## Changes

- Added `test:watch` script
