### PR TITLE
Filter Lightbox/Slideshow By Width

### DIFF
--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -44,7 +44,7 @@ const Img: FC<Props> = ({ image, sizes, className, format }) =>
         styledH('img', {
             src: image.src,
             alt: image.alt.withDefault(''),
-            className: image.launchSlideshow ? 'js-launch-slideshow' : '',
+            className: image.width > 620 ? 'js-launch-slideshow' : '',
             css: [styles(image.role, format), className],
             'data-caption': image.nativeCaption.withDefault(''),
             'data-credit': image.credit.withDefault(''),

--- a/src/components/liveblog/avatar.test.tsx
+++ b/src/components/liveblog/avatar.test.tsx
@@ -23,7 +23,6 @@ describe('Avatar component renders as expected', () => {
             alt: new None(),
             role: new None(),
             nativeCaption: new None(),
-            launchSlideshow: false
         }),
     }]
     it('Adds correct alt attribute', () => {

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -39,7 +39,6 @@ const parseContributors = (salt: string, content: Content): Contributor[] =>
             alt: new None(),
             role: new None(),
             nativeCaption: new None(),
-            launchSlideshow: false
         })),
     }));
 

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -42,7 +42,6 @@ const image: Image = {
     credit: new None(),
     nativeCaption: new None(),
     role: new None(),
-    launchSlideshow: true
 };
 
 

--- a/src/image.ts
+++ b/src/image.ts
@@ -54,7 +54,6 @@ interface Image {
     credit: Option<string>;
     nativeCaption: Option<string>;
     role: Option<Role>;
-    launchSlideshow: boolean;
 }
 
 interface BodyImageProps {
@@ -144,7 +143,6 @@ const parseImage = ({ docParser, salt }: Context) =>
             credit: parseCredit(data?.displayCredit, data?.credit),
             nativeCaption: fromNullable(data?.caption),
             role: parseRole(data?.role),
-            launchSlideshow: true
         });
     });
 };

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -40,7 +40,6 @@ const imageElement = (): BodyElement =>
         width: 500,
         height: 500,
         role: new None(),
-        launchSlideshow: true
     });
 
 const imageElementWithRole = () =>


### PR DESCRIPTION
## Why are you doing this?

Only show images in the lightbox/slideshow if their width is greater than `620`. Brings AR into line with the [logic on dotcom](https://github.com/guardian/frontend/blob/2f8b53c7bac3a9c1933837d93a54809661499064/common/app/model/content.scala#L514).

## Changes

- Applied the slideshow class for `width > 620`
- Removed the `launchSlideshow` property from `Image`
