### PR TITLE
Dump the ad targeting params into a script tag

### DIFF
--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -14,7 +14,7 @@ import LiveblogArticle from 'components/liveblog/article';
 import Opinion from 'components/opinion/article';
 import Media from 'components/media/article';
 import Interactive from 'components/interactive/article';
-import { Content } from '@guardian/content-api-models/v1/content';
+import { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import { includesTweets } from 'capi';
 import { renderAll, renderAllWithoutStyles } from 'renderer';
 import { partition } from 'types/result';
@@ -159,12 +159,12 @@ const styles = `
 
 function page(
     imageSalt: string,
-    content: Content,
+    renderingRequest: RenderingRequest,
     getAssetLocation: (assetName: string) => string,
 ): Page {
-    const item = fromCapi({ docParser, salt: imageSalt })(content);
-    const shouldHideAds = content.fields?.shouldHideAdverts ?? false;
-    const hasTwitter = includesTweets(content);
+    const item = fromCapi({ docParser, salt: imageSalt })(renderingRequest.content);
+    const shouldHideAds = renderingRequest.content.fields?.shouldHideAdverts ?? false;
+    const hasTwitter = includesTweets(renderingRequest.content);
     const clientScript = scriptName(item).fmap(getAssetLocation);
     const { html: body, css, ids } = compose(extractCritical, renderToString)(
         <CacheProvider value={cache}>
@@ -175,13 +175,16 @@ function page(
     const html = `
         <html lang="en">
             <head>
-                ${renderToString(<Head webTitle={content.webTitle} />)}
+                ${renderToString(<Head webTitle={renderingRequest.content.webTitle} />)}
                 <meta
                     http-equiv="Content-Security-Policy"
                     content="${cspString}"
                 />
                 <style>${styles}</style>
                 <style data-emotion-css="${ids.join(' ')}">${css}</style>
+                <script id="targetingParams" type="application/json">
+                    ${JSON.stringify(renderingRequest.targetingParams)}
+                </script>
             </head>
             <body>
                 ${body}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -138,7 +138,11 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
                         "k": "potato,tomato,avocado"
                     }
                 };
-                const { html, clientScript } = page(imageSalt, mockedRenderingRequest, getAssetLocation);
+                const { html, clientScript } = page(
+                    imageSalt,
+                    mockedRenderingRequest,
+                    getAssetLocation
+                );
                 res.set('Link', getPrefetchHeader(clientScript.fmap(toArray).withDefault([])));
                 res.write('<!DOCTYPE html>');
                 res.write('<meta charset="UTF-8" />');

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -21,6 +21,7 @@ import { getMappedAssetLocation } from './assets';
 import { response } from './liveblogResponse';
 import { mapiDecoder, capiDecoder, errorDecoder } from 'server/decoders';
 import { Result, Ok, Err } from 'types/result';
+import { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import { Content } from '@guardian/content-api-models/v1/content';
 import { ContentType } from '@guardian/content-api-models/v1/contentType';
 import {
@@ -106,7 +107,7 @@ async function serveArticlePost(
         const renderingRequest = await mapiDecoder(body);
         const imageSalt = await getConfigValue<string>('apis.img.salt');
 
-        const { html, clientScript } = page(imageSalt, renderingRequest.content, getAssetLocation);
+        const { html, clientScript } = page(imageSalt, renderingRequest, getAssetLocation);
         res.set('Link', getPrefetchHeader(clientScript.fmap(toArray).withDefault([])));
         res.write('<!DOCTYPE html>');
         res.write(html);
@@ -130,7 +131,14 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
         capiContent.either(
             errorStatus => { res.sendStatus(errorStatus) },
             content => {
-                const { html, clientScript } = page(imageSalt, content, getAssetLocation);
+                const mockedRenderingRequest: RenderingRequest = {
+                    content: content,
+                    targetingParams: {
+                        "co": "Jane Smith",
+                        "k": "potato,tomato,avocado"
+                    }
+                };
+                const { html, clientScript } = page(imageSalt, mockedRenderingRequest, getAssetLocation);
                 res.set('Link', getPrefetchHeader(clientScript.fmap(toArray).withDefault([])));
                 res.write('<!DOCTYPE html>');
                 res.write('<meta charset="UTF-8" />');

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -132,7 +132,7 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
             errorStatus => { res.sendStatus(errorStatus) },
             content => {
                 const mockedRenderingRequest: RenderingRequest = {
-                    content: content,
+                    content,
                     targetingParams: {
                         "co": "Jane Smith",
                         "k": "potato,tomato,avocado"


### PR DESCRIPTION
## Why are you doing this?
To enable the native side of the apps to access to the targeting data.

## Changes

- Use the RenderingRequest type in the `page` function
- Dump the targeting params in a script tag

## Screenshots
No change (promise!)
