### PR TITLE
Pass the targeting data to the native side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4613,9 +4613,9 @@
       "integrity": "sha512-Uug54iosZNTOcoSsRQ4GyEIUUiA5Dg+0ikrkQJOP+wSFdGhoYKBGcS39COXZ0V8xcij/hnopiIJeOVxMW3x5Uw=="
     },
     "@guardian/bridget": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-0.60.0.tgz",
-      "integrity": "sha512-6bjeYv5+F3Aj9MqxEkdn1bYWhgrf/B5lFe7N9s4Wa8s1CbYhd+wVKkPYa1lc6nyf0k2IBRyUkN1W5C2eAW2eXg=="
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-0.61.0.tgz",
+      "integrity": "sha512-1uE/km9zPOzbWK/QI8jcUFhy8G0JHVGcz9fTUMhXRVjgdqQC8bqt94XgYHeW2lO0xvQ0OyrCffjZUdChgnhZlA=="
     },
     "@guardian/content-api-models": {
       "version": "15.9.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
     "@guardian/atoms-rendering": "^1.3.3",
-    "@guardian/bridget": "^0.60.0",
+    "@guardian/bridget": "^0.61.0",
     "@guardian/content-api-models": "^15.9.1",
     "@guardian/content-atom-model": "^3.2.2",
     "@guardian/apps-rendering-api-models": "^0.4.0",

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -9,7 +9,8 @@ const getTargetingParams: () => Map<string, string> = memoise(() => {
     const parsed = JSON.parse(content);
     const map: Map<string, string> = new Map();
     for (const key in parsed) {
-        if (parsed.hasOwnProperty(key) && typeof parsed[key] === 'string') {
+        if (Object.prototype.hasOwnProperty.call(parsed.hasOwnProperty, key) &&
+            typeof parsed[key] === 'string') {
             map.set(key, parsed[key]);
         }
     }

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -2,7 +2,7 @@ import { AdSlot } from "@guardian/bridget/AdSlot";
 import { Image } from "@guardian/bridget/Image";
 import { commercialClient, galleryClient, userClient, acquisitionsClient } from "../native/nativeApi";
 import { logger } from "../logger";
-import {memoise} from "../lib";
+import { memoise } from "../lib";
 
 const getTargetingParams: () => Map<string, string> = memoise(() => {
     const content = document.getElementById('targeting-params')?.innerHTML ?? '{}';

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -2,9 +2,23 @@ import { AdSlot } from "@guardian/bridget/AdSlot";
 import { Image } from "@guardian/bridget/Image";
 import { commercialClient, galleryClient, userClient, acquisitionsClient } from "../native/nativeApi";
 import { logger } from "../logger";
+import {memoise} from "../lib";
+
+const getTargetingParams: () => Map<string, string> = memoise(() => {
+    const content = document.getElementById('targeting-params')?.innerHTML ?? '{}';
+    const parsed = JSON.parse(content);
+    const map: Map<string, string> = new Map();
+    for (const key in parsed) {
+        if (parsed.hasOwnProperty(key) && typeof parsed[key] === 'string') {
+            map.set(key, parsed[key]);
+        }
+    }
+    return map;
+});
 
 function getAdSlots(): AdSlot[] {
     const advertSlots = document.getElementsByClassName('ad-slot');
+    const targetingParams = getTargetingParams();
 
     if (!advertSlots) {
         return [];
@@ -21,7 +35,8 @@ function getAdSlots(): AdSlot[] {
             x: slotPosition.left + scrollLeft,
             y: slotPosition.top + scrollTop,
             width: slotPosition.width,
-            height: slotPosition.height
+            height: slotPosition.height,
+            targetingParams
         })
     });
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -13,12 +13,13 @@ const toArray = Array.of.bind(null);
 
 function memoise<A>(fn: () => A): () => A {
     let state: A | null = null;
-    return () => {
+    const memoised: () => A = () => {
         if (!state) {
             state = fn();
         }
-        return state
-    }
+        return state;
+    };
+    return memoised;
 }
 
 // ----- Exports ----- //

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -11,6 +11,15 @@ function isElement(node: Node): node is Element {
 
 const toArray = Array.of.bind(null);
 
+function memoise<A>(fn: () => A): () => A {
+    let state: A | null = null;
+    return () => {
+        if (!state) {
+            state = fn();
+        }
+        return state
+    }
+}
 
 // ----- Exports ----- //
 
@@ -19,4 +28,5 @@ export {
     identity,
     isElement,
     toArray,
+    memoise
 };

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -182,7 +182,7 @@ function page(
                 />
                 <style>${styles}</style>
                 <style data-emotion-css="${ids.join(' ')}">${css}</style>
-                <script id="targetingParams" type="application/json">
+                <script id="targeting-params" type="application/json">
                     ${JSON.stringify(renderingRequest.targetingParams)}
                 </script>
             </head>


### PR DESCRIPTION
## Why are you doing this?

To pass all the required ad targeting data to render the ads

## Changes

- Bump Bridget (no one got hurt)
- Parse the targeting data and send it to the native layer

I've "memoised" the function that loads the ad targeting data such that if it's called a second time it doesn't need to parse the JSON again.

## Screenshots
Hasn't changed!
