### PR TITLE
use ellipsis for overflowing tags

### DIFF
--- a/src/components/shared/tags.tsx
+++ b/src/components/shared/tags.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/core'
-import { darkModeCss, basePx } from '../../styles';
+import { darkModeCss } from '../../styles';
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, background } from '@guardian/src-foundations/palette';
+import { remSpace } from '@guardian/src-foundations';
 
 const tagsStyles = (background: string = neutral[97]): SerializedStyles => css`
     margin-top: 0;
@@ -10,11 +11,11 @@ const tagsStyles = (background: string = neutral[97]): SerializedStyles => css`
 
     display: block;
     list-style: none;
-    padding: ${basePx(1, 0, 2, 0)};
+    padding: ${remSpace[2]} 0 ${remSpace[4]} 0;
     ${textSans.medium()}
 
     li {
-        margin: ${basePx(1, 1, 0, 0)};
+        margin: ${remSpace[2]} ${remSpace[2]} 0 0;
         display: inline-block;
 
         a {

--- a/src/components/shared/tags.tsx
+++ b/src/components/shared/tags.tsx
@@ -14,9 +14,8 @@ const tagsStyles = (background: string = neutral[97]): SerializedStyles => css`
     ${textSans.medium()}
 
     li {
-        margin: ${basePx(1, 1, .5, 0)};
+        margin: ${basePx(1, 1, 0, 0)};
         display: inline-block;
-        padding: ${basePx(.5, 0)};
 
         a {
             text-decoration: none;
@@ -27,6 +26,9 @@ const tagsStyles = (background: string = neutral[97]): SerializedStyles => css`
             max-width: 18.75rem;
             color: ${neutral[7]};
             background-color: ${background};
+            display: inline-block;
+            white-space: nowrap;
+            overflow: hidden;
         }
     }
 `;


### PR DESCRIPTION
## Why are you doing this?
The tags on this article were overflowing, causing a white space to the right of the article.
This PR uses ellipsis for long tags.

https://www.theguardian.com/environment/2020/jun/22/uk-arts-leading-figures-join-call-for-green-recovery-from-coronavirus-crisis

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/85272012-81320880-b473-11ea-9a80-98a0614446d1.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/85272126-aa529900-b473-11ea-887d-69baffeceb99.png" width="300px" /> |
