### PR TITLE
show paid content logo on advertisement features

### DIFF
--- a/src/capi.ts
+++ b/src/capi.ts
@@ -7,15 +7,20 @@ import { TagType } from '@guardian/content-api-models/v1/tagType';
 import { BlockElement} from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import { CapiDateTime } from '@guardian/content-api-models/v1/capiDateTime'
-import { Option, fromNullable } from 'types/option';
+import { Option, fromNullable, None, Some } from 'types/option';
 import { fromString as dateFromString } from 'date';
-
 
 // ----- Lookups ----- //
 
 interface Series {
     webTitle?: string;
     webUrl?: string;
+}
+
+interface Logo {
+    src: string;
+    url: string;
+    alt: string;
 }
 
 const tagsOfType = (tagType: TagType) => (tags: Tag[]): Tag[] =>
@@ -63,6 +68,17 @@ const includesTweets = (content: Content): boolean => {
         .some(Boolean)
 }
 
+const paidContentLogo = (tags: Tag[]): Option<Logo> => {
+    const sponsorship = tags
+        .find(tag => tag.type === TagType.PAID_CONTENT)?.activeSponsorships?.pop();
+    const src = sponsorship?.sponsorLogo;
+    const url = sponsorship?.sponsorLink;
+    const alt = sponsorship?.sponsorName ?? "";
+    return (!src || !url)
+        ? new None()
+        : new Some({ src, url, alt })
+}
+
 
 // ----- Functions ----- //
 
@@ -104,6 +120,7 @@ const maybeCapiDate = (date: CapiDateTime | undefined): Option<Date> =>
 
 export {
     Series,
+    Logo,
     isPhotoEssay,
     isImmersive,
     isInteractive,
@@ -116,4 +133,5 @@ export {
     capiEndpoint,
     includesTweets,
     maybeCapiDate,
+    paidContentLogo,
 };

--- a/src/components/advertisementFeature/article.tsx
+++ b/src/components/advertisementFeature/article.tsx
@@ -13,7 +13,7 @@ import Body from 'components/shared/articleBody';
 import Metadata from 'components/metadata';
 import { darkModeCss, articleWidthStyles } from 'styles';
 import { Keyline } from 'components/shared/keyline';
-import { Standard, getFormat } from 'item';
+import { AdvertisementFeature, getFormat } from 'item';
 import Logo from './logo';
 
 
@@ -41,7 +41,7 @@ const BorderStyles = css`
 // ----- Component ----- //
 
 interface Props {
-    item: Standard;
+    item: AdvertisementFeature;
     children: ReactNode[];
 }
 
@@ -63,7 +63,7 @@ const AdvertisementFeature = ({ item, children }: Props): JSX.Element => {
                 <Keyline {...item} />
                 <section css={articleWidthStyles}>
                     <Metadata item={item} />
-                    <Logo item={item}/>
+                    {item.logo.fmap(props => <Logo logo={props} />).withDefault(<></>)}
                 </section>
             </header>
             <Body className={[articleWidthStyles]}>

--- a/src/components/advertisementFeature/article.tsx
+++ b/src/components/advertisementFeature/article.tsx
@@ -14,6 +14,7 @@ import Metadata from 'components/metadata';
 import { darkModeCss, articleWidthStyles } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { Standard, getFormat } from 'item';
+import Logo from './logo';
 
 
 // ----- Styles ----- //
@@ -62,6 +63,7 @@ const AdvertisementFeature = ({ item, children }: Props): JSX.Element => {
                 <Keyline {...item} />
                 <section css={articleWidthStyles}>
                     <Metadata item={item} />
+                    <Logo item={item}/>
                 </section>
             </header>
             <Body className={[articleWidthStyles]}>

--- a/src/components/advertisementFeature/logo.tsx
+++ b/src/components/advertisementFeature/logo.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Item } from 'item';
+import { TagType } from '@guardian/content-api-models/v1/tagType';
+import { css } from '@emotion/core';
+import { textSans } from '@guardian/src-foundations/typography';
+
+interface Props {
+    item: Item;
+}
+
+const styles = css`
+    display: flex;
+    justify-content: space-between;
+    ${textSans.medium()}
+`;
+
+const Logo = ({ item }: Props): JSX.Element => {
+    const sponsorship = item.tags.find(tag => tag.type === TagType.PAID_CONTENT)?.activeSponsorships?.pop()
+    const logo = sponsorship?.sponsorLogo;
+    const link = sponsorship?.sponsorLink;
+    const alt = sponsorship?.sponsorName ?? "";
+
+    if (!logo || !link) return <></>;
+
+    return <section css={styles}>
+        <span>Paid for by</span>
+        <span>
+            <a href={link}>
+                <img src={logo} alt={alt} />
+            </a>
+        </span>
+    </section>
+}
+
+
+export default Logo;

--- a/src/components/advertisementFeature/logo.tsx
+++ b/src/components/advertisementFeature/logo.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import { Item } from 'item';
-import { TagType } from '@guardian/content-api-models/v1/tagType';
 import { css } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography';
 import { darkModeCss } from 'styles';
 import { remSpace, neutral, text } from '@guardian/src-foundations';
+import { Logo } from 'capi';
 
 interface Props {
-    item: Item;
+    logo: Logo;
 }
 
 const styles = css`
@@ -25,24 +24,15 @@ const styles = css`
     `}
 `;
 
-const Logo = ({ item }: Props): JSX.Element => {
-    const sponsorship = item.tags
-        .find(tag => tag.type === TagType.PAID_CONTENT)?.activeSponsorships?.pop();
-    const logo = sponsorship?.sponsorLogo;
-    const link = sponsorship?.sponsorLink;
-    const alt = sponsorship?.sponsorName ?? "";
-
-    if (!logo || !link) return <></>;
-
-    return <section css={styles}>
+const Logo = ({ logo }: Props): JSX.Element =>
+    <section css={styles}>
         <span>Paid for by</span>
         <span>
-            <a href={link}>
-                <img src={logo} alt={alt} />
+            <a href={logo.url}>
+                <img src={logo.src} alt={logo.alt} />
             </a>
         </span>
     </section>
-}
 
 
 export default Logo;

--- a/src/components/advertisementFeature/logo.tsx
+++ b/src/components/advertisementFeature/logo.tsx
@@ -3,6 +3,8 @@ import { Item } from 'item';
 import { TagType } from '@guardian/content-api-models/v1/tagType';
 import { css } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography';
+import { darkModeCss } from 'styles';
+import { remSpace, neutral, text } from '@guardian/src-foundations';
 
 interface Props {
     item: Item;
@@ -12,6 +14,15 @@ const styles = css`
     display: flex;
     justify-content: space-between;
     ${textSans.medium()}
+    color: ${text.supporting};
+
+    ${darkModeCss`
+        color: ${neutral[60]};
+        img {
+            padding: ${remSpace[2]};
+            background: ${neutral[86]};
+        }
+    `}
 `;
 
 const Logo = ({ item }: Props): JSX.Element => {

--- a/src/components/advertisementFeature/logo.tsx
+++ b/src/components/advertisementFeature/logo.tsx
@@ -26,7 +26,8 @@ const styles = css`
 `;
 
 const Logo = ({ item }: Props): JSX.Element => {
-    const sponsorship = item.tags.find(tag => tag.type === TagType.PAID_CONTENT)?.activeSponsorships?.pop()
+    const sponsorship = item.tags
+        .find(tag => tag.type === TagType.PAID_CONTENT)?.activeSponsorships?.pop();
     const logo = sponsorship?.sponsorLogo;
     const link = sponsorship?.sponsorLink;
     const alt = sponsorship?.sponsorName ?? "";

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -56,6 +56,7 @@ const review: Review = {
 
 const advertisementFeature: Item = {
     design: Design.AdvertisementFeature,
+    logo: new None(),
     ...fields,
 };
 

--- a/src/item.ts
+++ b/src/item.ts
@@ -63,7 +63,10 @@ interface Interactive extends Fields {
 // Catch-all for other Designs for now. As coverage of Designs increases,
 // this will likely be split out into each Design type.
 interface Standard extends Fields {
-    design: Exclude<Design, Design.Live | Design.Review | Design.Comment | Design.AdvertisementFeature>;
+    design: Exclude<Design, Design.Live |
+        Design.Review |
+        Design.Comment |
+        Design.AdvertisementFeature>;
     body: Body;
 }
 

--- a/src/item.ts
+++ b/src/item.ts
@@ -7,7 +7,7 @@ import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import { Element } from '@guardian/content-api-models/v1/element';
 import { Asset } from '@guardian/content-api-models/v1/asset';
 import { AssetType } from '@guardian/content-api-models/v1/assetType';
-import { articleMainImage, articleSeries, isPhotoEssay, isImmersive, isInteractive, maybeCapiDate } from 'capi';
+import { articleMainImage, articleSeries, isPhotoEssay, isImmersive, isInteractive, maybeCapiDate, paidContentLogo, Logo } from 'capi';
 import { Option, fromNullable } from 'types/option';
 import { Format, Pillar, Design, Display } from 'format';
 import { Image as ImageData, parseImage } from 'image';
@@ -15,7 +15,6 @@ import { LiveBlock, parseMany as parseLiveBlocks } from 'liveBlock';
 import { Body, parseElements } from 'bodyElement';
 import { Context } from 'types/parserContext';
 import { Contributor, parseContributors } from 'contributor';
-
 
 // ----- Item Type ----- //
 
@@ -45,6 +44,12 @@ interface Review extends Fields {
     starRating: number;
 }
 
+interface AdvertisementFeature extends Fields {
+    design: Design.AdvertisementFeature;
+    body: Body;
+    logo: Option<Logo>;
+}
+
 interface Comment extends Fields {
     design: Design.Comment;
     body: Body;
@@ -58,7 +63,7 @@ interface Interactive extends Fields {
 // Catch-all for other Designs for now. As coverage of Designs increases,
 // this will likely be split out into each Design type.
 interface Standard extends Fields {
-    design: Exclude<Design, Design.Live | Design.Review | Design.Comment>;
+    design: Exclude<Design, Design.Live | Design.Review | Design.Comment | Design.AdvertisementFeature>;
     body: Body;
 }
 
@@ -68,6 +73,7 @@ type Item
     | Comment
     | Standard
     | Interactive
+    | AdvertisementFeature
     ;
 
 
@@ -267,6 +273,7 @@ const fromCapi = (context: Context) => (content: Content): Item => {
         return {
             design: Design.AdvertisementFeature,
             ...itemFieldsWithBody(context, content),
+            logo: paidContentLogo(content.tags),
         };
     }
 
@@ -284,6 +291,7 @@ export {
     Comment,
     Liveblog,
     Review,
+    AdvertisementFeature,
     Standard,
     fromCapi,
     fromCapiLiveBlog,

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -60,7 +60,7 @@ const assetHashes = (assets: string[]): string =>
 const buildCsp = ({ styles, scripts }: Assets, twitter: boolean): string => `
     default-src 'self';
     style-src ${assetHashes(styles)} https://interactive.guim.co.uk ${twitter ? 'https://platform.twitter.com' : ''};
-    img-src 'self' https://*.guim.co.uk ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:' : ''};
+    img-src 'self' https://*.theguardian.com https://*.guim.co.uk ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:' : ''};
     script-src 'self' ${assetHashes(scripts)} http://www.instagram.com/embed.js https://interactive.guim.co.uk https://s16.tiktokcdn.com https://www.tiktok.com/embed.js ${twitter ? 'https://platform.twitter.com https://cdn.syndication.twimg.com' : ''};
     frame-src https://www.theguardian.com https://www.scribd.com https://www.instagram.com https://www.tiktok.com https://interactive.guim.co.uk https://open.spotify.com https://www.youtube-nocookie.com ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://twitter.com' : ''};
     font-src 'self' https://interactive.guim.co.uk;

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -60,7 +60,7 @@ const assetHashes = (assets: string[]): string =>
 const buildCsp = ({ styles, scripts }: Assets, twitter: boolean): string => `
     default-src 'self';
     style-src ${assetHashes(styles)} https://interactive.guim.co.uk ${twitter ? 'https://platform.twitter.com' : ''};
-    img-src 'self' https://*.theguardian.com https://*.guim.co.uk ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:' : ''};
+    img-src 'self' https://static.theguardian.com https://*.guim.co.uk ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:' : ''};
     script-src 'self' ${assetHashes(scripts)} http://www.instagram.com/embed.js https://interactive.guim.co.uk https://s16.tiktokcdn.com https://www.tiktok.com/embed.js ${twitter ? 'https://platform.twitter.com https://cdn.syndication.twimg.com' : ''};
     frame-src https://www.theguardian.com https://www.scribd.com https://www.instagram.com https://www.tiktok.com https://interactive.guim.co.uk https://open.spotify.com https://www.youtube-nocookie.com ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://twitter.com' : ''};
     font-src 'self' https://interactive.guim.co.uk;


### PR DESCRIPTION
## Changes

- `<Logo />` component for AdvertisementFeatures
- Enable images from `https://*.guardian.com`

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/85399935-86648580-b54f-11ea-96af-cb31447eca5d.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11618797/85399956-8f555700-b54f-11ea-841d-92c2715df001.png" width="300" /> |
| <img src="https://user-images.githubusercontent.com/11618797/85399971-98debf00-b54f-11ea-9f95-182420a9989e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11618797/85399990-a1cf9080-b54f-11ea-99c9-f323f06931c9.png" width="300" /> |
