### PR TITLE
Functional Option

### DIFF
--- a/src/capi.ts
+++ b/src/capi.ts
@@ -7,8 +7,10 @@ import { TagType } from '@guardian/content-api-models/v1/tagType';
 import { BlockElement} from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import { CapiDateTime } from '@guardian/content-api-models/v1/capiDateTime'
-import { Option, fromNullable, None, Some } from 'types/option';
+import { Option, fromNullable, andThen, none, some } from 'types/option';
 import { fromString as dateFromString } from 'date';
+import { pipe2 } from 'lib';
+
 
 // ----- Lookups ----- //
 
@@ -75,8 +77,8 @@ const paidContentLogo = (tags: Tag[]): Option<Logo> => {
     const url = sponsorship?.sponsorLink;
     const alt = sponsorship?.sponsorName ?? "";
     return (!src || !url)
-        ? new None()
-        : new Some({ src, url, alt })
+        ? none
+        : some({ src, url, alt })
 }
 
 
@@ -113,7 +115,7 @@ const capiDateTimeToDate = (date: CapiDateTime): Option<Date> =>
     dateFromString(date.iso8601);
 
 const maybeCapiDate = (date: CapiDateTime | undefined): Option<Date> =>
-    fromNullable(date).andThen(capiDateTimeToDate);
+    pipe2(date, fromNullable, andThen(capiDateTimeToDate));
 
 
 // ----- Exports ----- //

--- a/src/client/liveblog.ts
+++ b/src/client/liveblog.ts
@@ -8,6 +8,7 @@ import setup from 'client/setup';
 import { fromSerialisable } from 'liveBlock';
 import { parse } from 'client/parser';
 import LiveblogBody from 'components/liveblog/body';
+import { withDefault } from 'types/option';
 
 
 // ----- Setup ----- //
@@ -24,9 +25,7 @@ const format: Format = {
 // ----- Functions ----- //
 
 const docParser = (html: string): DocumentFragment =>
-    parse(domParser)(html)
-        .toOption()
-        .withDefault(new DocumentFragment());
+    withDefault(new DocumentFragment())(parse(domParser)(html).toOption());
 
 const deserialise = fromSerialisable(docParser);
 

--- a/src/components/advertisementFeature/article.tsx
+++ b/src/components/advertisementFeature/article.tsx
@@ -15,6 +15,8 @@ import { darkModeCss, articleWidthStyles } from 'styles';
 import { Keyline } from 'components/shared/keyline';
 import { AdvertisementFeature, getFormat } from 'item';
 import Logo from './logo';
+import { withDefault, map } from 'types/option';
+import { pipe2 } from 'lib';
 
 
 // ----- Styles ----- //
@@ -63,7 +65,7 @@ const AdvertisementFeature = ({ item, children }: Props): JSX.Element => {
                 <Keyline {...item} />
                 <section css={articleWidthStyles}>
                     <Metadata item={item} />
-                    {item.logo.fmap(props => <Logo logo={props} />).withDefault(<></>)}
+                    {pipe2(item.logo, map(props => <Logo logo={props} />), withDefault(<></>))}
                 </section>
             </header>
             <Body className={[articleWidthStyles]}>

--- a/src/components/atoms/interactiveAtom.tsx
+++ b/src/components/atoms/interactiveAtom.tsx
@@ -3,7 +3,8 @@ import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Format } from '@guardian/types/Format';
 import { getPillarStyles, PillarStyles } from 'pillarStyles';
-import { Option } from 'types/option';
+import { Option, map, withDefault } from 'types/option';
+import { pipe2 } from 'lib';
 
 
 export interface InteractiveAtomProps {
@@ -27,9 +28,11 @@ const InteractiveAtom: FC<InteractiveAtomProps> = (props: InteractiveAtomProps):
     const { html, styles, js, format } = props;
     const pillarStyles = getPillarStyles(format.pillar);
     const style = h('style', { dangerouslySetInnerHTML: { __html: styles } });
-    const script = js.fmap<ReactElement | null>(jsString =>
-        h('script', { dangerouslySetInnerHTML: { __html: jsString } }),
-    ).withDefault(null);
+    const script = pipe2(
+        js,
+        map(jsString => h('script', { dangerouslySetInnerHTML: { __html: jsString } })),
+        withDefault<ReactElement | null>(null),
+    );
     const markup = styledH('figure', { css: InteractiveAtomStyles(pillarStyles), dangerouslySetInnerHTML: { __html: html } });
 
     return <>

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -8,6 +8,8 @@ import { Format } from 'format';
 import { getPillarStyles } from 'pillarStyles';
 import Img from 'components/img';
 import { remSpace } from '@guardian/src-foundations';
+import { map, withDefault } from 'types/option';
+import { pipe2 } from 'lib';
 
 
 // ----- Setup ----- //
@@ -43,14 +45,18 @@ const Avatar: FC<Props> = ({ contributors, ...format }: Props) => {
         return null;
     }
 
-    return contributor.image.fmap<ReactElement | null>(image =>
-        <Img
-            image={image}
-            sizes={dimensions}
-            className={getStyles(format)}
-            format={format}
-        />
-    ).withDefault(null);
+    return pipe2(
+        contributor.image,
+        map(image =>
+            <Img
+                image={image}
+                sizes={dimensions}
+                className={getStyles(format)}
+                format={format}
+            />
+        ),
+        withDefault<ReactElement | null>(null),
+    );
 }
 
 

--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -5,11 +5,12 @@ import { css, SerializedStyles } from '@emotion/core';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 
 import { Design, Format } from 'format';
-import { Option } from 'types/option';
+import { Option, withDefault, map } from 'types/option';
 import { neutral, palette } from '@guardian/src-foundations';
 import { getPillarStyles } from 'pillarStyles';
 import { getHref } from 'renderer';
 import { darkModeCss } from 'styles';
+import { pipe2 } from 'lib';
 
 
 // ----- Component ----- //
@@ -104,7 +105,7 @@ const getAnchorStyles = (format: Format): SerializedStyles => {
 }
 
 const getProfileLink = (node: Node): string => {
-    const href = getHref(node).withDefault('');
+    const href = withDefault('')(getHref(node));
     return href.startsWith('profile/')
         ? `https://www.theguardian.com/${href}`
         : href
@@ -127,11 +128,15 @@ const renderText = (format: Format, byline: DocumentFragment): ReactNode =>
     Array.from(byline.childNodes).map(toReact(format));
 
 const Byline: FC<Props> = ({ bylineHtml, ...format }) =>
-    bylineHtml.fmap<ReactElement | null>(byline =>
-        <address css={getStyles(format)}>
-            {renderText(format, byline)}
-        </address>
-    ).withDefault(null);
+    pipe2(
+        bylineHtml,
+        map(byline =>
+            <address css={getStyles(format)}>
+                {renderText(format, byline)}
+            </address>
+        ),
+        withDefault<ReactElement | null>(null),
+    );
 
 
 // ----- Exports ----- //

--- a/src/components/dateline.stories.tsx
+++ b/src/components/dateline.stories.tsx
@@ -3,14 +3,14 @@
 import React, { FC } from 'react';
 import { date, withKnobs } from '@storybook/addon-knobs';
 
-import { Some } from 'types/option';
+import { some } from 'types/option';
 import Dateline from './dateline';
 
 
 // ----- Stories ----- //
 
 const Default: FC = () =>
-    <Dateline date={new Some(new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))))} />
+    <Dateline date={some(new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))))} />
 
 
 // ----- Exports ----- //

--- a/src/components/dateline.tsx
+++ b/src/components/dateline.tsx
@@ -5,9 +5,10 @@ import { css } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography';
 import { text, neutral } from '@guardian/src-foundations/palette';
 
-import { Option } from 'types/option';
+import { Option, withDefault, map } from 'types/option';
 import { darkModeCss as darkMode } from 'styles';
 import { formatDate } from 'date';
+import { pipe2 } from 'lib';
 
 
 // ----- Component ----- //
@@ -28,9 +29,11 @@ const styles = css`
 `;
 
 const Dateline: FC<Props> = ({ date }) =>
-    date.fmap<ReactElement | null>(d =>
-        <time css={styles} data-date={d} className="date">{ formatDate(d) }</time>
-    ).withDefault(null);
+    pipe2(
+        date,
+        map(d => <time css={styles} data-date={d} className="date">{ formatDate(d) }</time>),
+        withDefault<ReactElement | null>(null),
+    )
 
 
 // ----- Exports ----- //

--- a/src/components/figCaption.stories.tsx
+++ b/src/components/figCaption.stories.tsx
@@ -7,7 +7,7 @@ import { Format, Pillar, Design, Display } from '@guardian/types/Format';
 import { background } from '@guardian/src-foundations/palette';
 
 import FigCaption from './figCaption';
-import { Option, None, Some } from 'types/option';
+import { Option, none, some } from 'types/option';
 
 
 // ----- Setup ----- //
@@ -20,10 +20,10 @@ const format: Format = {
 
 const credit = (): Option<string> => {
     if (boolean('Show Credit', false)) {
-        return new Some(text('Credit', 'Photograph: A photographer'));
+        return some(text('Credit', 'Photograph: A photographer'));
     }
 
-    return new None();
+    return none;
 }
 
 const caption = (): Option<DocumentFragment> => {
@@ -34,7 +34,7 @@ const caption = (): Option<DocumentFragment> => {
 
     fragment.appendChild(node);
 
-    return new Some(fragment);
+    return some(fragment);
 }
 
 

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -8,10 +8,11 @@ import { remSpace, palette } from '@guardian/src-foundations';
 import { Format, Design } from '@guardian/types/Format';
 
 import { getPillarStyles } from 'pillarStyles';
-import { Option } from 'types/option';
+import { Option, map, withDefault } from 'types/option';
 import { renderTextElement, getHref } from 'renderer';
 import { darkModeCss } from 'styles';
 import Anchor from 'components/anchor';
+import { pipe2 } from 'lib';
 
 
 // ----- Subcomponents ----- //
@@ -60,14 +61,18 @@ const creditStyles = css`
 `;
 
 const Credit: FC<CreditProps> = ({ format, credit }: CreditProps) =>
-    credit.fmap<ReactElement | null>(cred => {
-        switch (format.design) {
-            case Design.Media:
-                return <p css={creditStyles}>{cred}</p>;
-            default:
-                return <> {cred}</>;
-        }
-    }).withDefault(null);
+    pipe2(
+        credit,
+        map(cred => {
+            switch (format.design) {
+                case Design.Media:
+                    return <p css={creditStyles}>{cred}</p>;
+                default:
+                    return <> {cred}</>;
+            }
+        }),
+        withDefault<ReactElement | null>(null),
+    );
 
 const captionHeadingStyles = css`
     ${headline.xxxsmall()}
@@ -95,7 +100,7 @@ const captionElement = (format: Format) => (node: Node, key: number): ReactNode 
         case 'A':
             return (
                 <Anchor
-                    href={getHref(node).withDefault('')}
+                    href={withDefault('')(getHref(node))}
                     className={anchorStyles}
                     format={format}
                 >
@@ -147,13 +152,17 @@ const getStyles = (format: Format): SerializedStyles => {
 }
 
 const FigCaption: FC<Props> = ({ format, caption, credit }: Props) =>
-    caption.fmap<ReactElement | null>(cap =>
-        <figcaption css={getStyles(format)}>
-            <Triangle format={format} />
-            {renderCaption(cap, format)}
-            <Credit format={format} credit={credit} />
-        </figcaption>
-    ).withDefault(null);
+    pipe2(
+        caption,
+        map(cap =>
+            <figcaption css={getStyles(format)}>
+                <Triangle format={format} />
+                {renderCaption(cap, format)}
+                <Credit format={format} credit={credit} />
+            </figcaption>
+        ),
+        withDefault<ReactElement | null>(null),
+    );
 
 
 // ----- Exports ----- //

--- a/src/components/follow.stories.tsx
+++ b/src/components/follow.stories.tsx
@@ -6,7 +6,7 @@ import { withKnobs } from '@storybook/addon-knobs';
 import Follow from './follow';
 import { Pillar, Design, Display } from 'format';
 import { selectPillar } from 'storybookHelpers';
-import { None } from 'types/option';
+import { none } from 'types/option';
 
 
 // ----- Stories ----- //
@@ -18,7 +18,7 @@ const Default: FC = () =>
                 id: 'profile/janesmith',
                 apiUrl: 'janesmith.com',
                 name: 'Jane Smith',
-                image: new None(),
+                image: none,
             }
         ]}
         pillar={selectPillar(Pillar.News)}

--- a/src/components/follow.test.tsx
+++ b/src/components/follow.test.tsx
@@ -6,7 +6,7 @@ import Adapter from 'enzyme-adapter-react-16';
 
 import Follow from './follow';
 import { Pillar, Design, Display } from 'format';
-import { None } from 'types/option';
+import { none } from 'types/option';
 import { Contributor } from 'contributor';
 
 
@@ -30,7 +30,7 @@ describe('Follow component renders as expected', () => {
                 apiUrl: "https://mapi.co.uk/test",
                 name: "George Monbiot",
                 id: "test",
-                image: new None(),
+                image: none,
             },
         ];
         const follow = shallow(
@@ -42,7 +42,7 @@ describe('Follow component renders as expected', () => {
 
     it('Renders null if no apiUrl', () => {
         const contributors: Contributor[] = [
-            { name: "George Monbiot", id: "test", apiUrl: "", image: new None() },
+            { name: "George Monbiot", id: "test", apiUrl: "", image: none },
         ];
         const follow = shallow(
             <Follow contributors={contributors} {...followFormat} />
@@ -57,13 +57,13 @@ describe('Follow component renders as expected', () => {
                 name: "Contributor 1",
                 apiUrl: "https://mapi.co.uk/test",
                 id: "test",
-                image: new None(),
+                image: none,
             },
             {
                 name: "Contributor 2",
                 apiUrl: "https://mapi.co.uk/test",
                 id: "test",
-                image: new None(),
+                image: none,
             },
         ];
         const follow = shallow(

--- a/src/components/headerImage.test.tsx
+++ b/src/components/headerImage.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-import { None, Option } from 'types/option';
+import { none, Option } from 'types/option';
 import HeaderImage from 'components/headerImage';
 import { Image } from 'image';
 import { Pillar, Design, Display } from 'format';
@@ -19,7 +19,7 @@ configure({ adapter: new Adapter() });
 
 describe('HeaderImage component renders as expected', () => {
     it('Renders null if no block element', () => {
-        const image: Option<Image> = new None;
+        const image: Option<Image> = none;
         const format = {
             pillar: Pillar.News,
             design: Design.Article,

--- a/src/components/headerImage.tsx
+++ b/src/components/headerImage.tsx
@@ -7,10 +7,11 @@ import { remSpace } from '@guardian/src-foundations';
 
 import HeaderImageCaption, { captionId } from 'components/headerImageCaption';
 import { wideContentWidth } from 'styles';
-import { Option } from 'types/option';
+import { Option, map, withDefault } from 'types/option';
 import { Image } from 'image';
 import Img from 'components/img';
 import { Format, Display, Design } from 'format';
+import { pipe2 } from 'lib';
 
 
 // ----- Subcomponents ----- //
@@ -117,17 +118,21 @@ interface Props {
 }
 
 const HeaderImage: FC<Props> = ({ className, image, format }) =>
-    image.fmap<ReactElement | null>(imageData =>
-        <figure css={[getStyles(format), className]} aria-labelledby={captionId}>
-            <Img
-                image={imageData}
-                sizes={getSizes(format, imageData)}
-                className={getImgStyles(format, imageData)}
-                format={format}
-            />
-            <Caption format={format} image={imageData} />
-        </figure>
-    ).withDefault(null);
+    pipe2(
+        image,
+        map(imageData =>
+            <figure css={[getStyles(format), className]} aria-labelledby={captionId}>
+                <Img
+                    image={imageData}
+                    sizes={getSizes(format, imageData)}
+                    className={getImgStyles(format, imageData)}
+                    format={format}
+                />
+                <Caption format={format} image={imageData} />
+            </figure>
+        ),
+        withDefault<ReactElement | null>(null),
+    );
 
 
 // ----- Exports ----- //

--- a/src/components/headerImageCaption.test.tsx
+++ b/src/components/headerImageCaption.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import HeaderImageCaption, { captionId } from 'components/headerImageCaption';
-import { Some } from 'types/option';
+import { some } from 'types/option';
 
 configure({ adapter: new Adapter() });
 
@@ -10,8 +10,8 @@ describe('HeaderImageCaption component renders as expected', () => {
     it('Caption formatted correctly', () => {
         const headerImageCaption = shallow(
             <HeaderImageCaption
-                caption={new Some('Here is a caption.')}
-                credit={new Some('Photograph: cameraman')}
+                caption={some('Here is a caption.')}
+                credit={some('Photograph: cameraman')}
             />
         );
         expect(headerImageCaption.find(`#${captionId}`).text()).toBe("Here is a caption. Photograph: cameraman")

--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -5,7 +5,8 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, brandAlt } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { remSpace } from '@guardian/src-foundations';
-import { Option } from 'types/option';
+import { Option, map, withDefault } from 'types/option';
+import { pipe2 } from 'lib';
 
 const captionId = 'header-image-caption';
 
@@ -79,15 +80,19 @@ interface Props {
 	credit: Option<string>;
 }
 
-const HeaderImageCaption: FC<Props> = ({ caption, credit }: Props) => 
-	caption.fmap<ReactElement | null>(cap =>
-		<figcaption css={HeaderImageCaptionStyles}>
-			<details>
-				<summary><span>Click to see figure caption</span></summary>
-				<span id={captionId}>{cap} {credit.withDefault('')}</span>
-			</details>
-		</figcaption>
-	).withDefault(null);
+const HeaderImageCaption: FC<Props> = ({ caption, credit }: Props) =>
+	pipe2(
+		caption,
+		map(cap =>
+			<figcaption css={HeaderImageCaptionStyles}>
+				<details>
+					<summary><span>Click to see figure caption</span></summary>
+					<span id={captionId}>{cap} {withDefault('')(credit)}</span>
+				</details>
+			</figcaption>
+		),
+		withDefault<ReactElement | null>(null),
+	);
 
 export default HeaderImageCaption;
 

--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -7,7 +7,8 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { Image, Role } from 'image';
 import { darkModeCss } from 'styles';
 import { Format, Design } from '@guardian/types/Format';
-import { Option } from 'types/option';
+import { Option, map, withDefault } from 'types/option';
+import { pipe2 } from 'lib';
 
 
 // ----- Component ----- //
@@ -21,13 +22,16 @@ interface Props {
 
 const styles = (role: Option<Role>, format?: Format): SerializedStyles => {
     const backgroundColour = format?.design === Design.Media ? neutral[20] : neutral[97];
-    return role.fmap(imageRole => imageRole).withDefault(Role.HalfWidth) === Role.Thumbnail
-        ? css`color: ${neutral[60]};`
+    return pipe2(
+        role,
+        map(imageRole => imageRole),
+        withDefault(Role.HalfWidth),
+    ) === Role.Thumbnail ? css`color: ${neutral[60]};`
         : css`
             background-color: ${backgroundColour};
             ${darkModeCss`background-color: ${neutral[20]};`}
             color: ${neutral[60]};
-        `
+        `;
 }
 
 const Img: FC<Props> = ({ image, sizes, className, format }) =>
@@ -43,11 +47,11 @@ const Img: FC<Props> = ({ image, sizes, className, format }) =>
         }),
         styledH('img', {
             src: image.src,
-            alt: image.alt.withDefault(''),
+            alt: withDefault('')(image.alt),
             className: image.width > 620 ? 'js-launch-slideshow' : '',
             css: [styles(image.role, format), className],
-            'data-caption': image.nativeCaption.withDefault(''),
-            'data-credit': image.credit.withDefault(''),
+            'data-caption': withDefault('')(image.nativeCaption),
+            'data-credit': withDefault('')(image.credit),
         }),
     ] );
 

--- a/src/components/liveblog/avatar.test.tsx
+++ b/src/components/liveblog/avatar.test.tsx
@@ -3,7 +3,7 @@ import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Avatar from 'components/liveblog/avatar';
 import { Contributor } from 'contributor';
-import { None, Some } from 'types/option';
+import { none, some } from 'types/option';
 
 configure({ adapter: new Adapter() });
 
@@ -12,17 +12,17 @@ describe('Avatar component renders as expected', () => {
         name: "Web Title",
         id: "test",
         apiUrl: 'test',
-        image: new Some({
+        image: some({
             src: '',
             srcset: '',
             dpr2Srcset: '',
             height: 192,
             width: 192,
-            credit: new None(),
-            caption: new None(),
-            alt: new None(),
-            role: new None(),
-            nativeCaption: new None(),
+            credit: none,
+            caption: none,
+            alt: none,
+            role: none,
+            nativeCaption: none,
         }),
     }]
     it('Adds correct alt attribute', () => {
@@ -37,8 +37,8 @@ describe('Avatar component renders as expected', () => {
 
     it('Renders null if more than one contributor', () => {
         const contributors: Contributor[] = [
-            { name: "Contributor 1", id: "test", apiUrl: 'test', image: new None() },
-            { name: "Contributor 2", id: "test", apiUrl: 'test', image: new None() },
+            { name: "Contributor 1", id: "test", apiUrl: 'test', image: none },
+            { name: "Contributor 2", id: "test", apiUrl: 'test', image: none },
         ]
         const avatar = shallow(<Avatar contributors={contributors} bgColour="" />);
         expect(avatar.html()).toBe(null)

--- a/src/components/liveblog/avatar.tsx
+++ b/src/components/liveblog/avatar.tsx
@@ -4,6 +4,8 @@ import React, { ReactElement } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 
 import { Contributor, isSingleContributor } from 'contributor';
+import { map, withDefault } from 'types/option';
+import { pipe2 } from 'lib';
 
 
 // ----- Styles ----- //
@@ -42,16 +44,20 @@ function Avatar({ contributors, bgColour }: AvatarProps): JSX.Element | null {
         return null;
     }
 
-    return contributor.image.fmap<ReactElement | null>(image =>
-        <div css={AvatarStyles(bgColour)}>
-            <img
-                srcSet={image.srcset}
-                src={image.src}
-                alt={contributor.name}
-                sizes={imageWidth}
-            />
-        </div>
-    ).withDefault(null);
+    return pipe2(
+        contributor.image,
+        map(image =>
+            <div css={AvatarStyles(bgColour)}>
+                <img
+                    srcSet={image.srcset}
+                    src={image.src}
+                    alt={contributor.name}
+                    sizes={imageWidth}
+                />
+            </div>
+        ),
+        withDefault<ReactElement | null>(null),
+    );
 }
 
 

--- a/src/components/liveblog/block.tsx
+++ b/src/components/liveblog/block.tsx
@@ -8,8 +8,9 @@ import { makeRelativeDate, formatDate } from 'date';
 import LeftColumn from 'components/shared/leftColumn';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
-import { Option } from 'types/option';
+import { Option, withDefault, map } from 'types/option';
 import { remSpace } from '@guardian/src-foundations';
+import { pipe2 } from 'lib';
 
 const LiveblogBlockStyles = ({ kicker }: PillarStyles, highlighted: boolean): SerializedStyles => css`
     background: ${neutral[100]};
@@ -74,14 +75,17 @@ const LiveblogBlock = ({
     firstPublishedDate,
     lastModifiedDate,
 }: LiveblogBlockProps): JSX.Element => {
-    const relativeFirstPublished = (date: Option<Date>): JSX.Element | null => date
-        .fmap<JSX.Element | null>(date => <time>{makeRelativeDate(date)}</time>)
-        .withDefault(null)
+    const relativeFirstPublished = (date: Option<Date>): JSX.Element | null => pipe2(
+        date,
+        map(date => <time>{makeRelativeDate(date)}</time>),
+        withDefault<JSX.Element | null>(null),
+    );
 
-    const relativeLastModified: JSX.Element | null = lastModifiedDate
-        .fmap<JSX.Element | null>(date => <time>Last updated: {formatDate(date)}</time>)
-        .withDefault(null)
-
+    const relativeLastModified: JSX.Element | null = pipe2(
+        lastModifiedDate,
+        map(date => <time>Last updated: {formatDate(date)}</time>),
+        withDefault<JSX.Element | null>(null),
+    );
 
     const [dateJsx, setDateJsx] = useState(relativeFirstPublished(firstPublishedDate));
 

--- a/src/components/liveblog/keyEvents.tsx
+++ b/src/components/liveblog/keyEvents.tsx
@@ -7,6 +7,8 @@ import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
 import { LiveBlock } from 'liveBlock';
 import { body, headline } from '@guardian/src-foundations/typography';
+import { map, withDefault } from 'types/option';
+import { pipe2 } from 'lib';
 
 const LiveblogKeyEventsStyles = ({ kicker }: PillarStyles): SerializedStyles => css`
     background: ${neutral[100]};
@@ -154,9 +156,11 @@ const LiveblogKeyEvents = ({ pillar, blocks }: LiveblogKeyEventsProps): JSX.Elem
                 <summary><h2>Key Events ({keyEvents.length})</h2></summary>
                 <ul>
                     {keyEvents.map(event => {
-                        const relativeDate: JSX.Element | null = event.firstPublished
-                            .fmap<JSX.Element | null>(date => <time>{makeRelativeDate(date)}</time>)
-                            .withDefault(null)
+                        const relativeDate: JSX.Element | null = pipe2(
+                            event.firstPublished,
+                            map(date => <time>{makeRelativeDate(date)}</time>),
+                            withDefault<JSX.Element | null>(null),
+                        );
 
                         return <li key={event.id}>
                             { relativeDate }

--- a/src/components/liveblog/metadata.tsx
+++ b/src/components/liveblog/metadata.tsx
@@ -11,6 +11,8 @@ import { CommentCount } from './commentCount';
 import { Liveblog, getFormat } from 'item';
 import { renderText } from 'renderer';
 import Dateline from 'components/dateline';
+import { pipe2 } from 'lib';
+import { map, withDefault } from 'types/option';
 
 const styles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
     background: ${liveblogBackground};
@@ -77,9 +79,11 @@ interface Props {
 const Metadata = ({ item }: Props): JSX.Element => {
     const pillarStyles = getPillarStyles(item.pillar);
 
-    const byline = item.bylineHtml.fmap<ReactNode>(html =>
-        <address>{ renderText(html, getFormat(item)) }</address>
-    ).withDefault(null);
+    const byline = pipe2(
+        item.bylineHtml,
+        map(html => <address>{ renderText(html, getFormat(item)) }</address>),
+        withDefault<ReactNode>(null),
+    );
 
     return (
         <div css={[styles(pillarStyles)]}>

--- a/src/components/liveblog/series.tsx
+++ b/src/components/liveblog/series.tsx
@@ -5,7 +5,8 @@ import { Series } from '../../capi';
 import LeftColumn from 'components/shared/leftColumn';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
-import { Option } from 'types/option';
+import { Option, map, withDefault } from 'types/option';
+import { pipe2 } from 'lib';
 
 const LiveblogSeriesStyles = ({ kicker }: PillarStyles): SerializedStyles => css`    
     padding-bottom: 0;
@@ -23,11 +24,14 @@ interface LiveblogSeriesProps {
 }
 
 const LiveblogSeries = (props: LiveblogSeriesProps): JSX.Element | null =>
-
-    props.series.fmap<JSX.Element | null>(series =>
+    pipe2(
+        props.series,
+        map(series =>
             <LeftColumn className={LiveblogSeriesStyles(getPillarStyles(props.pillar))}>
                 <a href={series.webUrl}>{series.webTitle}</a>
             </LeftColumn>
-    ).withDefault(null);
+        ),
+        withDefault<JSX.Element | null>(null),
+    );
 
 export default LiveblogSeries;

--- a/src/components/liveblog/standfirst.tsx
+++ b/src/components/liveblog/standfirst.tsx
@@ -5,8 +5,9 @@ import LeftColumn from 'components/shared/leftColumn';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Format } from 'format';
 import { renderText } from 'renderer';
-import { Option } from 'types/option';
+import { Option, map, withDefault } from 'types/option';
 import { headline } from '@guardian/src-foundations/typography';
+import { pipe2 } from 'lib';
 
 const StandfirstStyles = ({ liveblogBackground }: PillarStyles): SerializedStyles => css`
     background: ${liveblogBackground};
@@ -34,10 +35,14 @@ interface LiveblogStandfirstProps {
 }
 
 const LiveblogStandfirst = ({ standfirst, format }: LiveblogStandfirstProps): JSX.Element | null =>
-    standfirst.fmap<JSX.Element | null>(doc =>
-        <LeftColumn className={StandfirstStyles(getPillarStyles(format.pillar))}>
-            <div>{ renderText(doc, format) }</div>
-        </LeftColumn>
-    ).withDefault(null)
+    pipe2(
+        standfirst,
+        map(doc =>
+            <LeftColumn className={StandfirstStyles(getPillarStyles(format.pillar))}>
+                <div>{ renderText(doc, format) }</div>
+            </LeftColumn>
+        ),
+        withDefault<JSX.Element | null>(null),
+    );
 
 export default LiveblogStandfirst;

--- a/src/components/media/articleSeries.tsx
+++ b/src/components/media/articleSeries.tsx
@@ -4,7 +4,8 @@ import { Series } from 'capi';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
 import { headline } from '@guardian/src-foundations/typography';
-import { Option } from 'types/option';
+import { Option, map, withDefault } from 'types/option';
+import { pipe2 } from 'lib';
 
 const ArticleSeriesStyles = ({ inverted }: PillarStyles): SerializedStyles => css`    
     a {
@@ -20,11 +21,14 @@ interface ArticleSeriesProps {
 }
 
 const ArticleSeries = (props: ArticleSeriesProps): JSX.Element | null =>
-
-    props.series.fmap<ReactElement | null>(series =>
-        <nav css={ArticleSeriesStyles(getPillarStyles(props.pillar))}>
-            <a href={series.webUrl}>{series.webTitle}</a>
-        </nav>
-    ).withDefault(null);
+    pipe2(
+        props.series,
+        map(series =>
+            <nav css={ArticleSeriesStyles(getPillarStyles(props.pillar))}>
+                <a href={series.webUrl}>{series.webTitle}</a>
+            </nav>
+        ),
+        withDefault<ReactElement | null>(null),
+    );
 
 export default ArticleSeries;

--- a/src/components/media/byline.tsx
+++ b/src/components/media/byline.tsx
@@ -4,12 +4,13 @@ import React, { ReactNode } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Pillar } from 'format';
-import { Option } from 'types/option';
+import { Option, map, withDefault } from 'types/option';
 import { Item, getFormat } from 'item';
 import { textSans } from "@guardian/src-foundations/typography";
 import { renderText } from "../../renderer";
 import { remSpace } from "@guardian/src-foundations";
 import Dateline from 'components/dateline';
+import { pipe2 } from 'lib';
 
 
 // ----- Styles ----- //
@@ -46,9 +47,11 @@ interface Props {
 
 function Byline({ pillar, publicationDate, className, item }: Props): JSX.Element {
 
-    const byline = item.bylineHtml.fmap<ReactNode>(html =>
-        <address>{ renderText(html, getFormat(item)) }</address>
-    ).withDefault(null);
+    const byline = pipe2(
+        item.bylineHtml,
+        map(html => <address>{ renderText(html, getFormat(item)) }</address>),
+        withDefault<ReactNode>(null),
+    );
 
     return (
         <div css={[className, styles]}>

--- a/src/components/opinion/cutout.tsx
+++ b/src/components/opinion/cutout.tsx
@@ -6,6 +6,8 @@ import { css, SerializedStyles } from '@emotion/core';
 import { Contributor, isSingleContributor } from 'contributor';
 import Img from 'components/img';
 import { darkModeCss } from 'styles';
+import { pipe2 } from 'lib';
+import { map, withDefault } from 'types/option';
 
 
 // ----- Styles ----- //
@@ -41,16 +43,19 @@ const Cutout = ({ contributors, className }: Props): JSX.Element | null => {
         return null;
     }
 
-    return contributor.image.fmap<ReactElement | null>(image => {
-        return (
+    return pipe2(
+        contributor.image,
+        map(image =>
             <div css={[className, styles]}>
                 <Img
                     image={image}
                     sizes="12rem"
                     className={imageStyles}
                 />
-            </div>)
-    }).withDefault(null);
+            </div>
+        ),
+        withDefault<ReactElement | null>(null),
+    );
 }
 
 

--- a/src/components/series.tsx
+++ b/src/components/series.tsx
@@ -11,6 +11,8 @@ import { Format, Display } from '@guardian/types/Format';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
 import { darkModeCss, wideContentWidth, articleWidthStyles } from 'styles';
 import { Item } from 'item';
+import { pipe2 } from 'lib';
+import { map, withDefault } from 'types/option';
 
 
 // ----- Component ----- //
@@ -71,13 +73,17 @@ const getStyles = ({ display, pillar }: Format): SerializedStyles => {
 }
 
 const Series: FC<Props> = ({ item }: Props) =>
-    item.series.fmap<ReactElement | null>(series =>
-        <nav css={getStyles(item)}>
-            <a css={getLinkStyles(item)} href={series.webUrl}>
-                {series.webTitle}
-            </a>
-        </nav>
-    ).withDefault(null);
+    pipe2(
+        item.series,
+        map(series =>
+            <nav css={getStyles(item)}>
+                <a css={getLinkStyles(item)} href={series.webUrl}>
+                    {series.webTitle}
+                </a>
+            </nav>
+        ),
+        withDefault<ReactElement | null>(null),
+    );
 
 
 // ----- Exports ----- //

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -10,6 +10,8 @@ import { Item, getFormat } from 'item';
 import { renderStandfirstText } from 'renderer';
 import { darkModeCss as darkMode } from 'styles';
 import { Display, Design } from 'format';
+import { map, withDefault } from 'types/option';
+import { pipe2 } from 'lib';
 
 
 // ----- Component ----- //
@@ -100,14 +102,18 @@ function content(standfirst: DocumentFragment, item: Item): ReactNode {
     const bylineInStandfirst = item.byline !== '' && standfirst.textContent?.includes(item.byline);
 
     if (item.display === Display.Immersive && !bylineInStandfirst) {
-        return item.bylineHtml.fmap<ReactNode>(byline =>
-            <>
-                {rendered}
-                <address>
-                    <p>By {renderStandfirstText(byline, format)}</p>
-                </address>
-            </>
-        ).withDefault(rendered);
+        return pipe2(
+            item.bylineHtml,
+            map(byline =>
+                <>
+                    {rendered}
+                    <address>
+                        <p>By {renderStandfirstText(byline, format)}</p>
+                    </address>
+                </>
+            ),
+            withDefault<ReactNode>(rendered),
+        );
     }
 
     return rendered;
@@ -115,9 +121,13 @@ function content(standfirst: DocumentFragment, item: Item): ReactNode {
 
 
 const Standfirst: FC<Props> = ({ item }) =>
-    item.standfirst.fmap<ReactElement | null>(standfirst =>
-        <div css={getStyles(item)}>{content(standfirst, item)}</div>,
-    ).withDefault(null);
+    pipe2(
+        item.standfirst,
+        map(standfirst =>
+            <div css={getStyles(item)}>{content(standfirst, item)}</div>,
+        ),
+        withDefault<ReactElement | null>(null),
+    );
 
 
 // ----- Exports ----- //

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -1,9 +1,10 @@
 // ----- Imports ----- //
 
-import { Option, fromNullable, None } from 'types/option';
+import { Option, fromNullable, none, map } from 'types/option';
 import { Content } from '@guardian/content-api-models/v1/content';
 import { articleContributors } from 'capi';
 import { srcsetWithWidths, src, Dpr, Image } from 'image';
+import { pipe2 } from 'lib';
 
 
 // ------ Types ----- //
@@ -28,18 +29,22 @@ const parseContributors = (salt: string, content: Content): Contributor[] =>
         id: contributor.id,
         apiUrl: contributor.apiUrl,
         name: contributor.webTitle,
-        image: fromNullable(contributor.bylineLargeImageUrl).fmap(url => ({
-            srcset: contributorSrcset(url, salt, Dpr.One),
-            src: src(salt, url, 64, Dpr.One),
-            dpr2Srcset: contributorSrcset(url, salt, Dpr.Two),
-            height: 192,
-            width: 192,
-            credit: new None(),
-            caption: new None(),
-            alt: new None(),
-            role: new None(),
-            nativeCaption: new None(),
-        })),
+        image: pipe2(
+            contributor.bylineLargeImageUrl,
+            fromNullable,
+            map(url => ({
+                srcset: contributorSrcset(url, salt, Dpr.One),
+                src: src(salt, url, 64, Dpr.One),
+                dpr2Srcset: contributorSrcset(url, salt, Dpr.Two),
+                height: 192,
+                width: 192,
+                credit: none,
+                caption: none,
+                alt: none,
+                role: none,
+                nativeCaption: none,
+            })),
+        ),
     }));
 
 

--- a/src/date.ts
+++ b/src/date.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Option, Some, None } from 'types/option';
+import { Option, some, none } from 'types/option';
 
 
 // ----- Setup ----- //
@@ -92,9 +92,9 @@ const format = (date: Date): string =>
 
 function fromString(date: string): Option<Date> {
     try {
-        return new Some(new Date(date));
+        return some(new Date(date));
     } catch(e) {
-        return new None();
+        return none;
     }
 }
 

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -3,8 +3,7 @@
 import { Pillar, Design, Display } from '@guardian/types/Format';
 
 import { Item, Review } from 'item';
-import { None, Some } from 'types/option';
-import { Image } from 'image';
+import { none, some } from 'types/option';
 
 
 // ----- Fixture ----- //
@@ -14,13 +13,13 @@ const fields = {
     display: Display.Standard,
     body: [],
     headline: 'Reclaimed lakes and giant airports: how Mexico City might have looked',
-    standfirst: new None<DocumentFragment>(),
+    standfirst: none,
     byline: '',
-    bylineHtml: new None<DocumentFragment>(),
-    publishDate: new None<Date>(),
-    mainImage: new None<Image>(),
+    bylineHtml: none,
+    publishDate: none,
+    mainImage: none,
     contributors: [],
-    series: new Some({
+    series: some({
         id: '',
         type: 0,
         webTitle: '',

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -55,7 +55,7 @@ const review: Review = {
 
 const advertisementFeature: Item = {
     design: Design.AdvertisementFeature,
-    logo: new None(),
+    logo: none,
     ...fields,
 };
 

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -6,7 +6,8 @@ import { Dpr, parseImage, Image, srcset } from 'image';
 import { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import { AssetType } from '@guardian/content-api-models/v1/assetType';
-import { None } from 'types/option';
+import { none, withDefault } from 'types/option';
+import { pipe3 } from 'lib';
 
 
 // ----- Mocks ----- //
@@ -35,13 +36,13 @@ const image: Image = {
     src: '',
     srcset: '',
     dpr2Srcset: '',
-    alt: new None(),
+    alt: none,
     width: 0,
     height: 0,
-    caption: new None(),
-    credit: new None(),
-    nativeCaption: new None(),
-    role: new None(),
+    caption: none,
+    credit: none,
+    nativeCaption: none,
+    role: none,
 };
 
 
@@ -54,7 +55,12 @@ describe('image', () => {
             salt: 'mockSalt',
         })(imageBlock);
 
-        expect(parsed.withDefault(image).credit.withDefault('')).toBe('Credit');
+        expect(pipe3(
+            parsed,
+            withDefault(image),
+            (image: Image) => image.credit,
+            withDefault(''),
+        )).toBe('Credit');
     });
 
     test('does not include credit when displayCredit is false', () => {
@@ -69,7 +75,12 @@ describe('image', () => {
             }
         });
 
-        expect(parsed.withDefault(image).credit.withDefault('')).toBe('');
+        expect(pipe3(
+            parsed,
+            withDefault(image),
+            (image: Image) => image.credit,
+            withDefault(''),
+        )).toBe('');
     });
 
     test('show lower quality when DPR is 2', () => {

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -7,11 +7,12 @@ import { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { AtomType } from '@guardian/content-atom-model/atomType';
 import { Atoms } from '@guardian/content-api-models/v1/atoms';
 import { fromCapi, Standard, Review, getFormat } from 'item';
-import { ElementKind, Audio, Video } from 'bodyElement';
+import { ElementKind, Audio, Video, BodyElement } from 'bodyElement';
 import { Design } from 'format';
 import { JSDOM } from 'jsdom';
 import { Display } from '@guardian/types/Format';
 import Int64 from 'node-int64';
+import { withDefault } from 'types/option';
 
 const articleContent = {
     id: "",
@@ -190,7 +191,7 @@ const articleContentWithImageWithoutFile = articleContentWith({
 const f = fromCapi({ docParser: JSDOM.fragment, salt: 'mockSalt' });
 
 const getFirstBody = (item: Review | Standard) =>
-    item.body[0].toOption().withDefault({ kind: ElementKind.Interactive, url: '' });
+    withDefault<BodyElement>({ kind: ElementKind.Interactive, url: '' })(item.body[0].toOption());
 
 
 describe('fromCapi returns correct Item', () => {
@@ -343,7 +344,9 @@ describe('interactive elements', () => {
             }
         }
         const item = f(articleContentWith(interactiveElement)) as Standard;
-        const element = item.body[0].toOption().withDefault({ kind: ElementKind.RichLink, url: '', linkText: '' })
+        const element = withDefault<BodyElement>
+            ({ kind: ElementKind.RichLink, url: '', linkText: '' })
+            (item.body[0].toOption());
         expect(element.kind).toBe(ElementKind.Interactive);
     })
 
@@ -356,7 +359,9 @@ describe('interactive elements', () => {
             }
         }
         const item = f(articleContentWith(interactiveElement)) as Standard;
-        const element = item.body[0].toOption().withDefault({ kind: ElementKind.RichLink, url: '', linkText: '' })
+        const element = withDefault<BodyElement>
+            ({ kind: ElementKind.RichLink, url: '', linkText: '' })
+            (item.body[0].toOption());
         expect(element.kind).toBe(ElementKind.RichLink);
     })
 });

--- a/src/item.ts
+++ b/src/item.ts
@@ -8,13 +8,15 @@ import { Element } from '@guardian/content-api-models/v1/element';
 import { Asset } from '@guardian/content-api-models/v1/asset';
 import { AssetType } from '@guardian/content-api-models/v1/assetType';
 import { articleMainImage, articleSeries, isPhotoEssay, isImmersive, isInteractive, maybeCapiDate, paidContentLogo, Logo } from 'capi';
-import { Option, fromNullable } from 'types/option';
+import { Option, fromNullable, map, andThen } from 'types/option';
 import { Format, Pillar, Design, Display } from 'format';
 import { Image as ImageData, parseImage } from 'image';
 import { LiveBlock, parseMany as parseLiveBlocks } from 'liveBlock';
 import { Body, parseElements } from 'bodyElement';
 import { Context } from 'types/parserContext';
 import { Contributor, parseContributors } from 'contributor';
+import { pipe2 } from 'lib';
+
 
 // ----- Item Type ----- //
 
@@ -132,11 +134,11 @@ const itemFields = (context: Context, content: Content): ItemFields =>
         pillar: pillarFromString(content?.pillarId),
         display: getDisplay(content),
         headline: content?.fields?.headline ?? "",
-        standfirst: fromNullable(content?.fields?.standfirst).fmap(context.docParser),
+        standfirst: pipe2(content?.fields?.standfirst, fromNullable, map(context.docParser)),
         byline: content?.fields?.byline ?? "",
-        bylineHtml: fromNullable(content?.fields?.bylineHtml).fmap(context.docParser),
+        bylineHtml: pipe2(content?.fields?.bylineHtml, fromNullable, map(context.docParser)),
         publishDate: maybeCapiDate(content.webPublicationDate),
-        mainImage: articleMainImage(content).andThen(parseImage(context)),
+        mainImage: pipe2(content, articleMainImage, andThen(parseImage(context))),
         contributors: parseContributors(context.salt, content),
         series: articleSeries(content),
         commentable: content?.fields?.commentable ?? false,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,6 +1,10 @@
 // ----- Functions ----- //
 
 const compose = <A, B, C>(f: (_b: B) => C, g: (_a: A) => B) => (a: A): C => f(g(a));
+const pipe = <A, B>(a: A, f: (_a: A) => B): B => f(a);
+const pipe2 = <A, B, C>(a: A, f: (_a: A) => B, g: (_b: B) => C): C => g(f(a));
+const pipe3 = <A, B, C, D>(a: A, f: (_a: A) => B, g: (_b: B) => C, h: (_c: C) => D): D =>
+    h(g(f(a)));
 
 const identity = <A>(a: A): A => a;
 
@@ -26,6 +30,9 @@ function memoise<A>(fn: () => A): () => A {
 
 export {
     compose,
+    pipe,
+    pipe2,
+    pipe3,
     identity,
     isElement,
     toArray,

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -6,7 +6,7 @@ import { compose } from 'lib';
 import { BodyElement, ElementKind } from 'bodyElement';
 import { Role } from 'image';
 import { configure, shallow } from 'enzyme';
-import { None, Some } from 'types/option';
+import { none, some } from 'types/option';
 import Adapter from 'enzyme-adapter-react-16';
 import { Format, Design, Display } from '@guardian/types/Format';
 
@@ -33,26 +33,26 @@ const imageElement = (): BodyElement =>
         src: 'https://gu.com/img.png',
         srcset: '',
         dpr2Srcset: '',
-        alt: new Some("alt tag"),
-        caption: new Some(JSDOM.fragment('this caption contains <em>html</em>')),
-        nativeCaption: new Some('caption'),
-        credit: new Some('credit'),
+        alt: some("alt tag"),
+        caption: some(JSDOM.fragment('this caption contains <em>html</em>')),
+        nativeCaption: some('caption'),
+        credit: some('credit'),
         width: 500,
         height: 500,
-        role: new None(),
+        role: none,
     });
 
 const imageElementWithRole = () =>
     ({
         ...imageElement(),
-        role: new Some(Role.Thumbnail)
+        role: some(Role.Thumbnail)
     })
 
 const pullquoteElement = (): BodyElement =>
     ({
         kind: ElementKind.Pullquote,
         quote: "quote",
-        attribution: new None()
+        attribution: none,
     })
 
 
@@ -60,7 +60,7 @@ const pullquoteWithAttributionElement = (): BodyElement =>
     ({
         kind: ElementKind.Pullquote,
         quote: "quote",
-        attribution: new Some('attribution')
+        attribution: some('attribution')
     })
 
 const richLinkElement = (): BodyElement =>
@@ -92,7 +92,7 @@ const embedElement = (): BodyElement =>
     ({
         kind: ElementKind.Embed,
         html: '<section>Embed</section>',
-        alt: new None
+        alt: none,
     })
 
 const videoElement = (): BodyElement =>
@@ -116,7 +116,7 @@ const atomElement = (): BodyElement =>
         kind: ElementKind.InteractiveAtom,
         css: "main { background: yellow; }",
         html: "<main>Some content</main>",
-        js: new Some("console.log('init')"),
+        js: some("console.log('init')"),
     })
 
 const render = (element: BodyElement): ReactNode[] =>

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -6,7 +6,8 @@ import { Design } from '@guardian/types/Format';
 import { BodyElement, ElementKind } from 'bodyElement';
 import { partition, Result } from 'types/result';
 import { Item } from 'item';
-import { compose } from 'lib';
+import { compose, pipe2 } from 'lib';
+import { map, withDefault } from 'types/option';
 
 
 // ----- Types ----- //
@@ -27,7 +28,7 @@ const extractInteractiveAssets = (elements: BodyElement[]): Assets =>
         if (elem.kind === ElementKind.InteractiveAtom) {
             return {
                 styles: [ ...styles, elem.css ],
-                scripts: elem.js.fmap(js => [ ...scripts, js ]).withDefault(scripts),
+                scripts: pipe2(elem.js, map(js => [ ...scripts, js ]), withDefault(scripts)),
             };
         }
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,8 +2,9 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { remSpace } from '@guardian/src-foundations';
 import { css, SerializedStyles } from '@emotion/core'
-import { Option, Some, None } from 'types/option';
+import { Option, some, none, map, withDefault } from 'types/option';
 import { textSans } from '@guardian/src-foundations/typography';
+import { pipe2 } from 'lib';
 
 const BASE_PADDING = 8;
 
@@ -160,35 +161,35 @@ export const fontFace = (
 ): string => `
   @font-face {
     font-family: ${family};
-    ${style.fmap((s: string) => `font-style: ${s};`).withDefault('')}
-    ${weight.fmap((w: number | string) => `font-weight: ${w};`).withDefault('')}
+    ${pipe2(style, map((s: string) => `font-style: ${s};`), withDefault(''))}
+    ${pipe2(weight, map((w: number | string) => `font-weight: ${w};`), withDefault(''))}
     src: url('${url}');
   }
 `;
 
 export const pageFonts = `
-    ${fontFace("Guardian Text Egyptian Web", new Some(400), new None, "/assets/fonts/GuardianTextEgyptian-Reg.ttf")}
-    ${fontFace("Guardian Text Egyptian Web", new Some(400), new Some("italic"), "/assets/fonts/GuardianTextEgyptian-RegItalic.ttf")}
-    ${fontFace("Guardian Text Egyptian Web", new Some(700), new None, "/assets/fonts/GuardianTextEgyptian-Bold.ttf")}
-    ${fontFace("Guardian Text Egyptian Web", new Some(700), new Some("italic"), "/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf")}
-    ${fontFace("Guardian Text Egyptian Web", new Some("bold"), new None, "/assets/fonts/GuardianTextEgyptian-Bold.ttf")}
-    ${fontFace("Guardian Text Egyptian Web", new Some("bold"), new Some("italic"), "/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf")}
+    ${fontFace("Guardian Text Egyptian Web", some(400), none, "/assets/fonts/GuardianTextEgyptian-Reg.ttf")}
+    ${fontFace("Guardian Text Egyptian Web", some(400), some("italic"), "/assets/fonts/GuardianTextEgyptian-RegItalic.ttf")}
+    ${fontFace("Guardian Text Egyptian Web", some(700), none, "/assets/fonts/GuardianTextEgyptian-Bold.ttf")}
+    ${fontFace("Guardian Text Egyptian Web", some(700), some("italic"), "/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf")}
+    ${fontFace("Guardian Text Egyptian Web", some("bold"), none, "/assets/fonts/GuardianTextEgyptian-Bold.ttf")}
+    ${fontFace("Guardian Text Egyptian Web", some("bold"), some("italic"), "/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf")}
 
-    ${fontFace("Guardian Text Sans Web", new Some(400), new None, "/assets/fonts/GuardianTextSans-Regular.ttf")}
-    ${fontFace("Guardian Text Sans Web", new Some(400), new Some("italic"), "/assets/fonts/GuardianTextSans-RegularItalic.ttf")}
-    ${fontFace("Guardian Text Sans Web", new Some(700), new None, "/assets/fonts/GuardianTextSans-Bold.ttf")}
-    ${fontFace("Guardian Text Sans Web", new Some(700), new Some("italic"), "/assets/fonts/GuardianTextSans-BoldItalic.ttf")}
+    ${fontFace("Guardian Text Sans Web", some(400), none, "/assets/fonts/GuardianTextSans-Regular.ttf")}
+    ${fontFace("Guardian Text Sans Web", some(400), some("italic"), "/assets/fonts/GuardianTextSans-RegularItalic.ttf")}
+    ${fontFace("Guardian Text Sans Web", some(700), none, "/assets/fonts/GuardianTextSans-Bold.ttf")}
+    ${fontFace("Guardian Text Sans Web", some(700), some("italic"), "/assets/fonts/GuardianTextSans-BoldItalic.ttf")}
 
-    ${fontFace("GH Guardian Headline", new Some(300), new None, "/assets/fonts/GHGuardianHeadline-Light.ttf")}
-    ${fontFace("GH Guardian Headline", new Some(300), new Some("italic"), "/assets/fonts/GHGuardianHeadline-LightItalic.ttf")}
-    ${fontFace("GH Guardian Headline", new Some(400), new None, "/assets/fonts/GHGuardianHeadline-Regular.ttf")}
-    ${fontFace("GH Guardian Headline", new Some(400), new Some("italic"), "/assets/fonts/GHGuardianHeadline-RegularItalic.ttf")}
-    ${fontFace("GH Guardian Headline", new Some(500), new None,  "/assets/fonts/GHGuardianHeadline-Medium.ttf")}
-    ${fontFace("GH Guardian Headline", new Some(500), new Some("italic"),  "/assets/fonts/GHGuardianHeadline-MediumItalic.ttf")}
-    ${fontFace("GH Guardian Headline", new Some(600), new None,  "/assets/fonts/GHGuardianHeadline-Semibold.ttf")}
-    ${fontFace("GH Guardian Headline", new Some(600), new Some("italic"),  "/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf")}
-    ${fontFace("GH Guardian Headline", new Some(700), new None, "/assets/fonts/GHGuardianHeadline-Bold.ttf")}
-    ${fontFace("GH Guardian Headline", new Some(700), new Some("italic"), "/assets/fonts/GHGuardianHeadline-BoldItalic.ttf")}
+    ${fontFace("GH Guardian Headline", some(300), none, "/assets/fonts/GHGuardianHeadline-Light.ttf")}
+    ${fontFace("GH Guardian Headline", some(300), some("italic"), "/assets/fonts/GHGuardianHeadline-LightItalic.ttf")}
+    ${fontFace("GH Guardian Headline", some(400), none, "/assets/fonts/GHGuardianHeadline-Regular.ttf")}
+    ${fontFace("GH Guardian Headline", some(400), some("italic"), "/assets/fonts/GHGuardianHeadline-RegularItalic.ttf")}
+    ${fontFace("GH Guardian Headline", some(500), none,  "/assets/fonts/GHGuardianHeadline-Medium.ttf")}
+    ${fontFace("GH Guardian Headline", some(500), some("italic"),  "/assets/fonts/GHGuardianHeadline-MediumItalic.ttf")}
+    ${fontFace("GH Guardian Headline", some(600), none,  "/assets/fonts/GHGuardianHeadline-Semibold.ttf")}
+    ${fontFace("GH Guardian Headline", some(600), some("italic"),  "/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf")}
+    ${fontFace("GH Guardian Headline", some(700), none, "/assets/fonts/GHGuardianHeadline-Bold.ttf")}
+    ${fontFace("GH Guardian Headline", some(700), some("italic"), "/assets/fonts/GHGuardianHeadline-BoldItalic.ttf")}
 
-    ${fontFace("Guardian Icons", new None, new None, "/assets/fonts/icons.otf")}
+    ${fontFace("Guardian Icons", none, none, "/assets/fonts/icons.otf")}
 `;

--- a/src/types/result.test.ts
+++ b/src/types/result.test.ts
@@ -2,6 +2,7 @@
 
 import { Result, Ok, Err } from './result';
 import { identity } from 'lib';
+import { withDefault } from 'types/option';
 
 
 // ----- Setup ----- //
@@ -76,10 +77,10 @@ describe('mapError', () => {
 
 describe('toOption', () => {
     it('produces Some when Result is Ok', () => {
-        expect(ok.toOption().withDefault(6)).toBe(4);
+        expect(withDefault(6)(ok.toOption())).toBe(4);
     });
 
     it('produces None when Result is Err', () => {
-        expect(err.toOption().withDefault(6)).toBe(6);
+        expect(withDefault(6)(err.toOption())).toBe(6);
     });
 });

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import { Monad } from './monad';
-import { Option, Some, None } from './option';
+import { Option, some, none } from './option';
 
 
 // ----- Classes ----- //
@@ -76,7 +76,7 @@ class Ok<E, B> implements ResultInterface<E, B> {
      * a `None`.
      */
     toOption(): Option<B> {
-        return new Some(this.value);
+        return some(this.value);
     }
 
     constructor(value: B) {
@@ -106,7 +106,7 @@ class Err<E, B> implements ResultInterface<E, B> {
     }
 
     toOption(): Option<B> {
-        return new None();
+        return none;
     }
 
     constructor(error: E) {


### PR DESCRIPTION
## Why are you doing this?

`Option` moves from an [ES6 class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) to a simpler [discriminated union](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions).

I'm hoping this will provide a few benefits for us. Firstly, we should not longer need to write serialisation/deserialisation code for `Option`, as it will now be comprised of plain JS objects that JSON serialisers understand out of the box. Secondly, it should allow us to make use of `Option` in places like the new [liveblog-rendering](https://github.com/guardian/liveblog-rendering) repo *without* placing a requirement on dotcom to migrate to the framework that comes with it. In practice, this means that they can treat it like a normal JS object if they choose, without worrying about `map`, `andThen` et al. Thirdly, it simplifies the implementation of `Option` itself, which is now made up of a couple of types and a handful of functions, rather than the class-based inheritance model it was using before.

I've also included a new set of `pipe` functions to make working with the new `Option` format easier. These are inspired in part by the elegant [fp-ts](https://github.com/gcanti/fp-ts) library, as well as similar operators that exist in languages like [Elm](https://package.elm-lang.org/packages/elm/core/latest/Basics#|%3E), [Haskell](https://hackage.haskell.org/package/base-4.14.0.0/docs/Prelude.html#v:-36-), [F#](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/symbol-and-operator-reference/) etc.

**Note:** If this is successful I will look to migrating over `Result` next.

FYI @SiAdcock @gtrufitt @dskamiotis @oliverlloyd 

## Changes

- Removed the use of ES6 classes for `Option`; now simple objects
- Migrated `Option` methods to plain functions
- Refactored codebase to use new `Option`
- Removed serialisation code for `Option`
