### PR TITLE
add branding to apps rendering request

### DIFF
--- a/api-models/thrift/src/main/thrift/appsRendering.thrift
+++ b/api-models/thrift/src/main/thrift/appsRendering.thrift
@@ -3,13 +3,20 @@ include "content/v1.thrift"
 namespace scala com.gu.mobile.ar.models
 namespace typescript _at_guardian.apps_rendering_api_models
 
+struct Branding {
+    1: required string brandingType
+    2: required string sponsorName
+    3: required string logo
+    4: required string sponsorUri
+    5: required string label
+    6: optional string altLogo
+    7: required string aboutUri
+}
+
 struct RenderingRequest {
-
     1: required v1.Content content
-
     2: optional i32 commentCount 
-
     3: optional bool specialReport
-
     4: optional map<string,string> targetingParams
+    5: optional Branding branding
 }


### PR DESCRIPTION
## Why are you doing this?
This data is needed to render logos on articles such as this https://www.theguardian.com/cities/2020/jan/13/guardian-cities-farewell-from-the-editor.

We have an `alt` logo for dark backgrounds that we can make use of in dark mode.


<img width="157" alt="Screen Shot 2020-06-24 at 16 50 42" src="https://user-images.githubusercontent.com/11618797/85588754-e126db80-b63a-11ea-9b44-df192dc0deb2.png">
