### PR TITLE
LiveBlog dark mode list items

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -109,10 +109,8 @@ const listStyles: SerializedStyles = css`
     clear: both;
 `;
 
-const listItemStyles = (format: Format): SerializedStyles => {
-    const backgroundColour = format.design === Design.Media
-        ? neutral[46] : neutral[86];
-    return css`
+const listItemStyles = (format: Format): SerializedStyles[] => {
+    const baseStyles = css`
         padding-left: ${remSpace[6]};
         padding-bottom: .375rem;
 
@@ -123,7 +121,7 @@ const listItemStyles = (format: Format): SerializedStyles => {
             height: 1rem;
             width: 1rem;
             margin-right: ${remSpace[2]};
-            background-color: ${backgroundColour};
+            background-color: ${neutral[86]};
             margin-left: -${remSpace[6]};
             vertical-align: middle;
         }
@@ -139,6 +137,29 @@ const listItemStyles = (format: Format): SerializedStyles => {
             }
         `}
     `;
+
+    const mediaStyles = css`
+        &::before {
+            background-color: ${neutral[46]};
+        }
+    `
+
+    const liveblogStyles = css`
+        ${darkModeCss`
+            &::before {
+                background-color: ${neutral[86]};
+            }
+        `}
+    `
+
+    switch (format.design) {
+        case (Design.Media):
+            return [baseStyles, mediaStyles];
+        case (Design.Live):
+            return [baseStyles, liveblogStyles];
+        default:
+            return [baseStyles];
+    }
 }
 
 const HeadingTwoStyles = (format: Format): SerializedStyles => {


### PR DESCRIPTION
## Why are you doing this?
Live blog in dark mode was not displaying listItem bullet points clearly, changed value to make lighter in colour and clearer to see.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/85757806-ad65b780-b707-11ea-8436-4888b9b19dd6.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/85757904-c40c0e80-b707-11ea-8dc8-4a5558466869.png" width="300px" /> |
