### PR TITLE
Functional Result

### DIFF
--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -1,6 +1,6 @@
 import { Atoms } from "@guardian/content-api-models/v1/atoms";
 import { BlockElement } from "@guardian/content-api-models/v1/blockElement";
-import { Result, Err, Ok } from "types/result";
+import { Result, err, ok } from 'types/result';
 import { BodyElement, ElementKind } from "bodyElement";
 import { fromNullable } from "types/option";
 
@@ -12,16 +12,16 @@ function parseAtom(element: BlockElement, atoms: Atoms): Result<string, BodyElem
             const atom = atoms.interactives?.find(interactive => interactive.id === id);
 
             if (atom?.data?.kind !== "interactive") {
-                return new Err(`No atom matched this id: ${id}`);
+                return err(`No atom matched this id: ${id}`);
             }
 
             const { html, css, mainJS: js } = atom?.data?.interactive;
 
             if (!html || !css) {
-                return new Err(`No html or css for atom: ${id}`);
+                return err(`No html or css for atom: ${id}`);
             }
 
-            return new Ok({
+            return ok({
                 kind: ElementKind.InteractiveAtom,
                 html,
                 css,
@@ -33,20 +33,20 @@ function parseAtom(element: BlockElement, atoms: Atoms): Result<string, BodyElem
             const atom = atoms.explainers?.find(explainer => explainer.id === id);
 
             if (atom?.data?.kind !== "explainer" || !id) {
-                return new Err(`No atom matched this id: ${id}`);
+                return err(`No atom matched this id: ${id}`);
             }
 
             const { title, body } = atom?.data?.explainer;
 
             if (!title || !body) {
-                return new Err(`No title or body for atom: ${id}`);
+                return err(`No title or body for atom: ${id}`);
             }
 
-            return new Ok({ kind: ElementKind.ExplainerAtom, html: body, title, id });
+            return ok({ kind: ElementKind.ExplainerAtom, html: body, title, id });
         }
 
         default: {
-            return new Err(`Atom type not supported: ${element.contentAtomTypeData?.atomType}`);
+            return err(`Atom type not supported: ${element.contentAtomTypeData?.atomType}`);
         }
     }
 }

--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -9,13 +9,14 @@ import {
     map,
     withDefault,
 } from 'types/option';
-import { Result, Err, Ok } from 'types/result';
+import { Result, err, ok, map as rmap } from 'types/result';
 import { Context, DocParser } from 'types/parserContext';
 import { Image as ImageData, parseImage } from 'image';
-import { isElement, pipe2 } from 'lib';
+import { isElement, pipe2, pipe } from 'lib';
 import JsonSerialisable from 'types/jsonSerialisable';
 import { parseAtom } from 'atoms';
 import { formatDate } from 'date';
+
 
 // ----- Types ----- //
 
@@ -159,10 +160,10 @@ const tweetContent = (tweetId: string, doc: DocumentFragment): Result<string, No
     const blockquote = doc.querySelector('blockquote');
 
     if (blockquote !== null) {
-        return new Ok(blockquote.childNodes);
+        return ok(blockquote.childNodes);
     }
 
-    return new Err(`There was no blockquote element in the tweet with id: ${tweetId}`);
+    return err(`There was no blockquote element in the tweet with id: ${tweetId}`);
 }
 
 const parseIframe = (docParser: DocParser) =>
@@ -171,10 +172,10 @@ const parseIframe = (docParser: DocParser) =>
         const src = iframe?.getAttribute('src');
 
         if (!iframe || !src) {
-            return new Err('No iframe within html');
+            return err('No iframe within html');
         }
 
-        return new Ok({
+        return ok({
             kind,
             src,
             width: iframe.getAttribute('width') ?? "380",
@@ -190,30 +191,30 @@ const parse = (context: Context, atoms?: Atoms) =>
             const html = element?.textTypeData?.html;
 
             if (!html) {
-                return new Err('No html field on textTypeData');
+                return err('No html field on textTypeData');
             }
 
-            return new Ok({ kind: ElementKind.Text, doc: context.docParser(html) });
+            return ok({ kind: ElementKind.Text, doc: context.docParser(html) });
         }
 
         case ElementType.IMAGE:
             return pipe2(
                 parseImage(context)(element),
-                map<ImageData, Result<string, Image>>(image => new Ok({
+                map<ImageData, Result<string, Image>>(image => ok({
                     kind: ElementKind.Image,
                     ...image
                 })),
-                withDefault<Result<string, Image>>(new Err('I couldn\'t find a master asset')),
+                withDefault<Result<string, Image>>(err('I couldn\'t find a master asset')),
             );
 
         case ElementType.PULLQUOTE: {
             const { html: quote, attribution } = element.pullquoteTypeData ?? {};
 
             if (!quote) {
-                return new Err('No quote field on pullquoteTypeData');
+                return err('No quote field on pullquoteTypeData');
             }
 
-            return new Ok({
+            return ok({
                 kind: ElementKind.Pullquote,
                 quote,
                 attribution: fromNullable(attribution),
@@ -224,45 +225,47 @@ const parse = (context: Context, atoms?: Atoms) =>
             const { iframeUrl, alt } = element.interactiveTypeData ?? {};
 
             if (!iframeUrl) {
-                return new Err('No iframeUrl field on interactiveTypeData');
+                return err('No iframeUrl field on interactiveTypeData');
             }
 
-            return new Ok({ kind: ElementKind.Interactive, url: iframeUrl, alt });
+            return ok({ kind: ElementKind.Interactive, url: iframeUrl, alt });
         }
 
         case ElementType.RICH_LINK: {
             const { url, linkText } = element.richLinkTypeData ?? {};
 
             if (!url) {
-                return new Err('No "url" field on richLinkTypeData');
+                return err('No "url" field on richLinkTypeData');
             } else if (!linkText) {
-                return new Err('No "linkText" field on richLinkTypeData');
+                return err('No "linkText" field on richLinkTypeData');
             }
 
-            return new Ok({ kind: ElementKind.RichLink, url, linkText });
+            return ok({ kind: ElementKind.RichLink, url, linkText });
         }
 
         case ElementType.TWEET: {
             const { id, html: h } = element.tweetTypeData ?? {};
 
             if (!id) {
-                return new Err('No "id" field on tweetTypeData')
+                return err('No "id" field on tweetTypeData')
             } else if (!h) {
-                return new Err('No "html" field on tweetTypeData')
+                return err('No "html" field on tweetTypeData')
             }
 
-            return tweetContent(id, context.docParser(h))
-                .fmap(content => ({ kind: ElementKind.Tweet, content }));
+            return pipe(
+                tweetContent(id, context.docParser(h)),
+                rmap(content => ({ kind: ElementKind.Tweet, content })),
+            );
         }
 
         case ElementType.EMBED: {
             const { html: embedHtml, alt } = element.embedTypeData ?? {};
 
             if (!embedHtml) {
-                return new Err('No html field on embedTypeData')
+                return err('No html field on embedTypeData')
             }
 
-            return new Ok({ kind: ElementKind.Embed, html: embedHtml, alt: fromNullable(alt) });
+            return ok({ kind: ElementKind.Embed, html: embedHtml, alt: fromNullable(alt) });
         }
 
         case ElementType.MEMBERSHIP: {
@@ -275,13 +278,13 @@ const parse = (context: Context, atoms?: Atoms) =>
             } = element.membershipTypeData ?? {};
 
             if (!linkText || !url) {
-                return new Err('No linkText or originalUrl field on membershipTypeData');
+                return err('No linkText or originalUrl field on membershipTypeData');
             }
 
             const formattedDate = start?.iso8601 && !isNaN(new Date(start?.iso8601).valueOf())
                 ? formatDate(new Date(start?.iso8601)) : undefined;
 
-            return new Ok({
+            return ok({
                 kind: ElementKind.LiveEvent,
                 linkText,
                 url,
@@ -295,17 +298,17 @@ const parse = (context: Context, atoms?: Atoms) =>
             const { html: instagramHtml } = element.instagramTypeData ?? {};
 
             if (!instagramHtml) {
-                return new Err('No html field on instagramTypeData')
+                return err('No html field on instagramTypeData')
             }
 
-            return new Ok({ kind: ElementKind.Instagram, html: instagramHtml });
+            return ok({ kind: ElementKind.Instagram, html: instagramHtml });
         }
 
         case ElementType.AUDIO: {
             const { html: audioHtml } = element.audioTypeData ?? {};
 
             if (!audioHtml) {
-                return new Err('No html field on audioTypeData')
+                return err('No html field on audioTypeData')
             }
 
             return parseIframe(context.docParser)(audioHtml, ElementKind.Audio);
@@ -315,7 +318,7 @@ const parse = (context: Context, atoms?: Atoms) =>
             const { html: videoHtml } = element.videoTypeData ?? {};
 
             if (!videoHtml) {
-                return new Err('No html field on videoTypeData')
+                return err('No html field on videoTypeData')
             }
 
             return parseIframe(context.docParser)(videoHtml, ElementKind.Video);
@@ -323,14 +326,14 @@ const parse = (context: Context, atoms?: Atoms) =>
 
         case ElementType.CONTENTATOM: {
             if (!atoms) {
-                return new Err('No atom data returned by capi')
+                return err('No atom data returned by capi')
             }
 
             return parseAtom(element, atoms);
         }
 
         default:
-            return new Err(`I'm afraid I don't understand the element I was given: ${element.type}`);
+            return err(`I'm afraid I don't understand the element I was given: ${element.type}`);
     }
 
 }
@@ -338,7 +341,7 @@ const parse = (context: Context, atoms?: Atoms) =>
 const parseElements = (context: Context, atoms?: Atoms) =>
     (elements: Elements): Result<string, BodyElement>[] => {
         if (!elements) {
-            return [new Err('No body elements available')];
+            return [err('No body elements available')];
         }
         return elements.map(parse(context, atoms));
     }

--- a/src/client/liveblog.ts
+++ b/src/client/liveblog.ts
@@ -9,6 +9,8 @@ import { fromSerialisable } from 'liveBlock';
 import { parse } from 'client/parser';
 import LiveblogBody from 'components/liveblog/body';
 import { withDefault } from 'types/option';
+import { pipe3 } from 'lib';
+import { toOption } from 'types/result';
 
 
 // ----- Setup ----- //
@@ -25,7 +27,12 @@ const format: Format = {
 // ----- Functions ----- //
 
 const docParser = (html: string): DocumentFragment =>
-    withDefault(new DocumentFragment())(parse(domParser)(html).toOption());
+    pipe3(
+        html,
+        parse(domParser),
+        toOption,
+        withDefault(new DocumentFragment()),
+    );
 
 const deserialise = fromSerialisable(docParser);
 

--- a/src/client/parser.ts
+++ b/src/client/parser.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Result, Err, Ok } from 'types/result';
+import { Result, err, ok } from 'types/result';
 
 
 // ----- Functions ----- //
@@ -12,9 +12,9 @@ const parse = (domParser: DOMParser) => (s: string): Result<string, DocumentFrag
         const docNodes = domParser.parseFromString(s, 'text/html').body.childNodes;
 
         Array.from(docNodes).forEach(node => frag.appendChild(node));
-        return new Ok(frag);
+        return ok(frag);
     } catch (e) {
-        return new Err(`I wasn't able to parse the string into a DocumentFragment because: ${e}`);
+        return err(`I wasn't able to parse the string into a DocumentFragment because: ${e}`);
     }
 
 }

--- a/src/components/byline.stories.tsx
+++ b/src/components/byline.stories.tsx
@@ -8,6 +8,8 @@ import Byline from './byline';
 import { Pillar, Design, Display } from 'format';
 import { Option } from 'types/option';
 import { parse } from 'client/parser';
+import { pipe2 } from 'lib';
+import { toOption } from 'types/result';
 
 
 // ----- Setup ----- //
@@ -25,8 +27,11 @@ const job = (): string =>
     text('Job Title', 'Editor of things');
 
 const mockBylineHtml = (): Option<DocumentFragment> =>
-    parseByline(`<a href="${profileLink()}">${byline()}</a> ${job()}`)
-        .toOption();
+    pipe2(
+        `<a href="${profileLink()}">${byline()}</a> ${job()}`,
+        parseByline,
+        toOption,
+    );
 
 
 // ----- Stories ----- //

--- a/src/components/standfirst.stories.tsx
+++ b/src/components/standfirst.stories.tsx
@@ -9,6 +9,8 @@ import { Option } from 'types/option';
 import { article, review, feature, comment } from 'fixtures/item';
 import { parse } from 'client/parser';
 import { selectPillar } from 'storybookHelpers';
+import { pipe2 } from 'lib';
+import { toOption } from 'types/result';
 
 
 // ----- Setup ----- //
@@ -17,8 +19,11 @@ const parser = new DOMParser();
 const parseStandfirst = parse(parser);
 
 const standfirst: Option<DocumentFragment> =
-    parseStandfirst('<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>')
-        .toOption();
+    pipe2(
+        '<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>',
+        parseStandfirst,
+        toOption,
+    );
 
 
 // ----- Stories ----- //

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -585,7 +585,7 @@ describe('audio elements', () => {
         const item = f(articleContentWith(audioElement)) as Standard;
         pipe2(
             item.body[0],
-            map<string, BodyElement, Audio>(element => element as Audio),
+            map<BodyElement, Audio>(element => element as Audio),
             map(({ src, width, height }) => {
                 expect(src).toContain('https://open.spotify.com/embed/track/');
                 expect(width).toContain('300');
@@ -645,7 +645,7 @@ describe('video elements', () => {
         const item = f(articleContentWith(videoElement)) as Standard;
         pipe2(
             item.body[0],
-            map<string, BodyElement, Video>(element => element as Video),
+            map<BodyElement, Video>(element => element as Video),
             map(({ src, width, height }) => {
                 expect(src).toBe('https://www.youtube-nocookie.com/embed/');
                 expect(width).toBe('460');

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -13,6 +13,8 @@ import { JSDOM } from 'jsdom';
 import { Display } from '@guardian/types/Format';
 import Int64 from 'node-int64';
 import { withDefault } from 'types/option';
+import { pipe2 } from 'lib';
+import { toOption, map } from 'types/result';
 
 const articleContent = {
     id: "",
@@ -191,8 +193,11 @@ const articleContentWithImageWithoutFile = articleContentWith({
 const f = fromCapi({ docParser: JSDOM.fragment, salt: 'mockSalt' });
 
 const getFirstBody = (item: Review | Standard) =>
-    withDefault<BodyElement>({ kind: ElementKind.Interactive, url: '' })(item.body[0].toOption());
-
+    pipe2(
+        item.body[0],
+        toOption,
+        withDefault<BodyElement>({ kind: ElementKind.Interactive, url: '' }),
+    );
 
 describe('fromCapi returns correct Item', () => {
     test('media', () => {
@@ -344,9 +349,11 @@ describe('interactive elements', () => {
             }
         }
         const item = f(articleContentWith(interactiveElement)) as Standard;
-        const element = withDefault<BodyElement>
-            ({ kind: ElementKind.RichLink, url: '', linkText: '' })
-            (item.body[0].toOption());
+        const element = pipe2(
+            item.body[0],
+            toOption,
+            withDefault<BodyElement>({ kind: ElementKind.RichLink, url: '', linkText: '' }),
+        );
         expect(element.kind).toBe(ElementKind.Interactive);
     })
 
@@ -359,9 +366,11 @@ describe('interactive elements', () => {
             }
         }
         const item = f(articleContentWith(interactiveElement)) as Standard;
-        const element = withDefault<BodyElement>
-            ({ kind: ElementKind.RichLink, url: '', linkText: '' })
-            (item.body[0].toOption());
+        const element = pipe2(
+            item.body[0],
+            toOption,
+            withDefault<BodyElement>({ kind: ElementKind.RichLink, url: '', linkText: '' }),
+        );
         expect(element.kind).toBe(ElementKind.RichLink);
     })
 });
@@ -574,12 +583,15 @@ describe('audio elements', () => {
             }
         }
         const item = f(articleContentWith(audioElement)) as Standard;
-        item.body[0].fmap<Audio>(element => element as Audio)
-            .fmap(({ src, width, height }) => {
+        pipe2(
+            item.body[0],
+            map<string, BodyElement, Audio>(element => element as Audio),
+            map(({ src, width, height }) => {
                 expect(src).toContain('https://open.spotify.com/embed/track/');
                 expect(width).toContain('300');
                 expect(height).not.toContain('380');
-            });
+            }),
+        );
     });
 
     test('does not render if no iframe inside the html', () => {
@@ -631,12 +643,15 @@ describe('video elements', () => {
             }
         }
         const item = f(articleContentWith(videoElement)) as Standard;
-        item.body[0].fmap<Video>(element => element as Video)
-            .fmap(({ src, width, height }) => {
+        pipe2(
+            item.body[0],
+            map<string, BodyElement, Video>(element => element as Video),
+            map(({ src, width, height }) => {
                 expect(src).toBe('https://www.youtube-nocookie.com/embed/');
                 expect(width).toBe('460');
                 expect(height).toBe('259');
-            });
+            })
+        );
     });
 
     test('does not render if no iframe inside the html', () => {

--- a/src/liveBlock.ts
+++ b/src/liveBlock.ts
@@ -13,7 +13,7 @@ import {
     fromSerialisable as bodyElementFromSerialisable,
 } from 'bodyElement';
 import { maybeCapiDate } from 'capi';
-import { partition, Ok } from 'types/result';
+import { partition, ok } from 'types/result';
 import { compose, pipe3 } from 'lib';
 import { fromString as dateFromString } from 'date';
 
@@ -66,7 +66,7 @@ const deserialiseLiveBlock = (docParser: DocParser) => ({
         title,
         firstPublished: andThen(dateFromString)(firstPublished),
         lastModified: andThen(dateFromString)(lastModified),
-        body: body.map((elem: any) => new Ok(bodyElementFromSerialisable(docParser)(elem))),
+        body: body.map((elem: any) => ok(bodyElementFromSerialisable(docParser)(elem))),
     });
 
 const toSerialisable = (blocks: LiveBlock[]): JsonSerialisable =>

--- a/src/types/result.test.ts
+++ b/src/types/result.test.ts
@@ -1,14 +1,14 @@
 // ----- Imports ----- //
 
-import { Result, Ok, Err } from './result';
-import { identity } from 'lib';
+import { Result, ok, err, either, map, andThen, mapError, toOption } from './result';
+import { identity, pipe2 } from 'lib';
 import { withDefault } from 'types/option';
 
 
 // ----- Setup ----- //
 
-const ok: Result<string, number> = new Ok(4);
-const err: Result<string, number> = new Err('message');
+const mockOk: Result<string, number> = ok(4);
+const mockErr: Result<string, number> = err('message');
 
 const onOk = (a: number): number => a + 2;
 const onError = (e: string): string => `Output: ${e}`;
@@ -18,69 +18,99 @@ const onError = (e: string): string => `Output: ${e}`;
 
 describe('either', () => {
     it('runs the correct function when Result is Ok', () => {
-        expect(ok.either<number | string>(onError, onOk)).toBe(6);
+        expect(either<string, number, number | string>(onError, onOk)(mockOk)).toBe(6);
     });
 
     it('runs the correct function when Result is Err', () => {
-        expect(err.either<number | string>(onError, onOk)).toBe('Output: message');
+        expect(either<string, number, number | string>(onError, onOk)(mockErr))
+            .toBe('Output: message');
     });
 });
 
-describe('fmap', () => {
+describe('map', () => {
     it('runs the function when Result is Ok', () => {
-        expect(ok.fmap(onOk).either<number | string>(identity, identity)).toBe(6);
+        expect(pipe2(
+            mockOk,
+            map(onOk),
+            either(identity, identity),
+        )).toBe(6);
     });
 
     it('passes the error through when Result is Err', () => {
-        expect(err.fmap(a => `Output: ${a}`).either<number | string>(identity, identity))
-            .toBe('message');
+        expect(pipe2(
+            mockErr,
+            map(a => `Output: ${a}`),
+            either(identity, identity),
+        )).toBe('message');
     });
 });
 
 describe('andThen', () => {
     it('runs the function and unwraps the result when both Results are Ok', () => {
-        const f = (a: number): Result<string, number> => new Ok(a + 2);
+        const f = (a: number): Result<string, number> => ok(a + 2);
 
-        expect(ok.andThen(f).either<string | number>(identity, identity)).toBe(6);
+        expect(pipe2(
+            mockOk,
+            andThen(f),
+            either<string, number, string | number>(identity, identity),
+        )).toBe(6);
     });
 
     it('passes through the Err when the first Result is Err', () => {
-        const f = (a: number): Result<string, number> => new Ok(a + 2);
+        const f = (a: number): Result<string, number> => ok(a + 2);
 
-        expect(err.andThen(f).either<string | number>(identity, identity)).toBe('message');
+        expect(pipe2(
+            mockErr,
+            andThen(f),
+            either<string, number, string | number>(identity, identity),
+        )).toBe('message');
     });
 
     it('passes through the Err when the second Result is Err', () => {
-        const f = (_: number): Result<string, number> => new Err('message');
+        const f = (_: number): Result<string, number> => err('message');
 
-        expect(ok.andThen(f).either<string | number>(identity, identity)).toBe('message');
+        expect(pipe2(
+            mockOk,
+            andThen(f),
+            either<string, number, string | number>(identity, identity),
+        )).toBe('message');
     });
 
     it('passes through the first Err when the first Result is Err', () => {
-        const f = (_: number): Result<string, number> => new Err('secondMessage');
+        const f = (_: number): Result<string, number> => err('secondMessage');
 
-        expect(err.andThen(f).either<string | number>(identity, identity)).toBe('message');
+        expect(pipe2(
+            mockErr,
+            andThen(f),
+            either<string, number, string | number>(identity, identity),
+        )).toBe('message');
     });
 });
 
 describe('mapError', () => {
     it('passes through the result when Result is Ok', () => {
-        expect(ok.mapError(onError).either<string | number>(identity, identity))
-            .toBe(4);
+        expect(pipe2(
+            mockOk,
+            mapError(onError),
+            either<string, number, string | number>(identity, identity)),
+        ).toBe(4);
     });
 
     it('runs the function when Result is Err', () => {
-        expect(err.mapError(onError).either<string | number>(identity, identity))
-            .toBe('Output: message');
+        expect(pipe2(
+            mockErr,
+            mapError(onError),
+            either(identity, identity),
+        )).toBe('Output: message');
     });
 });
 
 describe('toOption', () => {
     it('produces Some when Result is Ok', () => {
-        expect(withDefault(6)(ok.toOption())).toBe(4);
+        expect(pipe2(mockOk, toOption, withDefault(6))).toBe(4);
     });
 
     it('produces None when Result is Err', () => {
-        expect(withDefault(6)(err.toOption())).toBe(6);
+        expect(pipe2(mockErr, toOption, withDefault(6))).toBe(6);
     });
 });

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,124 +1,35 @@
 // ----- Imports ----- //
 
-import { Monad } from './monad';
 import { Option, some, none } from './option';
 
 
-// ----- Classes ----- //
+// ----- Types ----- //
 
-interface ResultInterface<E, B> extends Monad<B> {
-    either<C>(f: (e: E) => C, g: (b: B) => C): C;
-    mapError<F>(g: (e: E) => F): Result<F, B>;
-    toOption(): Option<B>;
+const enum ResultKind {
+    Ok,
+    Err,
 }
 
-class Ok<E, B> implements ResultInterface<E, B> {
-
-    value: B;
-
-    /**
-     * The method for turning a `Result<E, A>` into a plain value.
-     * If this is an `Err`, apply the first function to the error value and
-     * return the result. If this is an `Ok`, apply the second function to
-     * the value and return the result.
-     * @param f The function to apply if this is an `Err`
-     * @param g The function to apply if this is an `Ok`
-     * @example
-     * const flakyTaskResult: Result<string, number> = flakyTask(options);
-     * 
-     * flakyTaskResult.either(
-     *     data => `We got the data! Here it is: ${data}`,
-     *     error => `Uh oh, an error: ${error}`,
-     * )
-     */
-    either<C>(_f: (e: E) => C, g: (b: B) => C): C {
-        return g(this.value);
-    }
-
-    /**
-     * Similar to `Option.fmap`.
-     * Applies a function to the value in an `Ok`, does nothing to an `Err`.
-     * @param f The function to apply if this is an `Ok`
-     */
-    fmap<C>(f: (a: B) => C): Result<E, C> {
-        return new Ok(f(this.value));
-    }
-
-    /**
-     * Similar to `Option.andThen`. Applies to a `Result` a function that
-     * *also* returns a `Result`, and unwraps them to avoid nested `Result`s.
-     * Can be useful for stringing together operations that might fail.
-     * @example
-     * type RequestUser = number => Result<string, User>;
-     * type GetEmail = User => Result<string, string>;
-     * 
-     * // Request fails: Err('Network failure')
-     * // Request succeeds, problem accessing email: Err('Email field missing')
-     * // Both succeed: Ok('email_address')
-     * requestUser(id).andThen(getEmail)
-     */
-    andThen<C>(f: (b: B) => Result<E, C>): Result<E, C> {
-        return f(this.value);
-    }
-
-    /**
-     * The companion to `fmap`.
-     * Applies a function to the error in `Err`, does nothing to an `Ok`.
-     * @param g The function to apply if this is an `Err`
-     */
-    mapError<F>(_g: (e: E) => F): Result<F, B> {
-        return new Ok(this.value);
-    }
-
-    /**
-     * Converts a `Result<E, A>` into an `Option<A>`. If the result is an
-     * `Ok` this will be a `Some`, if the result is an `Err` this will be
-     * a `None`.
-     */
-    toOption(): Option<B> {
-        return some(this.value);
-    }
-
-    constructor(value: B) {
-        this.value = value;
-    }
-
+type Ok<A> = {
+    kind: ResultKind.Ok;
+    value: A;
 }
 
-class Err<E, B> implements ResultInterface<E, B> {
-
-    error: E;
-
-    either<C>(f: (e: E) => C, _g: (b: B) => C): C {
-        return f(this.error);
-    }
-
-    fmap<C>(_f: (a: B) => C): Result<E, C> {
-        return new Err(this.error);
-    }
-
-    andThen<C>(_f: (b: B) => Result<E, C>): Result<E, C> {
-        return new Err(this.error);
-    }
-
-    mapError<F>(g: (e: E) => F): Result<F, B> {
-        return new Err(g(this.error));
-    }
-
-    toOption(): Option<B> {
-        return none;
-    }
-
-    constructor(error: E) {
-        this.error = error;
-    }
-
+type Err<E> = {
+    kind: ResultKind.Err;
+    err: E;
 }
 
 /**
  * Represents either a value or an error; it's either an `Ok` or an `Err`.
  */
-type Result<E, A> = Ok<E, A> | Err<E, A>;
+type Result<E, A> = Err<E> | Ok<A>;
+
+
+// ----- Constructors ----- //
+
+const ok = <A>(a: A): Ok<A> => ({ kind: ResultKind.Ok, value: a });
+const err = <E>(e: E): Err<E> => ({ kind: ResultKind.Err, err: e });
 
 /**
  * Converts an operation that might throw into a `Result`
@@ -127,16 +38,81 @@ type Result<E, A> = Ok<E, A> | Err<E, A>;
  */
 function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
     try {
-        return new Ok(f());
+        return ok(f());
     } catch (_) {
-        return new Err(error);
+        return err(error);
     }
 }
+
+
+// ----- Functions ----- //
+
+/**
+ * The method for turning a `Result<E, A>` into a plain value.
+ * If this is an `Err`, apply the first function to the error value and
+ * return the result. If this is an `Ok`, apply the second function to
+ * the value and return the result.
+ * @param f The function to apply if this is an `Err`
+ * @param g The function to apply if this is an `Ok`
+ * @param result The Result
+ * @example
+ * const flakyTaskResult: Result<string, number> = flakyTask(options);
+ * 
+ * either(
+ *     data => `We got the data! Here it is: ${data}`,
+ *     error => `Uh oh, an error: ${error}`,
+ * )(flakyTaskResult)
+ */
+const either = <E, A, C>(f: (e: E) => C, g: (a: A) => C) => (result: Result<E, A>): C =>
+    result.kind === ResultKind.Ok ? g(result.value) : f(result.err);
+
+/**
+ * The companion to `map`.
+ * Applies a function to the error in `Err`, does nothing to an `Ok`.
+ * @param f The function to apply if this is an `Err`
+ * @param result The Result
+ */
+const mapError = <E, F>(f: (e: E) => F) => <A>(result: Result<E, A>): Result<F, A> =>
+    result.kind === ResultKind.Err ? err(f(result.err)) : result;
+
+/**
+ * Converts a `Result<E, A>` into an `Option<A>`. If the result is an
+ * `Ok` this will be a `Some`, if the result is an `Err` this will be
+ * a `None`.
+ * @param result The Result
+ */
+const toOption = <E, A>(result: Result<E, A>): Option<A> =>
+    result.kind === ResultKind.Ok ? some(result.value) : none;
+
+/**
+ * Similar to `Option.map`.
+ * Applies a function to the value in an `Ok`, does nothing to an `Err`.
+ * @param f The function to apply if this is an `Ok`
+ * @param result The Result
+ */
+const map = <E, A, B>(f: (a: A) => B) => (result: Result<E, A>): Result<E, B> =>
+    result.kind === ResultKind.Ok ? ok(f(result.value)) : result;
+
+/**
+ * Similar to `Option.andThen`. Applies to a `Result` a function that
+ * *also* returns a `Result`, and unwraps them to avoid nested `Result`s.
+ * Can be useful for stringing together operations that might fail.
+ * @example
+ * type RequestUser = number => Result<string, User>;
+ * type GetEmail = User => Result<string, string>;
+ * 
+ * // Request fails: Err('Network failure')
+ * // Request succeeds, problem accessing email: Err('Email field missing')
+ * // Both succeed: Ok('email_address')
+ * andThen(getEmail)(requestUser(id))
+ */
+const andThen = <E, A, B>(f: (a: A) => Result<E, B>) => (result: Result<E, A>): Result<E, B> =>
+    result.kind === ResultKind.Ok ? f(result.value) : result;
 
 /**
  * The return type of the `partition` function
  */
-type Partitioned<A, B> = { errs: A[]; oks: B[] };
+type Partitioned<E, A> = { errs: E[]; oks: A[] };
 
 /**
  * Takes a list of `Result`s and separates out the `Ok`s from the `Err`s.
@@ -144,12 +120,12 @@ type Partitioned<A, B> = { errs: A[]; oks: B[] };
  * @return {Partitioned} An object with two fields, one for the list of `Err`s
  * and one for the list of `Ok`s
  */
-const partition = <A, B>(results: Result<A, B>[]): Partitioned<A, B> =>
-    results.reduce(({ errs, oks }: Partitioned<A, B>, result) =>
-        result.either(
+const partition = <E, A>(results: Result<E, A>[]): Partitioned<E, A> =>
+    results.reduce(({ errs, oks }: Partitioned<E, A>, result) =>
+        either<E, A, Partitioned<E, A>>(
             err => ({ errs: [ ...errs, err ], oks }),
             ok => ({ errs, oks: [ ...oks, ok ] }),
-        ),
+        )(result),
         { errs: [], oks: [] },
     );
 
@@ -158,8 +134,13 @@ const partition = <A, B>(results: Result<A, B>[]): Partitioned<A, B> =>
 
 export {
     Result,
-    Ok,
-    Err,
+    ok,
+    err,
     fromUnsafe,
     partition,
+    either,
+    mapError,
+    toOption,
+    map,
+    andThen,
 };

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -90,7 +90,7 @@ const toOption = <E, A>(result: Result<E, A>): Option<A> =>
  * @param f The function to apply if this is an `Ok`
  * @param result The Result
  */
-const map = <E, A, B>(f: (a: A) => B) => (result: Result<E, A>): Result<E, B> =>
+const map = <A, B>(f: (a: A) => B) => <E>(result: Result<E, A>): Result<E, B> =>
     result.kind === ResultKind.Ok ? ok(f(result.value)) : result;
 
 /**


### PR DESCRIPTION
## Why are you doing this?

`Result` moves from an [ES6 class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) to a simpler [discriminated union](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions).

This PR is the companion to #404; the reasons for doing this are described in full there.

FYI @SiAdcock @gtrufitt @dskamiotis

## Changes

- Removed the use of ES6 classes for `Result`; now simple objects
- Migrated `Result` methods to plain functions
- Refactored codebase to use new `Result`
