### PR TITLE
transparent body background in dark mode

### DIFF
--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -21,7 +21,7 @@ import { partition } from 'types/result';
 import { getAdPlaceholderInserter } from 'ads';
 import { fromCapi, Item } from 'item';
 import { ElementKind, BodyElement } from 'bodyElement';
-import { pageFonts } from 'styles';
+import { pageFonts, darkModeCss } from 'styles';
 import { Option, some, none, map, withDefault } from 'types/option';
 import { compose, pipe2 } from 'lib';
 import { csp } from 'server/csp';
@@ -155,6 +155,10 @@ const styles = `
         font-family: 'Guardian Text Egyptian Web';
         overflow-x: hidden;
         line-height: 1.5;
+
+        ${darkModeCss`
+            background: transparent;
+        `}
     }
 `;
 


### PR DESCRIPTION
Removes the white line seen at the bottom of articles in dark mode.
## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/86006513-fa020900-ba0d-11ea-820e-e729d9b70c64.PNG" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/86006539-05edcb00-ba0e-11ea-8d36-ebbce0597c70.PNG" width="300px" /> |
