### PR TITLE
Fixed Deprecated Use Of Err and Ok

### DIFF
--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -48,7 +48,7 @@ function parseAtom(element: BlockElement, atoms: Atoms): Result<string, BodyElem
             const atom = atoms.media?.find(media => media.id === id);
 
             if (atom?.data?.kind !== "media") {
-                return new Err(`No atom matched this id: ${id}`);
+                return err(`No atom matched this id: ${id}`);
             }
 
             const { posterUrl, duration, assets, activeVersion } = atom?.data?.media;
@@ -56,14 +56,14 @@ function parseAtom(element: BlockElement, atoms: Atoms): Result<string, BodyElem
                 .find((asset) => asset.version.toNumber() === activeVersion?.toNumber())?.id;
 
             if (!posterUrl) {
-                return new Err(`No posterUrl for atom: ${id}`);
+                return err(`No posterUrl for atom: ${id}`);
             }
 
             if (!videoId) {
-                return new Err(`No videoId for atom: ${id}`);
+                return err(`No videoId for atom: ${id}`);
             }
 
-            return new Ok({
+            return ok({
                 kind: ElementKind.MediaAtom,
                 posterUrl,
                 videoId,


### PR DESCRIPTION
## Why are you doing this?

PRs #430 and #397 taken together have broken `master`. This fixes the problem by migrating uses of the `Err` and `Ok` classes to the `err` and `ok` functions.

## Changes

- Migrated `Err` and `Ok` to `err` and `ok`
