### PR TITLE
Send Performance Metrics With Bridget

### DIFF
--- a/src/client/metrics.test.ts
+++ b/src/client/metrics.test.ts
@@ -1,6 +1,8 @@
 // ----- Imports ----- //
 
-import { MetricKind, metrics } from './metrics';
+import { MetricType } from '@guardian/bridget/Metric';
+
+import { metrics } from './metrics';
 
 
 // ----- Setup ----- //
@@ -31,8 +33,8 @@ test('Captures paint events', () => {
     expect(results).toHaveLength(2);
     expect(results).toEqual(
         expect.arrayContaining([
-            expect.objectContaining({ kind: MetricKind.FirstPaint }),
-            expect.objectContaining({ kind: MetricKind.FirstContentfulPaint }),
+            expect.objectContaining({ __type: MetricType.MetricWithFirstPaint }),
+            expect.objectContaining({ __type: MetricType.MetricWithFirstContentfulPaint }),
         ]),
     );
 });

--- a/src/client/metrics.ts
+++ b/src/client/metrics.ts
@@ -1,24 +1,6 @@
-// ----- Types ----- //
+// ----- Imports ----- //
 
-const enum MetricKind {
-    FirstPaint,
-    FirstContentfulPaint,
-    Font,
-}
-
-type Metric = {
-    kind: MetricKind.FirstPaint;
-    time: number;
-} | {
-    kind: MetricKind.FirstContentfulPaint;
-    time: number;
-} | {
-    kind: MetricKind.Font;
-    duration: number;
-    // Safari doesn't support resource sizes
-    size: number | null;
-    name: string | null;
-}
+import { Metric, MetricType } from '@guardian/bridget/Metric';
 
 
 // ----- Functions ----- //
@@ -27,17 +9,25 @@ const isFont = (entry: PerformanceEntry): boolean =>
     entry.name.endsWith('.ttf') || entry.name.endsWith('.otf');
 
 const firstPaint = (entry: PerformanceEntry): Metric =>
-    ({ kind: MetricKind.FirstPaint, time: entry.startTime });
+    ({
+        __type: MetricType.MetricWithFirstPaint,
+        firstPaint: { time: entry.startTime },
+    });
 
 const firstContentfulPaint = (entry: PerformanceEntry): Metric =>
-    ({ kind: MetricKind.FirstContentfulPaint, time: entry.startTime });
+    ({
+        __type: MetricType.MetricWithFirstContentfulPaint,
+        firstContentfulPaint: { time: entry.startTime },
+    });
 
 const font = (entry: PerformanceResourceTiming): Metric =>
     ({
-        kind: MetricKind.Font,
-        duration: entry.duration,
-        size: entry.decodedBodySize ?? null,
-        name: entry.name.split('/').pop() ?? null,
+        __type: MetricType.MetricWithFont,
+        font: {
+            duration: entry.duration,
+            size: entry.decodedBodySize ?? undefined,
+            name: entry.name.split('/').pop(),
+        }
     });
 
 const metrics = (entries: PerformanceEntryList): Metric[] =>
@@ -59,7 +49,5 @@ const metrics = (entries: PerformanceEntryList): Metric[] =>
 // ----- Exports ----- //
 
 export {
-    MetricKind,
-    Metric,
     metrics,
 };

--- a/src/client/setup.ts
+++ b/src/client/setup.ts
@@ -48,11 +48,13 @@ function twitter(): void {
 function performanceMetrics(): void {
     window.addEventListener(
         'load',
-        () => pipe2(
-            performance.getEntries(),
-            metrics,
-            metricsClient.sendMetrics,
-        ),
+        () => {
+            pipe2(
+                performance.getEntries(),
+                metrics,
+                metricsClient.sendMetrics.bind(null),
+            );
+        },
         { once: true },
     );
 }

--- a/src/client/setup.ts
+++ b/src/client/setup.ts
@@ -2,6 +2,8 @@
 
 import { logger } from 'logger';
 import { metrics } from 'client/metrics';
+import { metricsClient } from 'native/nativeApi';
+import { pipe2 } from 'lib';
 
 
 // ----- Procedures ----- //
@@ -46,7 +48,11 @@ function twitter(): void {
 function performanceMetrics(): void {
     window.addEventListener(
         'load',
-        () => console.log('Metrics: ', metrics(performance.getEntries())),
+        () => pipe2(
+            performance.getEntries(),
+            metrics,
+            metricsClient.sendMetrics,
+        ),
         { once: true },
     );
 }

--- a/src/native/nativeApi.ts
+++ b/src/native/nativeApi.ts
@@ -5,6 +5,7 @@ import * as Acquisitions from '@guardian/bridget/Acquisitions';
 import * as Notifications from '@guardian/bridget/Notifications';
 import * as User from '@guardian/bridget/User';
 import * as Gallery from '@guardian/bridget/Gallery';
+import Metrics from '@guardian/bridget/Metrics';
 
 const environmentClient: Environment.Client<void> = createAppClient<Environment.Client>(Environment.Client, 'buffered', 'compact');
 const commercialClient: Commercial.Client<void> = createAppClient<Commercial.Client>(Commercial.Client, 'buffered', 'compact');
@@ -12,6 +13,7 @@ const acquisitionsClient: Acquisitions.Client<void> = createAppClient<Acquisitio
 const notificationsClient: Notifications.Client<void> = createAppClient<Notifications.Client>(Notifications.Client, 'buffered', 'compact');
 const userClient: User.Client<void> = createAppClient<User.Client>(User.Client, 'buffered', 'compact');
 const galleryClient: Gallery.Client<void> = createAppClient<Gallery.Client>(Gallery.Client, 'buffered', 'compact');
+const metricsClient: Metrics.Client<void> = createAppClient<Metrics.Client>(Metrics.Client, 'buffered', 'compact');
 
 export {
     environmentClient,
@@ -19,5 +21,6 @@ export {
     acquisitionsClient,
     notificationsClient,
     userClient,
-    galleryClient
-};
+    galleryClient,
+    metricsClient,
+}


### PR DESCRIPTION
## Why are you doing this?

This uses Bridget to send performance metrics ("first paint", "first contentful paint", "fonts") to the native layers. Based on the work done in [this Bridget PR](https://github.com/guardian/bridget/pull/49).

## Changes

- Refactored `metrics` module to use Bridget types
- Used metrics client in `setup`
- Created metrics client
