### PR TITLE
Fix Metrics Client

### DIFF
--- a/src/client/setup.ts
+++ b/src/client/setup.ts
@@ -3,7 +3,6 @@
 import { logger } from 'logger';
 import { metrics } from 'client/metrics';
 import { metricsClient } from 'native/nativeApi';
-import { pipe2 } from 'lib';
 
 
 // ----- Procedures ----- //
@@ -49,11 +48,8 @@ function performanceMetrics(): void {
     window.addEventListener(
         'load',
         () => {
-            pipe2(
-                performance.getEntries(),
-                metrics,
-                metricsClient.sendMetrics.bind(null),
-            );
+            const metricsToSend = metrics(performance.getEntries());
+            metricsClient.sendMetrics(metricsToSend);
         },
         { once: true },
     );

--- a/src/native/nativeApi.ts
+++ b/src/native/nativeApi.ts
@@ -5,7 +5,7 @@ import * as Acquisitions from '@guardian/bridget/Acquisitions';
 import * as Notifications from '@guardian/bridget/Notifications';
 import * as User from '@guardian/bridget/User';
 import * as Gallery from '@guardian/bridget/Gallery';
-import Metrics from '@guardian/bridget/Metrics';
+import * as Metrics from '@guardian/bridget/Metrics';
 
 const environmentClient: Environment.Client<void> = createAppClient<Environment.Client>(Environment.Client, 'buffered', 'compact');
 const commercialClient: Commercial.Client<void> = createAppClient<Commercial.Client>(Commercial.Client, 'buffered', 'compact');


### PR DESCRIPTION
## Why are you doing this?

Two separate issue with the metrics client introduced in #444... sadly the compile-time checks didn't pick up either of them 😔:

1. The default import of the metrics client isn't valid, we need to do `import * as...`
2. Using the `sendMetrics` method required binding it to `metricsClient` rather than `null` because it makes use of `this`. Rather than do this I've moved to the slightly less elegant option of just nesting function calls, as I think it's probably easier to follow at a glance.

## Changes

- Use `import *` instead of default imports for `metricsClient`
- Stopped using unbound `sendMetrics` method
