### PR TITLE
add fields to rendering request for callout forms

### DIFF
--- a/api-models/thrift/src/main/thrift/appsRendering.thrift
+++ b/api-models/thrift/src/main/thrift/appsRendering.thrift
@@ -13,10 +13,45 @@ struct Branding {
     7: required string aboutUri
 }
 
+struct FormOption {
+    1: required string label
+    2: required string value
+}
+
+struct FormField {
+    1: required string id
+    2: required string label
+    3: required string name
+    4: optional string description
+    5: required string type
+    6: required bool required
+    7: required list<FormOption> options
+}
+
+struct Fields {
+    1: required string callout
+    2: required i32 formId
+    3: required string tagName
+    4: optional string description
+    5: required list<FormField> formFields
+    6: optional string formUrl
+}
+
+struct Campaign {
+    1: required string id
+    2: required string name
+    3: required i32 priority
+    4: optional i64 activeFrom
+    5: optional i64 activeUntil
+    6: required bool displayOnSensitive
+    7: required Fields fields
+}
+
 struct RenderingRequest {
     1: required v1.Content content
     2: optional i32 commentCount 
     3: optional bool specialReport
     4: optional map<string,string> targetingParams
     5: optional Branding branding
+    6: optional list<Campaign> campaigns
 }


### PR DESCRIPTION
## Why are you doing this?

I've tried to map the campaign (callout) fields so we'll be able to render these forms inside articles.

<img width="649" alt="Screen Shot 2020-07-03 at 10 41 45" src="https://user-images.githubusercontent.com/11618797/86456370-df83a480-bd19-11ea-9ed1-dcb2c2ab6e3f.png">

