### PR TITLE
remove unused font resize link

### DIFF
--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -136,7 +136,6 @@ const Head: FC<HeadProps> = ({ webTitle }: HeadProps) =>
         <title>{webTitle}</title>
         <meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
         <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
-        <link rel="stylesheet" href="native://fontSize.css" />
     </>
 
 


### PR DESCRIPTION
We've got an open PR to change this for Android but it's causing a csp issue for beta users so maybe we remove it until it's needed?
