### PR TITLE
handle latest tags

### DIFF
--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -104,18 +104,11 @@ const getAnchorStyles = (format: Format): SerializedStyles => {
     }
 }
 
-const getProfileLink = (node: Node): string => {
-    const href = withDefault('')(getHref(node));
-    return href.startsWith('profile/')
-        ? `https://www.theguardian.com/${href}`
-        : href
-}
-
 const toReact = (format: Format) => (node: Node): ReactNode => {
     switch (node.nodeName) {
         case 'A':
             return (
-                <a href={getProfileLink(node)} css={getAnchorStyles(format)}>
+                <a href={withDefault('')(getHref(node))} css={getAnchorStyles(format)}>
                     {node.textContent ?? ''}
                 </a>
             );

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -33,6 +33,19 @@ import LiveEventLink from 'components/liveEventLink';
 const getAttrs = (node: Node): Option<NamedNodeMap> =>
     isElement(node) ? some(node.attributes) : none;
 
+
+const transformHref = (href: string): string => {
+    if (href.startsWith('profile/')) {
+        return `https://www.theguardian.com/${href}`;
+    }
+
+    if (/https:\/\/www\.theguardian\.com\/[a-zA-Z0-9|/|-]+\/latest/.exec(href)?.length) {
+        return href.slice(0, -7);
+    }
+
+    return href
+}
+
 const getHref = (node: Node): Option<string> =>
     pipe(
         getAttrs(node),
@@ -42,18 +55,6 @@ const getHref = (node: Node): Option<string> =>
             map(attr => transformHref(attr.value)),
         )),
     );
-
-const transformHref = (href: string): string => {
-    if (href.startsWith('profile/')) {
-        return `https://www.theguardian.com/${href}`;
-    }
-
-    if (href.match(/https:\/\/www\.theguardian\.com\/[a-zA-Z0-9|\/|-]+\/latest/)?.length) {
-        return href.slice(0, -7);
-    }
-
-    return href
-}
 
 const bulletStyles = (format: Format): SerializedStyles => {
     const { kicker, inverted } = getPillarStyles(format.pillar);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -33,18 +33,27 @@ import LiveEventLink from 'components/liveEventLink';
 const getAttrs = (node: Node): Option<NamedNodeMap> =>
     isElement(node) ? some(node.attributes) : none;
 
-const getAttr = (attr: string) => (node: Node): Option<string> =>
+const getHref = (node: Node): Option<string> =>
     pipe(
         getAttrs(node),
         andThen(attrs => pipe2(
-            attrs.getNamedItem(attr),
+            attrs.getNamedItem('href'),
             fromNullable,
-            map(attr => attr.value),
+            map(attr => transformHref(attr.value)),
         )),
     );
 
-const getHref: (node: Node) => Option<string> =
-    getAttr('href');
+const transformHref = (href: string): string => {
+    if (href.startsWith('profile/')) {
+        return `https://www.theguardian.com/${href}`;
+    }
+
+    if (href.match(/https:\/\/www\.theguardian\.com\/[a-zA-Z0-9|\/|-]+\/latest/)?.length) {
+        return href.slice(0, -7);
+    }
+
+    return href
+}
 
 const bulletStyles = (format: Format): SerializedStyles => {
     const { kicker, inverted } = getPillarStyles(format.pillar);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -39,7 +39,11 @@ const transformHref = (href: string): string => {
         return `https://www.theguardian.com/${href}`;
     }
 
-    if (/https:\/\/www\.theguardian\.com\/[a-zA-Z0-9|/|-]+\/latest/.exec(href)?.length) {
+    const url = new URL(href);
+    const path = url.pathname.split('/');
+    const isLatest = url.hostname === 'www.theguardian.com' && path[path.length - 1] === 'latest';
+
+    if (isLatest) {
         return href.slice(0, -7);
     }
 


### PR DESCRIPTION
The first link in the standfirst on this article links to a tag page with `/latest` at the end of the path. The current behaviour in apps rendering is to open up theguardian.com as it's not recognised as a valid tag.

Removing the `/latest` part of the url will link to a valid tag page and keep the users in app.

https://www.gu.com/stage/2020/jul/08/77-per-cent-comedy-venues-in-uk-face-closure-survey-emergency-arts-funding-coronvirus