### PR TITLE
render strong tags in standfirsts

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -274,13 +274,15 @@ const standfirstTextElement = (format: Format) => (node: Node, key: number): Rea
     switch (node.nodeName) {
         case 'P':
             return h('p', { key }, children);
+        case 'STRONG':
+            return h('strong', { key }, children);
         case 'UL':
             return styledH('ul', { css: listStyles }, children);
         case 'LI':
             return styledH('li', { css: listItemStyles(format) }, children);
         case 'A': {
             const colour = linkColourFromFormat(format);
-            const styles = css` color: ${colour}; text-decoration: none`;
+            const styles = css` color: ${colour}; text-decoration: none;`;
             const url = withDefault('')(getHref(node));
             const href = url.startsWith('profile/') ? `https://www.theguardian.com/${url}` : url
             return styledH('a', { key, href, css: styles }, children);


### PR DESCRIPTION
## Why are you doing this?
This ensures we stay inside the recursive `renderStandfirst`

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/87141010-482ecc00-c29a-11ea-8f73-78a3fce7b899.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/87141045-57157e80-c29a-11ea-8fe7-db54e9ee4f12.png" width="300px" /> |
