### PR TITLE
thinner analysis underlines

### DIFF
--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -65,11 +65,11 @@ const analysisStyles = (format: Format): SerializedStyles => css`
     ${headline.medium({ lineHeight: 'regular', fontWeight: 'light' })}
 
     span {
-        box-shadow: inset 0 -0.1rem ${border.primary(format)};
+        box-shadow: inset 0 -0.025rem ${border.primary(format)};
         padding-bottom: 0.2rem;
 
         ${darkModeCss`
-            box-shadow: inset 0 -0.1rem ${neutral[46]};
+            box-shadow: inset 0 -0.025rem ${neutral[46]};
         `}
     }
 `;


### PR DESCRIPTION
## Why are you doing this?
The thinner underline is closer to the templates and dotcom.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/87413737-9c9bb980-c5c2-11ea-8a27-6065c98c07fe.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/87413780-aa513f00-c5c2-11ea-8a78-ddc578a5af2d.png" width="300px" /> |