### PR TITLE
replace reserved keyword with mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ In order to release the models you'll need to:
  - have a bintray account with access to the guardian organisation
  - have an NPM account, part of the [@guardian](https://www.npmjs.com/org/guardian) org with a [configured token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens)
 
+Make sure you set upstream `git push --set-upstream origin <BRANCH_NAME>`
+
 In the SBT repl:
 ```sbtshell
 clean

--- a/api-models/scala/version.sbt
+++ b/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.0"
+version in ThisBuild := "0.6.1-SNAPSHOT"

--- a/api-models/scala/version.sbt
+++ b/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1-SNAPSHOT"
+version in ThisBuild := "0.6.0"

--- a/api-models/thrift/src/main/thrift/appsRendering.thrift
+++ b/api-models/thrift/src/main/thrift/appsRendering.thrift
@@ -24,7 +24,7 @@ struct FormField {
     3: required string name
     4: optional string description
     5: required string type
-    6: required bool required
+    6: required bool mandatory
     7: required list<FormOption> options
 }
 


### PR DESCRIPTION
## Why are you doing this?
When attempting to generate the Scala and TypeScript packages I get an error about using a reserved keyword "required".

It's a shame to lose the name "required" as it's commonly used to describe required fields in callouts throughout the targeting tool, dotcom and the callout React components that we hope to share with dotcom. For example: https://github.com/guardian/frontend/blob/master/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala

Would using French thrift allow this?