### PR TITLE
Remove sig-ignore-params For Images

### DIFF
--- a/src/image.ts
+++ b/src/image.ts
@@ -79,11 +79,12 @@ function src(salt: string, input: string, width: number, dpr: Dpr): string {
         width: width.toString(),
         quality: dpr === Dpr.Two ? lowerQuality.toString() : defaultQuality.toString(),
         fit: 'bounds',
-        'sig-ignores-params': 'true',
-        s: sign(salt, url.pathname),
     });
 
-    return `${imageResizer}/${service}${url.pathname}?${params.toString()}`;
+    const path = `${url.pathname}?${params.toString()}`;
+    const sig = sign(salt, path);
+
+    return `${imageResizer}/${service}${path}&s=${sig}`;
 }
 
 const srcsetWithWidths = (widths: number[]) => (url: string, salt: string, dpr: Dpr): string =>


### PR DESCRIPTION
## Why are you doing this?

Previously we needed this parameter because we didn't have access to the `salt` for signing image URLs at the point when we set the `width` parameter. However, since #326 this is no longer the case.

**Note:** This will require a config change to use a different salt.

## Changes

- Removed `sig-ignores-params` and started signing URLs with their query params
