### PR TITLE
Fix Lightbox Images

### DIFF
--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -97,18 +97,12 @@ function getImageWidth(src: string): number {
     return Math.max(screen.height * dpr, screen.width * dpr, width);
 }
 
-function updateUrl(src: string): string {
-    const url = new URL(src);
-    url.searchParams.set('width', getImageWidth(src).toString());
-    return url.href;
-}
-
 function launchSlideshow(src: string | null): void {
     const images = Array.from(document.querySelectorAll('.js-launch-slideshow'));
     const title = document.title;
     const imagesWithCaptions: Image[] = images.flatMap((image: Element) => {
         if (image instanceof HTMLImageElement) {
-            const url = updateUrl(image?.currentSrc ?? image.src);
+            const url = image?.currentSrc ?? image.src;
             const caption =  image.getAttribute('data-caption') ?? undefined;
             const credit = image.getAttribute('data-credit') ?? undefined;
             const width = getImageWidth(url);


### PR DESCRIPTION
## Why are you doing this?

Beta feedback has flagged that lightbox images are no longer working. This is a short-term fix for that problem.

This was a side-effect of the changes in #506, in which we started signing the query params of images, rather than just the path. Because we were altering the `width` parameter of lightbox images on the fly, depending on the device size, the URL passed to the lightbox no longer matched its signature.

**Note:** This may result in slightly lower resolutions for images in the lightbox. I'm going to do some additional work to remedy that in a later PR.

## Changes

- Stopped altering lightbox image sources
