### PR TITLE
Fixed dark mode colour for comment count

### DIFF
--- a/src/components/commentCount.tsx
+++ b/src/components/commentCount.tsx
@@ -3,12 +3,13 @@
 import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography';
-import { border } from '@guardian/src-foundations/palette';
+import { border, neutral } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 import { Option, map, withDefault } from 'types/option';
 import { Format } from 'format';
 import { getPillarStyles } from 'pillarStyles';
 import { pipe2 } from 'lib';
+import { darkModeCss } from 'styles';
 
 
 // ----- Component ----- //
@@ -25,6 +26,9 @@ const styles = (colour: string): SerializedStyles => css`
     border-left: 1px solid ${border.secondary};
     padding-top: ${remSpace[2]};
     color: ${colour};
+    ${darkModeCss`
+        border-left: 1px solid ${neutral[20]};
+    `}
 `;
 
 const bubbleStyles = (colour: string): SerializedStyles => css`

--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -21,14 +21,24 @@ interface Props {
 }
 
 const styles = (role: Option<Role>, format?: Format): SerializedStyles => {
-    const backgroundColour = format?.design === Design.Media ? neutral[20] : neutral[97];
+    const backgroundColour = () => {
+    switch (format?.design) {
+        case Design.Media:
+            return neutral[20];
+        case Design.Comment:
+            return neutral[86];
+        default:
+            return neutral[97];
+    }
+    };
+    // const backgroundColour = format?.design === Design.Media ? neutral[20] : neutral[97];
     return pipe2(
         role,
         map(imageRole => imageRole),
         withDefault(Role.HalfWidth),
     ) === Role.Thumbnail ? css`color: ${neutral[60]};`
         : css`
-            background-color: ${backgroundColour};
+            background-color: ${backgroundColour()};
             ${darkModeCss`background-color: ${neutral[20]};`}
             color: ${neutral[60]};
         `;

--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -10,13 +10,12 @@ export interface VideoProps {
 }
 
 const videoStyles = css`
-    background: ${neutral[97]};
+    background: red;
     padding-bottom: 56.25%;
     width: 100%;
     position: relative;
     overflow: hidden;
-    margin: ${remSpace[4]} 0;
-
+    margin: ${remSpace[4]}; 
     iframe {
         border: none;
         width: 100%;


### PR DESCRIPTION
## Why are you doing this?

Dark mode displayed inconsistent colour for comment count- should have been the same as keyline colours scheme
