### PR TITLE
AR-84: Change background colour for elements on opinion/comment articles

### DIFF
--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -1,6 +1,6 @@
 import { AdSlot } from "@guardian/bridget/AdSlot";
 import { Image } from "@guardian/bridget/Image";
-import { commercialClient, galleryClient, userClient, acquisitionsClient } from "../native/nativeApi";
+import { commercialClient, galleryClient, acquisitionsClient, userClient } from "../native/nativeApi";
 import { logger } from "../logger";
 import { memoise } from "../lib";
 

--- a/src/components/advertisementFeature/article.tsx
+++ b/src/components/advertisementFeature/article.tsx
@@ -65,7 +65,7 @@ const AdvertisementFeature = ({ item, children }: Props): JSX.Element => {
                     {pipe2(item.logo, map(props => <Logo logo={props} />), withDefault(<></>))}
                 </section>
             </header>
-            <Body className={[articleWidthStyles]}>
+            <Body className={[articleWidthStyles]} format={item}>
                 {children}
             </Body>
         </article>

--- a/src/components/headerVideo.tsx
+++ b/src/components/headerVideo.tsx
@@ -18,13 +18,24 @@ const marginAuto = `
     margin-right: auto;
 `;
 
+const backgroundColour = (format: Format) => {
+    switch (format.design) {
+        case Design.Media:
+            return neutral[20];
+        case Design.Comment:
+            return neutral[86];
+        default:
+            return neutral[97]
+    }
+};
+
 const styles = (format: Format): SerializedStyles => css`
     margin: 0 0 ${remSpace[2]} 0;
     position: relative;
     display: block;
     width: 100%;
     padding-bottom: 56.25%;
-    background: ${format.design === Design.Media ? neutral[20] : neutral[97]};
+    background: ${backgroundColour(format)};
 
     ${darkModeCss`
         background: ${neutral[20]};

--- a/src/components/headerVideo.tsx
+++ b/src/components/headerVideo.tsx
@@ -18,14 +18,14 @@ const marginAuto = `
     margin-right: auto;
 `;
 
-const backgroundColour = (format: Format) => {
+const backgroundColour = (format: Format): string => {
     switch (format.design) {
         case Design.Media:
             return neutral[20];
         case Design.Comment:
             return neutral[86];
         default:
-            return neutral[97]
+            return neutral[97];
     }
 };
 

--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -17,18 +17,27 @@ interface Props {
     image: Image;
     sizes: string;
     className?: SerializedStyles;
-    format?: Format;
+    format: Format;
 }
 
-const styles = (role: Option<Role>, format?: Format): SerializedStyles => {
-    const backgroundColour = format?.design === Design.Media ? neutral[20] : neutral[97];
+const styles = (role: Option<Role>, format: Format): SerializedStyles => {
+    const backgroundColour = (format: Format) => {
+        switch (format.design) {
+            case Design.Media:
+                return neutral[20];
+            case Design.Comment:
+                return neutral[86];
+            default:
+                return neutral[97]
+        }
+    };
     return pipe2(
         role,
         map(imageRole => imageRole),
         withDefault(Role.HalfWidth),
     ) === Role.Thumbnail ? css`color: ${neutral[60]};`
         : css`
-            background-color: ${backgroundColour};
+            background-color: ${backgroundColour(format)};
             ${darkModeCss`background-color: ${neutral[20]};`}
             color: ${neutral[60]};
         `;

--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -21,7 +21,7 @@ interface Props {
 }
 
 const styles = (role: Option<Role>, format: Format): SerializedStyles => {
-    const backgroundColour = (format: Format) => {
+    const backgroundColour = (format: Format): string => {
         switch (format.design) {
             case Design.Media:
                 return neutral[20];

--- a/src/components/liveblog/article.tsx
+++ b/src/components/liveblog/article.tsx
@@ -70,7 +70,7 @@ const LiveblogArticle = ({ item }: LiveblogArticleProps): JSX.Element => {
                     />
                 </article>
                 <div css={tagStyles}>
-                    <Tags tags={item.tags} background={neutral[93]} />
+                    <Tags tags={item.tags} format={format}/>
                 </div>
             </div>
         </main>

--- a/src/components/media/article.tsx
+++ b/src/components/media/article.tsx
@@ -59,7 +59,7 @@ const Media = ({ item, children }: Props): JSX.Element =>
                     />
                 </section>
             </header>
-            <Body pillar={item.pillar} className={[articleWidthStyles]}>
+            <Body pillar={item.pillar} className={[articleWidthStyles]} format={item}>
                 {children}
             </Body>
             <footer css={articleWidthStyles}>

--- a/src/components/media/articleBody.tsx
+++ b/src/components/media/articleBody.tsx
@@ -5,14 +5,15 @@ import { background, neutral } from '@guardian/src-foundations/palette';
 import { getPillarStyles, PillarStyles } from 'pillarStyles';
 import { Pillar } from 'format';
 import { remSpace } from "@guardian/src-foundations";
+import { Format } from '@guardian/types/Format';
 
-const ArticleBodyStyles = css`
+const ArticleBodyStyles = (format: Format) => css`
     position: relative;
     clear: both;
     background: ${background.inverse}    
     color: ${neutral[86]};
 
-    ${adStyles}
+    ${adStyles(format)}
 `;
 
 const ArticleBodyDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
@@ -29,14 +30,16 @@ interface ArticleBodyProps {
     pillar: Pillar;
     className: SerializedStyles[];
     children: ReactNode[];
+    format: Format;
 }
 
 const ArticleBodyMedia = ({
     pillar,
     className,
     children,
+    format
 }: ArticleBodyProps): JSX.Element =>
-    <div css={[ArticleBodyStyles, ArticleBodyDarkStyles(getPillarStyles(pillar)), ...className]}>
+    <div css={[ArticleBodyStyles(format), ArticleBodyDarkStyles(getPillarStyles(pillar)), ...className]}>
         {children}
     </div>
 

--- a/src/components/media/articleBody.tsx
+++ b/src/components/media/articleBody.tsx
@@ -7,7 +7,7 @@ import { Pillar } from 'format';
 import { remSpace } from "@guardian/src-foundations";
 import { Format } from '@guardian/types/Format';
 
-const ArticleBodyStyles = (format: Format) => css`
+const ArticleBodyStyles = (format: Format): SerializedStyles => css`
     position: relative;
     clear: both;
     background: ${background.inverse}    
@@ -39,7 +39,9 @@ const ArticleBodyMedia = ({
     children,
     format
 }: ArticleBodyProps): JSX.Element =>
-    <div css={[ArticleBodyStyles(format), ArticleBodyDarkStyles(getPillarStyles(pillar)), ...className]}>
+    <div css={[ArticleBodyStyles(format),
+        ArticleBodyDarkStyles(getPillarStyles(pillar)),
+        ...className]}>
         {children}
     </div>
 

--- a/src/components/opinion/article.tsx
+++ b/src/components/opinion/article.tsx
@@ -70,9 +70,10 @@ const Opinion = ({ item, children }: Props): JSX.Element =>
                 <div css={articleWidthStyles}>
                     <Byline {...item} />
                 </div>
-                <Cutout 
+                <Cutout
                     contributors={item.contributors}
                     className={articleWidthStyles}
+                    format={item}
                 />
                 <Keyline {...item} />
                 <div css={articleWidthStyles}>
@@ -88,11 +89,11 @@ const Opinion = ({ item, children }: Props): JSX.Element =>
                     {OptionalLogo(item)}
                 </section>
             </header>
-            <ArticleBody className={[articleWidthStyles]}>
+            <ArticleBody className={[articleWidthStyles]} format={item}>
                 {children}
             </ArticleBody>
             <footer css={articleWidthStyles}>
-                <Tags tags={item.tags}/>
+                <Tags tags={item.tags} format={item}/>
             </footer>
         </article>
     </main>

--- a/src/components/opinion/cutout.tsx
+++ b/src/components/opinion/cutout.tsx
@@ -8,6 +8,7 @@ import Img from 'components/img';
 import { darkModeCss } from 'styles';
 import { pipe2 } from 'lib';
 import { map, withDefault } from 'types/option';
+import { Format } from '@guardian/types/Format';
 
 
 // ----- Styles ----- //
@@ -34,9 +35,10 @@ const imageStyles = css`
 interface Props {
     contributors: Contributor[];
     className: SerializedStyles;
+    format: Format;
 }
 
-const Cutout = ({ contributors, className }: Props): JSX.Element | null => {
+const Cutout = ({ contributors, className, format }: Props): JSX.Element | null => {
     const [contributor] = contributors;
 
     if (!isSingleContributor(contributors)) {
@@ -51,6 +53,7 @@ const Cutout = ({ contributors, className }: Props): JSX.Element | null => {
                     image={image}
                     sizes="12rem"
                     className={imageStyles}
+                    format={format}
                 />
             </div>
         ),

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -3,8 +3,15 @@ import { css, SerializedStyles } from '@emotion/core'
 import { darkModeCss, adStyles } from 'styles';
 import { neutral, background } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
+import { Format } from '@guardian/types/Format';
 
-const ArticleBodyStyles = css`
+interface ArticleBodyProps {
+    className: SerializedStyles[];
+    children: ReactNode[];
+    format: Format;
+}
+
+const ArticleBodyStyles = (format: Format) => css`
     position: relative;
     clear: both;
 
@@ -13,7 +20,7 @@ const ArticleBodyStyles = css`
         border: none;
     }
 
-    ${adStyles}
+    ${adStyles(format)}
 
     twitter-widget,
     figure[data-atom-type="explainer"] {
@@ -37,16 +44,12 @@ const ArticleBodyDarkStyles: SerializedStyles = darkModeCss`
     }
 `;
 
-interface ArticleBodyProps {
-    className: SerializedStyles[];
-    children: ReactNode[];
-}
-
 const ArticleBody = ({
     className,
     children,
+    format
 }: ArticleBodyProps): JSX.Element =>
-    <div css={[ArticleBodyStyles, ArticleBodyDarkStyles, ...className]}>
+    <div css={[ArticleBodyStyles(format), ArticleBodyDarkStyles, ...className]}>
         {children}
     </div>
 

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -11,7 +11,7 @@ interface ArticleBodyProps {
     format: Format;
 }
 
-const ArticleBodyStyles = (format: Format) => css`
+const ArticleBodyStyles = (format: Format): SerializedStyles => css`
     position: relative;
     clear: both;
 

--- a/src/components/shared/shared.stories.tsx
+++ b/src/components/shared/shared.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Tags from './tags';
 import { Keyline } from './keyline';
 import { withKnobs } from "@storybook/addon-knobs";
-import { Design } from 'format';
+import { Design, Format } from 'format';
 export default { title: 'Shared', decorators: [withKnobs] };
 
 export const OpinionKeyline = (): JSX.Element =>
@@ -19,7 +19,7 @@ const tagsProps = [{
     webUrl: "https://mapi.co.uk/tag"
 }];
 
-export const tags = (): JSX.Element => 
-    <Tags tags={[...tagsProps, ...tagsProps, ...tagsProps]} />
+export const tags = (format: Format): JSX.Element =>
+    <Tags tags={[...tagsProps, ...tagsProps, ...tagsProps]} format={format} />
 
- 
+

--- a/src/components/shared/tags.test.tsx
+++ b/src/components/shared/tags.test.tsx
@@ -3,7 +3,7 @@ import { configure, shallow, ShallowWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Tags from 'components/shared/tags';
 import { SerializedStyles } from '@emotion/core';
-import { Design, Display, Format, Pillar } from "../../format";
+import { Design, Display, Format, Pillar } from '@guardian/types/Format';
 
 configure({ adapter: new Adapter() });
 

--- a/src/components/shared/tags.test.tsx
+++ b/src/components/shared/tags.test.tsx
@@ -3,7 +3,7 @@ import { configure, shallow, ShallowWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Tags from 'components/shared/tags';
 import { SerializedStyles } from '@emotion/core';
-import {Design, Display, Format, Pillar} from "../../format";
+import { Design, Display, Format, Pillar } from "../../format";
 
 configure({ adapter: new Adapter() });
 

--- a/src/components/shared/tags.test.tsx
+++ b/src/components/shared/tags.test.tsx
@@ -3,6 +3,7 @@ import { configure, shallow, ShallowWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Tags from 'components/shared/tags';
 import { SerializedStyles } from '@emotion/core';
+import {Design, Display, Format, Pillar} from "../../format";
 
 configure({ adapter: new Adapter() });
 
@@ -11,6 +12,12 @@ const tagsProps = [{
     webUrl: "https://mapi.co.uk/tag"
 }];
 
+const mockFormat: Format = {
+    pillar: Pillar.News,
+    design: Design.Comment,
+    display: Display.Standard,
+};
+
 const styles = (component: ShallowWrapper): string => Array.from(component.prop<SerializedStyles[]>('css'))
     .flat()
     .map(({ styles }: { styles: string }) => styles)
@@ -18,23 +25,23 @@ const styles = (component: ShallowWrapper): string => Array.from(component.prop<
 
 describe('Keyline component renders as expected', () => {
     it('Renders link to tag', () => {
-        const tags = shallow(<Tags tags={tagsProps} />)
+        const tags = shallow(<Tags tags={tagsProps} format={mockFormat}/>)
         const link = tags.find('a')
         expect(link.prop('href')).toBe('https://mapi.co.uk/tag')
     })
 
     it('Renders tag title', () => {
-        const tags = shallow(<Tags tags={tagsProps} />)
+        const tags = shallow(<Tags tags={tagsProps} format={mockFormat} />)
         expect(tags.find('li').text()).toBe("Tag title")
     })
 
     it('Renders correct number of tags', () => {
-        const tags = shallow(<Tags tags={[...tagsProps, ...tagsProps]} />)
+        const tags = shallow(<Tags tags={[...tagsProps, ...tagsProps]} format={mockFormat} />)
         expect(tags.find('li').length).toBe(2)
     })
 
-    it('Uses background prop in styles', () => {
-        const tags = shallow(<Tags tags={tagsProps} background={"pink"}/>)
-        expect(styles(tags)).toContain("background-color: pink;")
+    it('Renders correct background color', () => {
+        const tags = shallow(<Tags tags={tagsProps} format={mockFormat}/>)
+        expect(styles(tags)).toContain("background-color: #DCDCDC;")
     })
 });

--- a/src/components/shared/tags.tsx
+++ b/src/components/shared/tags.tsx
@@ -16,7 +16,7 @@ interface TagsProps {
 }
 
 const tagsStyles = (format: Format): SerializedStyles => {
-    const backgroundColour = (format: Format) => {
+    const backgroundColour = (format: Format): string => {
         switch (format.design) {
             case Design.Comment:
                 return neutral[86];

--- a/src/components/shared/tags.tsx
+++ b/src/components/shared/tags.tsx
@@ -2,10 +2,32 @@ import React from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { darkModeCss } from '../../styles';
 import { textSans } from '@guardian/src-foundations/typography';
-import { neutral, background } from '@guardian/src-foundations/palette';
+import { background, neutral } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
+import { Design, Format } from '@guardian/types/Format';
 
-const tagsStyles = (background: string = neutral[97]): SerializedStyles => css`
+interface TagsProps {
+    tags: {
+        webUrl: string;
+        webTitle: string;
+    }[];
+    background?: string;
+    format: Format;
+}
+
+const tagsStyles = (format: Format): SerializedStyles => {
+    const backgroundColour = (format: Format) => {
+        switch (format.design) {
+            case Design.Comment:
+                return neutral[86];
+            case Design.Live:
+                return neutral[93];
+            default:
+                return neutral[97];
+        }
+    };
+
+    return css`
     margin-top: 0;
     margin-bottom: 0;
 
@@ -26,13 +48,14 @@ const tagsStyles = (background: string = neutral[97]): SerializedStyles => css`
             text-overflow: ellipsis;
             max-width: 18.75rem;
             color: ${neutral[7]};
-            background-color: ${background};
+            background-color: ${backgroundColour(format)};
             display: inline-block;
             white-space: nowrap;
             overflow: hidden;
         }
     }
 `;
+}
 
 const tagsDarkStyles = darkModeCss`
     background: ${background.inverse};
@@ -44,16 +67,8 @@ const tagsDarkStyles = darkModeCss`
     }
 `;
 
-interface TagsProps {
-    tags: {
-        webUrl: string;
-        webTitle: string;
-    }[];
-    background?: string;
-}
-
-const Tags = ({ tags, background }: TagsProps): JSX.Element => (
-    <ul css={[tagsStyles(background), tagsDarkStyles]}>
+const Tags = ({ tags, format }: TagsProps): JSX.Element => (
+    <ul css={[tagsStyles(format), tagsDarkStyles]}>
         {tags.map((tag, index) => {
             return <li key={index}>
                 <a href={tag.webUrl}>

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -97,12 +97,12 @@ const Standard = ({ item, children }: Props): JSX.Element => {
                     {OptionalLogo(item)}
                 </section>
             </header>
-            <Body className={[articleWidthStyles, itemStyles(item)]}>
+            <Body className={[articleWidthStyles, itemStyles(item)]} format={item}>
                 {children}
             </Body>
             {epicContainer}
             <footer css={articleWidthStyles}>
-                <Tags tags={item.tags}/>
+                <Tags tags={item.tags} format={item}/>
             </footer>
         </article>
     </main>

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -1,14 +1,14 @@
-import { renderAll, renderStandfirstText, renderText, renderAllWithoutStyles } from 'renderer';
+import { renderAll, renderAllWithoutStyles, renderStandfirstText, renderText } from 'renderer';
 import { JSDOM } from 'jsdom';
 import { Pillar } from 'format';
-import { ReactNode, isValidElement } from 'react';
+import { isValidElement, ReactNode } from 'react';
 import { compose } from 'lib';
 import { BodyElement, ElementKind } from 'bodyElement';
 import { Role } from 'image';
 import { configure, shallow } from 'enzyme';
 import { none, some } from 'types/option';
 import Adapter from 'enzyme-adapter-react-16';
-import { Format, Design, Display } from '@guardian/types/Format';
+import { Design, Display, Format } from '@guardian/types/Format';
 
 configure({ adapter: new Adapter() });
 const mockFormat: Format = {
@@ -118,6 +118,22 @@ const atomElement = (): BodyElement =>
         html: "<main>Some content</main>",
         js: some("console.log('init')"),
     })
+
+const liveEventElement = (): BodyElement =>
+    ({
+        kind:ElementKind.LiveEvent,
+        linkText: "this links to a live event",
+        url: "https://gu.com/liveevent"
+    })
+
+const explainerElement = (): BodyElement =>
+    ({
+        kind:ElementKind.ExplainerAtom,
+        html: "<main>Some content</main>",
+        title: "this is an explainer atom",
+        id: ""
+    })
+
 
 const render = (element: BodyElement): ReactNode[] =>
     renderAll(mockFormat, [element]);
@@ -259,6 +275,18 @@ describe('Renders different types of elements', () => {
         expect(getHtml(atom)).toContain('main { background: yellow; }');
         expect(getHtml(atom)).toContain("console.log(&#x27;init&#x27;)");
         expect(getHtml(atom)).toContain('Some content');
+    })
+
+    test('ElementKind.LiveEvent', () => {
+        const nodes = render(liveEventElement())
+        const liveEvent = nodes.flat()[0];
+        expect(getHtml(liveEvent)).toContain('<h1>this links to a live event</h1>');
+    })
+
+    test('ElementKind.ExplainerAtom', () => {
+        const nodes = render(explainerElement())
+        const explainer = nodes.flat()[0];
+        expect(getHtml(explainer)).toContain('<main>Some content</main>');
     })
 });
 

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -121,7 +121,7 @@ const atomElement = (): BodyElement =>
 
 const liveEventElement = (): BodyElement =>
     ({
-        kind:ElementKind.LiveEvent,
+        kind: ElementKind.LiveEvent,
         linkText: "this links to a live event",
         url: "https://gu.com/liveevent"
     })

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -128,7 +128,7 @@ const liveEventElement = (): BodyElement =>
 
 const explainerElement = (): BodyElement =>
     ({
-        kind:ElementKind.ExplainerAtom,
+        kind: ElementKind.ExplainerAtom,
         html: "<main>Some content</main>",
         title: "this is an explainer atom",
         id: ""

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -380,7 +380,8 @@ const Pullquote: FC<PullquoteProps> = ({ quote, attribution, format }: Pullquote
 const richLinkWidth = '8.75rem';
 
 const richLinkStyles = (format: Format): SerializedStyles => {
-    const backgroundColor = (format: Format) => format.design === Design.Comment ? neutral[86] : neutral[97];
+    const backgroundColor = (format: Format): string =>
+        format.design === Design.Comment ? neutral[86] : neutral[97];
     const formatStyles = format.design === Design.Live
         ? `width: calc(100% - ${remSpace[4]});`
         : `
@@ -603,7 +604,8 @@ const render = (format: Format, excludeStyles = false) =>
         case ElementKind.MediaAtom: {
             const { posterUrl, videoId, duration, caption } = element;
 
-            const backgroundColor = (format: Format) => format.design === Design.Comment ? neutral[86] : neutral[97];
+            const backgroundColor = (format: Format): string =>
+                format.design === Design.Comment ? neutral[86] : neutral[97];
 
             const styles = css`
                 width: 100%;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -380,8 +380,7 @@ const Pullquote: FC<PullquoteProps> = ({ quote, attribution, format }: Pullquote
 const richLinkWidth = '8.75rem';
 
 const richLinkStyles = (format: Format): SerializedStyles => {
-    const backgroundColor = (format: Format): string =>
-        format.design === Design.Comment ? neutral[86] : neutral[97];
+    const backgroundColor = format.design === Design.Comment ? neutral[86] : neutral[97];
     const formatStyles = format.design === Design.Live
         ? `width: calc(100% - ${remSpace[4]});`
         : `
@@ -392,7 +391,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
         `
 
     return css`
-        background: ${backgroundColor(format)};
+        background: ${backgroundColor};
         padding: ${basePx(1)};
         border-top: solid 1px ${neutral[60]};
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,17 +1,17 @@
 // ----- Imports ----- //
 
-import { ReactNode, createElement as h, ReactElement, FC } from 'react';
+import { createElement as h, FC, ReactElement, ReactNode } from 'react';
 import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { from, until } from '@guardian/src-foundations/mq';
-import { text as textColour, neutral } from '@guardian/src-foundations/palette';
-import { Option, fromNullable, some, none, andThen, map, withDefault } from 'types/option';
-import { basePx, icons, darkModeCss } from 'styles';
+import { neutral, text as textColour } from '@guardian/src-foundations/palette';
+import { andThen, fromNullable, map, none, Option, some, withDefault } from 'types/option';
+import { basePx, darkModeCss, icons } from 'styles';
 import { getPillarStyles } from 'pillarStyles';
 import { Format } from 'format';
-import { ElementKind, BodyElement } from 'bodyElement';
-import { Role, BodyImageProps } from 'image';
+import { BodyElement, ElementKind } from 'bodyElement';
+import { BodyImageProps, Role } from 'image';
 import { body, headline, textSans } from '@guardian/src-foundations/typography';
-import { remSpace, palette } from '@guardian/src-foundations';
+import { palette, remSpace } from '@guardian/src-foundations';
 import Audio from 'components/audio';
 import Video from 'components/video';
 import Paragraph from 'components/paragraph';
@@ -20,10 +20,10 @@ import BodyImageThumbnail from 'components/bodyImageThumbnail';
 import FigCaption from 'components/figCaption';
 import BodyImageHalfWidth from 'components/bodyImageHalfWidth';
 import Anchor from 'components/anchor';
-import InteractiveAtom, { atomCss, atomScript } from 'components/atoms/interactiveAtom';
+import InteractiveAtom, {atomCss, atomScript} from 'components/atoms/interactiveAtom';
 import { Design } from '@guardian/types/Format';
 import Blockquote from 'components/blockquote';
-import { isElement, pipe2, pipe } from 'lib';
+import { isElement, pipe, pipe2 } from 'lib';
 import { ExplainerAtom } from '@guardian/atoms-rendering';
 import LiveEventLink from 'components/liveEventLink';
 import { fromUnsafe, Result, toOption } from 'types/result';
@@ -380,6 +380,7 @@ const Pullquote: FC<PullquoteProps> = ({ quote, attribution, format }: Pullquote
 const richLinkWidth = '8.75rem';
 
 const richLinkStyles = (format: Format): SerializedStyles => {
+    const backgroundColor = (format: Format) => format.design === Design.Comment ? neutral[86] : neutral[97];
     const formatStyles = format.design === Design.Live
         ? `width: calc(100% - ${remSpace[4]});`
         : `
@@ -390,7 +391,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
         `
 
     return css`
-        background: ${neutral[97]};
+        background: ${backgroundColor(format)};
         padding: ${basePx(1)};
         border-top: solid 1px ${neutral[60]};
 
@@ -601,11 +602,14 @@ const render = (format: Format, excludeStyles = false) =>
 
         case ElementKind.MediaAtom: {
             const { posterUrl, videoId, duration, caption } = element;
+
+            const backgroundColor = (format: Format) => format.design === Design.Comment ? neutral[86] : neutral[97];
+
             const styles = css`
                 width: 100%;
                 padding-bottom: 56.25%;
                 margin: 0;
-                background: ${neutral[97]};
+                background: ${backgroundColor(format)};
                 ${darkModeCss`
                     background: ${neutral[20]};
                 `}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,10 +1,10 @@
-import {neutral} from '@guardian/src-foundations/palette';
-import {from, until} from '@guardian/src-foundations/mq';
-import {remSpace} from '@guardian/src-foundations';
-import {css, SerializedStyles} from '@emotion/core'
-import {map, none, Option, some, withDefault} from 'types/option';
-import {textSans} from '@guardian/src-foundations/typography';
-import {pipe2} from 'lib';
+import { neutral } from '@guardian/src-foundations/palette';
+import { from, until } from '@guardian/src-foundations/mq';
+import { remSpace } from '@guardian/src-foundations';
+import { css, SerializedStyles } from '@emotion/core'
+import { map, none, Option, some, withDefault } from 'types/option';
+import { textSans } from '@guardian/src-foundations/typography';
+import { pipe2 }  from 'lib';
 import { Format, Design } from '@guardian/types/Format';
 
 const BASE_PADDING = 8;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -65,7 +65,7 @@ export const articleWidthStyles = css`
 
 const adHeight = '258px';
 
-export const adStyles  = (format: Format) => {
+export const adStyles  = (format: Format): SerializedStyles => {
     const backgroundColour = format.design === Design.Comment ? neutral[86] : neutral[97];
 
     return css`

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,10 +1,11 @@
-import { neutral } from '@guardian/src-foundations/palette';
-import { from, until } from '@guardian/src-foundations/mq';
-import { remSpace } from '@guardian/src-foundations';
-import { css, SerializedStyles } from '@emotion/core'
-import { Option, some, none, map, withDefault } from 'types/option';
-import { textSans } from '@guardian/src-foundations/typography';
-import { pipe2 } from 'lib';
+import {neutral} from '@guardian/src-foundations/palette';
+import {from, until} from '@guardian/src-foundations/mq';
+import {remSpace} from '@guardian/src-foundations';
+import {css, SerializedStyles} from '@emotion/core'
+import {map, none, Option, some, withDefault} from 'types/option';
+import {textSans} from '@guardian/src-foundations/typography';
+import {pipe2} from 'lib';
+import { Format, Design } from '@guardian/types/Format';
 
 const BASE_PADDING = 8;
 
@@ -64,14 +65,17 @@ export const articleWidthStyles = css`
 
 const adHeight = '258px';
 
-export const adStyles = css`
+export const adStyles  = (format: Format) => {
+    const backgroundColour = format.design === Design.Comment ? neutral[86] : neutral[97];
+
+    return css`
     .ad-placeholder {
         &.hidden {
             display: none;
         }
 
         color: ${neutral[20]};
-        background: ${neutral[97]};
+        background: ${backgroundColour};
 
         ${darkModeCss`
             color: ${neutral[60]};
@@ -152,6 +156,7 @@ export const adStyles = css`
         }
     }
 `
+}
 
 export const fontFace = (
     family: string,


### PR DESCRIPTION
## Why are you doing this?
Some of the contrast of background elements were not clear enough on opinion/comment articles, this PR changes the background colour from `neutral.97` to `neutral.86`

This is for:

- header images
- header videos
- body images
- body videos
- adverts
- tags
- rich links

Paired with @dskamiotis 

## Screenshots
Header
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/19835654/87774029-e8956b00-c81b-11ea-85e4-007d5bb03339.png" width="500px" /> | <img src="https://user-images.githubusercontent.com/19835654/87774074-fb0fa480-c81b-11ea-837c-964933cc5a5a.png" width="500px" /> |

Body
| Before | After (with Advert too) |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/19835654/87780751-424f6280-c827-11ea-8cf2-7c9d7f880aae.png" width="500px" /> | <img src="https://user-images.githubusercontent.com/19835654/87780810-5dba6d80-c827-11ea-8685-5a1bd7662a9a.png" width="500px" /> |

Tags and Richlink
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/19835654/87780886-8478a400-c827-11ea-872e-c721926760c0.png" width="500px" /> | <img src="https://user-images.githubusercontent.com/19835654/87780916-922e2980-c827-11ea-83d9-7624c9fe0e93.png" width="500px" /> |
