### PR TITLE
Stop running Chromatic on unnecessary PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,7 +2,12 @@ name: "Chromatic"
 on:
     push:
         paths:
-        - 'src/components'
+        - '!api-models/'
+        - '!project/'
+        - '!*.sbt'
+        - '!*.md'
+        - '!*.yaml'
+        - '!.gitignore'
 
 jobs:
     test:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,5 +1,8 @@
 name: "Chromatic"
-on: push
+on:
+    push:
+        paths:
+        - 'src/components'
 
 jobs:
     test:


### PR DESCRIPTION
## Why are you doing this?

We're currently running Chromatic on all branches, regardless of what has changed. This should filter out branches that do not directly impact components or version updates e.g. from Source.

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths

cc @gtrufitt @SiAdcock 