### PR TITLE
Use encrypted copy of xenial-mobile-node AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -5,6 +5,7 @@ deployments:
     type: cloud-formation
     app: mobile-apps-rendering
     parameters:
+      amiEncrypted: true
       amiTags:
         Recipe: xenial-mobile-node
         AmigoStage: PROD


### PR DESCRIPTION
## Why are you doing this?

An ec2 instance's disk might contain private data e.g. application secrets or user data. Therefore it's preferable to use an encrypted AMI.

## Changes

- Request an encrypted copy of our AMI, as per [the RiffRaff docs](https://riffraff.gutools.co.uk/docs/magenta-lib/types#cloudformation).