### PR TITLE
guardian/types Semver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4640,8 +4640,8 @@
       }
     },
     "@guardian/types": {
-      "version": "github:guardian/types#9ec4c22c5b415122cabbb5c232836022fe3994d1",
-      "from": "github:guardian/types#9ec4c22c5b415122cabbb5c232836022fe3994d1",
+      "version": "github:guardian/types#75dd28453223cfbb40347b550b109494d1168f06",
+      "from": "github:guardian/types#semver:^0.4.0",
       "requires": {
         "typescript": "^3.8.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4640,7 +4640,7 @@
       }
     },
     "@guardian/types": {
-      "version": "github:guardian/types#75dd28453223cfbb40347b550b109494d1168f06",
+      "version": "github:guardian/types#3277ac1456496a98115a7bb80bb79d385ed8417d",
       "from": "github:guardian/types#semver:^0.4.0",
       "requires": {
         "typescript": "^3.8.3"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@guardian/src-button": "^2.0.0",
     "@guardian/src-foundations": "^2.1.0",
     "@guardian/src-icons": "^2.1.0",
-    "@guardian/types": "github:guardian/types",
+    "@guardian/types": "github:guardian/types#semver:^0.4.0",
     "@types/jsdom": "^16.2.3",
     "@types/uuid": "^8.0.0",
     "aws-sdk": "^2.726.0",


### PR DESCRIPTION
## Why are you doing this?

Switching over to using [semver values](https://docs.npmjs.com/cli/install) for the `guardian/types` dependency.

This allows you to specify semver values for git repos, similar to how you can specify them for packages on the npm registry. The semver range is specified in `package.json`, and the exact commit that corresponds to the currently resolved version is recorded in `package-lock.json`. As far as I can tell, when looking up the target repository, the npm CLI uses a combination of the `version` specified in `package.json` and git tags to select a given commit. This mechanism also works with the [`npm update`](https://docs.npmjs.com/cli/update) command when it's time to bump your dependency.

FYI @guardian/client-side-infra 

## Changes

- Used semver to specify `guardian/types` dependency
- Updated `guardian/types` to `0.4.3`
