### PR TITLE
Cache dependencies for CI builds

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,6 +15,11 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: node-    
     - name: install
       run: npm ci
     - name: lint


### PR DESCRIPTION
## Why are you doing this?

This should speed up CI builds slightly; it seems to shave ~10 seconds off the `install` step (based on the limited testing I've done so far).

## Changes

- Add dependency caching, as per [GitHub example](https://github.com/actions/cache/blob/main/examples.md#node---npm).