### PR TITLE
LIVE-420: Added css styles to gallery cards with svg icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4557,7 +4557,7 @@
     },
     "@guardian/types": {
       "version": "github:guardian/types#3277ac1456496a98115a7bb80bb79d385ed8417d",
-      "from": "github:guardian/types",
+      "from": "github:guardian/types#semver:^0.4.0",
       "requires": {
         "typescript": "^3.8.3"
       }

--- a/src/components/media/articleBody.tsx
+++ b/src/components/media/articleBody.tsx
@@ -10,7 +10,7 @@ import { Format } from '@guardian/types/Format';
 const ArticleBodyStyles = (format: Format): SerializedStyles => css`
     position: relative;
     clear: both;
-    background: ${background.inverse}    
+    background: ${background.inverse};
     color: ${neutral[86]};
 
     ${adStyles(format)}

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -218,7 +218,7 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
                         {icon(relatedItem.type, format)} 
                         {date}
                     </div>
-                    <div css={ imageWrapperStyles }>{img}</div>
+                    <div css={imageWrapperStyles}>{img}</div>
                 </section>
             </a>
         </li>ç

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -6,7 +6,7 @@ import { remSpace, breakpoints } from '@guardian/src-foundations';
 import { Option, withDefault, map, fromNullable } from '@guardian/types/option';
 import { makeRelativeDate } from 'date';
 import { pipe2 } from 'lib';
-import { text, neutral } from '@guardian/src-foundations/palette';
+import { text, neutral, background } from '@guardian/src-foundations/palette';
 import { Design, Display, Format } from '@guardian/types/Format';
 import { Image } from 'image';
 import { darkModeCss } from 'styles';
@@ -14,6 +14,7 @@ import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItem
 import { getPillarStyles, pillarFromString } from 'pillarStyles';
 import Img from 'components/img';
 import { border } from 'editorialPalette';
+import { SvgCamera } from '@guardian/src-icons';
 
 
 
@@ -43,7 +44,7 @@ const listStyles = css`
         ${textSans.small()};
         color: ${text.supporting};
         text-align: right;
-        width: calc(100% - ${remSpace[2]});
+        float: right;
         display: inline-block;
     }
 `
@@ -107,7 +108,12 @@ const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles
         }
 
         case RelatedItemType.GALLERY: {
-            return css``;
+            return css`
+            background: ${background.inverse};
+            h3{
+                color: ${text.ctaPrimary};
+            }
+            `;
         }
 
         case RelatedItemType.SPECIAL: {
@@ -166,6 +172,39 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
         withDefault<ReactElement | null>(null)
     )
 
+    const parentIconStyles = (format:Format): SerializedStyles => css`
+        display:inline-block;
+        svg {
+            width: 0.875rem;
+            height: auto;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: 0.300rem;
+            display: block;
+        }
+    `;
+
+    const iconStyles = (format:Format): SerializedStyles => css`
+        width: 1.5rem;
+        height: 1.4375rem;
+        display: inline-block;
+        background-color: #eacca0;
+        border-radius: 50%;
+    `;
+
+    const icon = (itemType: RelatedItemType, format: Format) => {
+        if (itemType === RelatedItemType.GALLERY){
+            return <section css={parentIconStyles}><span css={iconStyles}>< SvgCamera /></span></section>;
+        } else {
+            return <section css={parentIconStyles} ></section>;
+        }
+    }
+
+    const metaDataStyles = (format:Format): SerializedStyles => css`
+        padding: 0 ${remSpace[2]};
+        min-height:35px;
+    `;
+
     const lastModified = relatedItem.lastModified?.iso8601;
     const date = lastModified ? relativeFirstPublished(fromNullable(new Date(lastModified))) : null;
 
@@ -175,11 +214,14 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
                     <h3 css={headingStyles}>{relatedItem.title}</h3>
                 </section>
                 <section>
-                    {date}
-                    <div css={imageWrapperStyles}>{img}</div>
+                    <div css= {metaDataStyles}>
+                        {icon(relatedItem.type, format)} 
+                        {date}
+                    </div>
+                    <div css={ imageWrapperStyles }>{img}</div>
                 </section>
             </a>
-        </li>
+        </li>ç
 }
 
 

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -183,7 +183,7 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
             display: block;
         }
     `;
-    const { kicker } = getPillarStyles(format.pillar);
+    const { inverted } = getPillarStyles(format.pillar);
     const iconStyles = (format: Format): SerializedStyles => css`
         width: 1.5rem;
         height: 1.4375rem;

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -172,7 +172,7 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
         withDefault<ReactElement | null>(null)
     )
 
-    const parentIconStyles = (format:Format): SerializedStyles => css`
+    const parentIconStyles = (format: Format): SerializedStyles => css`
         display:inline-block;
         svg {
             width: 0.875rem;
@@ -184,7 +184,7 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
         }
     `;
 
-    const iconStyles = (format:Format): SerializedStyles => css`
+    const iconStyles = (format: Format): SerializedStyles => css`
         width: 1.5rem;
         height: 1.4375rem;
         display: inline-block;
@@ -192,15 +192,17 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
         border-radius: 50%;
     `;
 
-    const icon = (itemType: RelatedItemType, format: Format) => {
+    const icon = (itemType: RelatedItemType, format: Format): JSX.Element => {
         if (itemType === RelatedItemType.GALLERY){
-            return <section css={parentIconStyles}><span css={iconStyles}>< SvgCamera /></span></section>;
+            return <section css={parentIconStyles}>
+                    <span css={iconStyles}>< SvgCamera /></span>
+                   </section>;
         } else {
             return <section css={parentIconStyles} ></section>;
         }
     }
 
-    const metaDataStyles = (format:Format): SerializedStyles => css`
+    const metaDataStyles = (format: Format): SerializedStyles => css`
         padding: 0 ${remSpace[2]};
         min-height:35px;
     `;
@@ -221,7 +223,7 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
                     <div css={imageWrapperStyles}>{img}</div>
                 </section>
             </a>
-        </li>ç
+        </li>
 }
 
 

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -188,7 +188,7 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
         width: 1.5rem;
         height: 1.4375rem;
         display: inline-block;
-        background-color: ${kicker};
+        background-color: ${inverted};
         border-radius: 50%;
     `;
 

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -109,10 +109,10 @@ const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles
 
         case RelatedItemType.GALLERY: {
             return css`
-            background: ${background.inverse};
-            h3{
-                color: ${text.ctaPrimary};
-            }
+                background: ${background.inverse};
+                h3 {
+                    color: ${text.ctaPrimary};
+                }
             `;
         }
 

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -183,12 +183,12 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
             display: block;
         }
     `;
-
+    const { kicker } = getPillarStyles(format.pillar);
     const iconStyles = (format: Format): SerializedStyles => css`
         width: 1.5rem;
         height: 1.4375rem;
         display: inline-block;
-        background-color: #eacca0;
+        background-color: ${kicker};
         border-radius: 50%;
     `;
 
@@ -204,7 +204,7 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
 
     const metaDataStyles = (format: Format): SerializedStyles => css`
         padding: 0 ${remSpace[2]};
-        min-height:35px;
+        min-height: 1.4375rem
     `;
 
     const lastModified = relatedItem.lastModified?.iso8601;


### PR DESCRIPTION
## Why are you doing this?

Gallery cards have no formatting to signify them as gallery cards. Formatting needed to _only_ be applied to gallery cards.
## Changes

- Gallery cards formatted consistent with DC, added background colour to card.
- Inverted the background colour of the card.
- This is applied only when the type of card is Gallery
- Also included the camera svg within new tags (aligned with date/time) adding appropriate formatting as per DC.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/90160261-75830400-dd89-11ea-8c99-44fb5d12828a.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/90160514-c72b8e80-dd89-11ea-9418-f29e9bd0dc28.png" width="300px" /> |
