### PR TITLE
Live-418: audio and video cards

### DIFF
--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -15,7 +15,7 @@ import { getPillarStyles, pillarFromString } from 'pillarStyles';
 import Img from 'components/img';
 import { border } from 'editorialPalette';
 import { SvgCamera } from '@guardian/src-icons';
-
+import { SvgAudio } from '@guardian/src-icons';
 
 
 interface Props {
@@ -80,7 +80,7 @@ const relativeFirstPublished = (date: Option<Date>): JSX.Element | null => pipe2
 );
 
 const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles => {
-    switch(itemType) {
+    switch (itemType) {
         case RelatedItemType.FEATURE: {
             const { kicker } = getPillarStyles(format.pillar);
 
@@ -121,7 +121,12 @@ const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles
         }
 
         case RelatedItemType.AUDIO: {
-            return css``;
+            return css`
+                background: ${background.inverse};
+                h3 {
+                    color: ${text.ctaPrimary};
+                }
+            `;
         }
 
         case RelatedItemType.LIVE: {
@@ -193,10 +198,14 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
     `;
 
     const icon = (itemType: RelatedItemType, format: Format): JSX.Element => {
-        if (itemType === RelatedItemType.GALLERY){
+        if (itemType === RelatedItemType.GALLERY) {
             return <section css={parentIconStyles}>
-                    <span css={iconStyles}>< SvgCamera /></span>
-                   </section>;
+                <span css={iconStyles}>< SvgCamera /></span>
+            </section>;
+        } else if (itemType === RelatedItemType.AUDIO) {
+            return <section css={parentIconStyles}>
+                <span css={iconStyles}>< SvgAudio /></span>
+            </section>;
         } else {
             return <section css={parentIconStyles} ></section>;
         }
@@ -207,23 +216,34 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
         min-height: 1.4375rem
     `;
 
+    const durationMedia = (duration: Option<string>): JSX.Element => {
+        return pipe2(
+            duration,
+            map(length => <span>{length}</span>),
+            withDefault(
+                <></>
+            )
+        )
+    }
+
     const lastModified = relatedItem.lastModified?.iso8601;
     const date = lastModified ? relativeFirstPublished(fromNullable(new Date(lastModified))) : null;
 
     return <li css={[listStyles, cardStyles(relatedItem.type, format)]}>
-            <a css={anchorStyles} href={relatedItem.link}>
-                <section css={headingWrapperStyles}>
-                    <h3 css={headingStyles}>{relatedItem.title}</h3>
-                </section>
-                <section>
-                    <div css= {metaDataStyles}>
-                        {icon(relatedItem.type, format)} 
-                        {date}
-                    </div>
-                    <div css={imageWrapperStyles}>{img}</div>
-                </section>
-            </a>
-        </li>
+        <a css={anchorStyles} href={relatedItem.link}>
+            <section css={headingWrapperStyles}>
+                <h3 css={headingStyles}>{relatedItem.title}</h3>
+            </section>
+            <section>
+                <div css={metaDataStyles}>
+                    {icon(relatedItem.type, format)}
+                    {durationMedia(fromNullable(relatedItem.mediaDuration))}
+                    {date}
+                </div>
+                <div css={imageWrapperStyles}>{img}</div>
+            </section>
+        </a>
+    </li>
 }
 
 

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -3,7 +3,7 @@ import { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
 import { css, SerializedStyles } from '@emotion/core';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { remSpace, breakpoints } from '@guardian/src-foundations';
-import { Option, withDefault, map, fromNullable } from '@guardian/types/option';
+import { Option, withDefault, map, fromNullable, OptionKind } from '@guardian/types/option';
 import { makeRelativeDate, formatSeconds } from 'date';
 import { pipe2 } from 'lib';
 import { text, neutral, background } from '@guardian/src-foundations/palette';
@@ -20,9 +20,10 @@ import { SvgCamera, SvgVideo, SvgAudio } from '@guardian/src-icons';
 interface Props {
     relatedItem: RelatedItem;
     image: Option<Image>;
+
 }
 
-const listStyles = css`
+const listStyles = (format: Format): SerializedStyles => css`
     background: white;
     margin-right: ${remSpace[3]};
     flex: 0 0 15rem;
@@ -30,7 +31,7 @@ const listStyles = css`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-
+    border-top : 1px solid ${getPillarStyles(format.pillar).kicker};
     img {
         width: 100%;
         height: 100%;
@@ -70,10 +71,19 @@ const headingWrapperStyles = css`
     min-height: 150px;
 `
 
-const headingStyles = css`
-    ${headline.xxxsmall()};
-    margin: 0;
+const headingStyles = (itemType: RelatedItemType) => {
+    if (itemType === RelatedItemType.ADVERTISEMENT_FEATURE){
+        return css`
+            ${textSans.medium({ lineHeight: 'regular' })}
+            margin: 0;
+    `;
+    } else {
+        return css`
+            ${headline.xxxsmall()};
+            margin: 0;
 `;
+    }
+}
 
 const imageWrapperStyles = css`
     padding-bottom: 56.25%;
@@ -87,6 +97,7 @@ const relativeFirstPublished = (date: Option<Date>): JSX.Element | null => pipe2
 );
 
 const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles => {
+    
     switch (itemType) {
         case RelatedItemType.FEATURE: {
             const { kicker } = getPillarStyles(format.pillar);
@@ -138,7 +149,10 @@ const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles
         }
 
         case RelatedItemType.ADVERTISEMENT_FEATURE: {
-            return css``;
+            return css`
+                background-color : ${neutral[97]};
+                ${textSans.large()}
+            `;
         }
 
         case RelatedItemType.COMMENT: {
@@ -196,9 +210,14 @@ const durationMedia = (duration: Option<string>): ReactElement | null => {
     return pipe2(
         duration,
         map(length => {
-            return <time css={[timeStyles, durationStyles]}>
-                {formatSeconds(length)}
-            </time>
+            const seconds = formatSeconds(length);
+            if (seconds.kind === OptionKind.Some) {
+                return <time css={[timeStyles, durationStyles]}>
+                    {seconds}
+                </time>
+            } else {
+                return null;
+            }
         }),
         withDefault<ReactElement | null>(null)
     )
@@ -226,26 +245,29 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
     )
 
     const lastModified = relatedItem.lastModified?.iso8601;
-    const date = lastModified ? relativeFirstPublished(fromNullable(new Date(lastModified))) : null;
+    const date = (lastModified && relatedItem.type !== RelatedItemType.ADVERTISEMENT_FEATURE) ?
+                     relativeFirstPublished(fromNullable(new Date(lastModified))) :
+                     null;
 
-    return <li css={[listStyles, cardStyles(relatedItem.type, format)]}>
-        <a css={anchorStyles} href={relatedItem.link}>
-            <section css={headingWrapperStyles}>
-                <h3 css={headingStyles}>{relatedItem.title}</h3>
-            </section>
-            <section>
-                <div css={metadataStyles}>
-                    <section css={parentIconStyles}>
-                        {icon(relatedItem.type, format)}
-                    </section>
-                    {durationMedia(fromNullable(relatedItem.mediaDuration))}
-                    {date}
-                </div>
-                <div css={imageWrapperStyles}>{img}</div>
-            </section>
-        </a>
-    </li>
+    return (
+        <li css={[listStyles(format), cardStyles(relatedItem.type, format)]}>
+            <a css={anchorStyles} href={relatedItem.link}>
+                <section css={headingWrapperStyles}>
+                    <h3 css={headingStyles(relatedItem.type)}>{relatedItem.title}</h3>
+                </section>
+                <section>
+                    <div css={metadataStyles}>
+                        <section css={parentIconStyles}>
+                            {icon(relatedItem.type, format)}
+                        </section>
+                        {durationMedia(fromNullable(relatedItem.mediaDuration))}
+                        {date}
+                    </div>
+                    <div css={imageWrapperStyles}>{img}</div>
+                </section>
+            </a>
+        </li>
+    )
 }
-
 
 export default Card;

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -14,8 +14,7 @@ import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItem
 import { getPillarStyles, pillarFromString } from 'pillarStyles';
 import Img from 'components/img';
 import { border } from 'editorialPalette';
-import { SvgCamera, SvgVideo } from '@guardian/src-icons';
-import { SvgAudio } from '@guardian/src-icons';
+import { SvgCamera, SvgVideo, SvgAudio } from '@guardian/src-icons';
 
 
 interface Props {
@@ -175,23 +174,16 @@ const iconStyles = (format: Format): SerializedStyles => {
     `;
 }
 
-const icon = (itemType: RelatedItemType, format: Format): JSX.Element => {
+const icon = (itemType: RelatedItemType, format: Format): ReactElement | null => {
     switch (itemType){
         case RelatedItemType.GALLERY:
-            return <section css={parentIconStyles}>
-                        <span css={iconStyles(format)}>< SvgCamera /></span>
-                    </section>;
+            return <span css={iconStyles(format)}>< SvgCamera /></span>;
         case RelatedItemType.AUDIO:
-            return <section css={parentIconStyles}>
-                        <span css={iconStyles(format)}>< SvgAudio /></span>
-                    </section>;
+            return <span css={iconStyles(format)}>< SvgAudio /></span>;
         case RelatedItemType.VIDEO:
-            return <section css={parentIconStyles}>
-                        <span css={iconStyles(format)}>< SvgVideo /></span>
-                    </section>;
+            return <span css={iconStyles(format)}>< SvgVideo /></span>
         default:
-            return <section css={parentIconStyles} ></section>;
-
+            return null;
     }
 }
 
@@ -200,7 +192,7 @@ const metadataStyles: SerializedStyles = css`
     min-height: 1.5rem
 `;
 
-const durationMedia = (duration: Option<string>): JSX.Element => {
+const durationMedia = (duration: Option<string>): ReactElement | null => {
     return pipe2(
         duration,
         map(length => {
@@ -208,7 +200,7 @@ const durationMedia = (duration: Option<string>): JSX.Element => {
                 {formatSeconds(length)}
             </time>
         }),
-        withDefault(<></>)
+        withDefault<ReactElement | null>(null)
     )
 }
 
@@ -243,7 +235,9 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
             </section>
             <section>
                 <div css={metadataStyles}>
-                    {icon(relatedItem.type, format)}
+                    <section css={parentIconStyles}>
+                        {icon(relatedItem.type, format)}
+                    </section>
                     {durationMedia(fromNullable(relatedItem.mediaDuration))}
                     {date}
                 </div>

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -3,7 +3,7 @@ import { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
 import { css, SerializedStyles } from '@emotion/core';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { remSpace, breakpoints } from '@guardian/src-foundations';
-import { Option, withDefault, map, fromNullable } from '@guardian/types/option';
+import { Option, withDefault, map, fromNullable, OptionKind } from '@guardian/types/option';
 import { makeRelativeDate, formatSeconds } from 'date';
 import { pipe2 } from 'lib';
 import { text, neutral, background } from '@guardian/src-foundations/palette';
@@ -196,9 +196,14 @@ const durationMedia = (duration: Option<string>): ReactElement | null => {
     return pipe2(
         duration,
         map(length => {
-            return <time css={[timeStyles, durationStyles]}>
-                {formatSeconds(length)}
-            </time>
+            const seconds = formatSeconds(length);
+            if (seconds.kind === OptionKind.Some) {
+                return <time css={[timeStyles, durationStyles]}>
+                    {seconds.value}
+                </time>
+            } else {
+                return null;
+            }
         }),
         withDefault<ReactElement | null>(null)
     )

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -3,7 +3,7 @@ import { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
 import { css, SerializedStyles } from '@emotion/core';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { remSpace, breakpoints } from '@guardian/src-foundations';
-import { Option, withDefault, map, fromNullable, OptionKind } from '@guardian/types/option';
+import { Option, withDefault, map, fromNullable } from '@guardian/types/option';
 import { makeRelativeDate, formatSeconds } from 'date';
 import { pipe2 } from 'lib';
 import { text, neutral, background } from '@guardian/src-foundations/palette';
@@ -20,10 +20,9 @@ import { SvgCamera, SvgVideo, SvgAudio } from '@guardian/src-icons';
 interface Props {
     relatedItem: RelatedItem;
     image: Option<Image>;
-
 }
 
-const listStyles = (format: Format): SerializedStyles => css`
+const listStyles = css`
     background: white;
     margin-right: ${remSpace[3]};
     flex: 0 0 15rem;
@@ -31,7 +30,7 @@ const listStyles = (format: Format): SerializedStyles => css`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    border-top : 1px solid ${getPillarStyles(format.pillar).kicker};
+
     img {
         width: 100%;
         height: 100%;
@@ -71,19 +70,10 @@ const headingWrapperStyles = css`
     min-height: 150px;
 `
 
-const headingStyles = (itemType: RelatedItemType) => {
-    if (itemType === RelatedItemType.ADVERTISEMENT_FEATURE){
-        return css`
-            ${textSans.medium({ lineHeight: 'regular' })}
-            margin: 0;
-    `;
-    } else {
-        return css`
-            ${headline.xxxsmall()};
-            margin: 0;
+const headingStyles = css`
+    ${headline.xxxsmall()};
+    margin: 0;
 `;
-    }
-}
 
 const imageWrapperStyles = css`
     padding-bottom: 56.25%;
@@ -97,7 +87,6 @@ const relativeFirstPublished = (date: Option<Date>): JSX.Element | null => pipe2
 );
 
 const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles => {
-    
     switch (itemType) {
         case RelatedItemType.FEATURE: {
             const { kicker } = getPillarStyles(format.pillar);
@@ -149,10 +138,7 @@ const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles
         }
 
         case RelatedItemType.ADVERTISEMENT_FEATURE: {
-            return css`
-                background-color : ${neutral[97]};
-                ${textSans.large()}
-            `;
+            return css``;
         }
 
         case RelatedItemType.COMMENT: {
@@ -210,14 +196,9 @@ const durationMedia = (duration: Option<string>): ReactElement | null => {
     return pipe2(
         duration,
         map(length => {
-            const seconds = formatSeconds(length);
-            if (seconds.kind === OptionKind.Some) {
-                return <time css={[timeStyles, durationStyles]}>
-                    {seconds.value}
-                </time>
-            } else {
-                return null;
-            }
+            return <time css={[timeStyles, durationStyles]}>
+                {formatSeconds(length)}
+            </time>
         }),
         withDefault<ReactElement | null>(null)
     )
@@ -245,29 +226,26 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
     )
 
     const lastModified = relatedItem.lastModified?.iso8601;
-    const date = (lastModified && relatedItem.type !== RelatedItemType.ADVERTISEMENT_FEATURE) ?
-                     relativeFirstPublished(fromNullable(new Date(lastModified))) :
-                     null;
+    const date = lastModified ? relativeFirstPublished(fromNullable(new Date(lastModified))) : null;
 
-    return (
-        <li css={[listStyles(format), cardStyles(relatedItem.type, format)]}>
-            <a css={anchorStyles} href={relatedItem.link}>
-                <section css={headingWrapperStyles}>
-                    <h3 css={headingStyles(relatedItem.type)}>{relatedItem.title}</h3>
-                </section>
-                <section>
-                    <div css={metadataStyles}>
-                        <section css={parentIconStyles}>
-                            {icon(relatedItem.type, format)}
-                        </section>
-                        {durationMedia(fromNullable(relatedItem.mediaDuration))}
-                        {date}
-                    </div>
-                    <div css={imageWrapperStyles}>{img}</div>
-                </section>
-            </a>
-        </li>
-    )
+    return <li css={[listStyles, cardStyles(relatedItem.type, format)]}>
+        <a css={anchorStyles} href={relatedItem.link}>
+            <section css={headingWrapperStyles}>
+                <h3 css={headingStyles}>{relatedItem.title}</h3>
+            </section>
+            <section>
+                <div css={metadataStyles}>
+                    <section css={parentIconStyles}>
+                        {icon(relatedItem.type, format)}
+                    </section>
+                    {durationMedia(fromNullable(relatedItem.mediaDuration))}
+                    {date}
+                </div>
+                <div css={imageWrapperStyles}>{img}</div>
+            </section>
+        </a>
+    </li>
 }
+
 
 export default Card;

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -213,7 +213,7 @@ const durationMedia = (duration: Option<string>): ReactElement | null => {
             const seconds = formatSeconds(length);
             if (seconds.kind === OptionKind.Some) {
                 return <time css={[timeStyles, durationStyles]}>
-                    {seconds}
+                    {seconds.value}
                 </time>
             } else {
                 return null;

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -155,11 +155,11 @@ const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles
 const parentIconStyles: SerializedStyles = css`
     display:inline-block;
     svg {
-        width: 0.875rem;
+        width: 1rem;
         height: auto;
         margin-left: auto;
         margin-right: auto;
-        margin-top: 0.300rem;
+        margin-top: 0.25rem;
         display: block;
     }
 `;
@@ -168,7 +168,7 @@ const iconStyles = (format: Format): SerializedStyles => {
     const { inverted } = getPillarStyles(format.pillar);
     return css`
         width: 1.5rem;
-        height: 1.4375rem;
+        height: 1.5rem;
         display: inline-block;
         background-color: ${inverted};
         border-radius: 50%;
@@ -176,26 +176,28 @@ const iconStyles = (format: Format): SerializedStyles => {
 }
 
 const icon = (itemType: RelatedItemType, format: Format): JSX.Element => {
-    if (itemType === RelatedItemType.GALLERY) {
-        return <section css={parentIconStyles}>
-            <span css={iconStyles(format)}>< SvgCamera /></span>
-        </section>;
-    } else if (itemType === RelatedItemType.AUDIO) {
-        return <section css={parentIconStyles}>
-            <span css={iconStyles(format)}>< SvgAudio /></span>
-        </section>;
-    } else if (itemType === RelatedItemType.VIDEO) {
-        return <section css={parentIconStyles}>
-            <span css={iconStyles(format)}>< SvgVideo /></span>
-        </section>;
-    } else {
-        return <section css={parentIconStyles} ></section>;
+    switch (itemType){
+        case RelatedItemType.GALLERY:
+            return <section css={parentIconStyles}>
+                        <span css={iconStyles(format)}>< SvgCamera /></span>
+                    </section>;
+        case RelatedItemType.AUDIO:
+            return <section css={parentIconStyles}>
+                        <span css={iconStyles(format)}>< SvgAudio /></span>
+                    </section>;
+        case RelatedItemType.VIDEO:
+            return <section css={parentIconStyles}>
+                        <span css={iconStyles(format)}>< SvgVideo /></span>
+                    </section>;
+        default:
+            return <section css={parentIconStyles} ></section>;
+
     }
 }
 
 const metadataStyles: SerializedStyles = css`
     padding: 0 ${remSpace[2]};
-    min-height: 1.4375rem
+    min-height: 1.5rem
 `;
 
 const durationMedia = (duration: Option<string>): JSX.Element => {

--- a/src/components/shared/relatedContent.tsx
+++ b/src/components/shared/relatedContent.tsx
@@ -7,6 +7,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { remSpace, neutral } from '@guardian/src-foundations';
 import { ResizedRelatedContent } from 'item';
 import { darkModeCss } from 'styles';
+import { from } from '@guardian/src-foundations/mq';
 
 interface Props {
     content: Option<ResizedRelatedContent>;
@@ -14,6 +15,10 @@ interface Props {
 
 const styles = css`
     padding: ${remSpace[6]} 0;
+    ${from.wide} {
+        width: 1300px;
+        margin: 0 auto;
+    }
 `;
 
 const headingStyles = css`

--- a/src/date.ts
+++ b/src/date.ts
@@ -98,6 +98,28 @@ function fromString(date: string): Option<Date> {
     }
 }
 
+function formatSeconds(seconds: string): string | null {
+    try {
+        const secondsInt = parseInt(seconds);
+        if (isNaN(secondsInt)) {
+            return null;
+        }
+        const hrs = Math.floor((secondsInt / 3600));
+        const mins = Math.floor(((secondsInt % 3600) / 60));
+        const secs = Math.floor(secondsInt) % 60;
+        let ret = "";
+
+        if (hrs > 0) {
+            ret += `${hrs}:${mins < 10 ? "0" : ""}`
+        }
+
+        ret += `${mins}:${secs < 10 ? "0" : ""}${secs}`;
+        return ret;
+    } catch(e) {
+        return null;
+    }
+}
+
 
 // ----- Exports ----- //
 
@@ -106,4 +128,5 @@ export {
     format as formatDate,
     isValidDate,
     fromString,
+    formatSeconds,
 }

--- a/src/date.ts
+++ b/src/date.ts
@@ -98,12 +98,13 @@ function fromString(date: string): Option<Date> {
     }
 }
 
-function formatSeconds(seconds: string): string | null {
-    try {
+function formatSeconds(seconds: string): Option<string> {
         const secondsInt = parseInt(seconds);
+
         if (isNaN(secondsInt)) {
-            return null;
+            return none;
         }
+
         const hrs = Math.floor((secondsInt / 3600));
         const mins = Math.floor(((secondsInt % 3600) / 60));
         const secs = Math.floor(secondsInt) % 60;
@@ -114,10 +115,7 @@ function formatSeconds(seconds: string): string | null {
         }
 
         ret += `${mins}:${secs < 10 ? "0" : ""}${secs}`;
-        return ret;
-    } catch(e) {
-        return null;
-    }
+        return some(ret);
 }
 
 

--- a/src/date.ts
+++ b/src/date.ts
@@ -98,13 +98,12 @@ function fromString(date: string): Option<Date> {
     }
 }
 
-function formatSeconds(seconds: string): Option<string> {
+function formatSeconds(seconds: string): string | null {
+    try {
         const secondsInt = parseInt(seconds);
-
         if (isNaN(secondsInt)) {
-            return none;
+            return null;
         }
-
         const hrs = Math.floor((secondsInt / 3600));
         const mins = Math.floor(((secondsInt % 3600) / 60));
         const secs = Math.floor(secondsInt) % 60;
@@ -115,7 +114,10 @@ function formatSeconds(seconds: string): Option<string> {
         }
 
         ret += `${mins}:${secs < 10 ? "0" : ""}${secs}`;
-        return some(ret);
+        return ret;
+    } catch(e) {
+        return null;
+    }
 }
 
 

--- a/src/item.ts
+++ b/src/item.ts
@@ -141,7 +141,6 @@ function getDisplay(content: Content): Display {
 
 const itemFields = (context: Context, request: RenderingRequest): ItemFields => {
     const { content, branding, commentCount, relatedContent } = request;
-
     return {
         pillar: pillarFromString(content?.pillarId),
         display: getDisplay(content),

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,4 +1,4 @@
-import { neutral, brandAltBackground } from '@guardian/src-foundations/palette';
+import { neutral, brandAltBackground, background } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { remSpace } from '@guardian/src-foundations';
 import { css, SerializedStyles } from '@emotion/core'
@@ -49,7 +49,6 @@ export const linkStyle = (kicker: string): string => `
     }
 `
 
-const relatedContentWidth = 1300;
 export const wideContentWidth = 620;
 export const wideColumnWidth = 220;
 
@@ -65,14 +64,15 @@ export const articleWidthStyles: SerializedStyles = css`
 `;
 
 export const relatedContentStyles: SerializedStyles = css`
+    background: ${neutral[97]};
     ${sidePadding}
     ${from.phablet} {
         margin: 0 auto;
     }
 
-    ${from.wide} {
-        width: ${relatedContentWidth}px;
-    }
+    ${darkModeCss`
+        background: ${background.inverse};
+    `};
 `
 
 const adHeight = '258px';


### PR DESCRIPTION
## Why are you doing this?

Appropriate formatting needed for audio and video cards need in related content, as well as svg and duration of audio/video for cards not displaying.

## Changes

- Added audio, video cards, the duration and also fixed the appearance on media pages (gallery, video, audio)

![video-card](https://user-images.githubusercontent.com/49187886/90262367-24851580-de46-11ea-860a-758aa76af8d5.png)

