### PR TITLE
stop linting node_modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 *.test.ts
+node_modules

--- a/src/components/comment/article.tsx
+++ b/src/components/comment/article.tsx
@@ -13,7 +13,7 @@ import Tags from 'components/shared/tags';
 import Cutout from 'components/comment/cutout';
 import { darkModeCss, articleWidthStyles, basePx, relatedContentStyles } from 'styles';
 import { Keyline } from 'components/shared/keyline';
-import { Comment } from 'item';
+import { Comment as CommentItem } from 'item';
 import Byline from 'components/byline';
 import Metadata from 'components/metadata';
 import HeaderMedia from 'headerMedia';
@@ -58,7 +58,7 @@ const topBorder = css`
 // ----- Component ----- //
 
 interface Props {
-    item: Comment;
+    item: CommentItem;
     children: ReactNode[];
 }
 


### PR DESCRIPTION
## Why are you doing this?
`node_modules` are being linted unnecessarily when running `npm run lint`. This adds about a minute to the running time.
