### PR TITLE
Live:416 - added styling for comment cards and added capiendpoint for date

### DIFF
--- a/src/capi.test.ts
+++ b/src/capi.test.ts
@@ -1,5 +1,4 @@
 import { capiEndpoint } from './capi';
-import { date } from '@storybook/addon-knobs';
 
 describe('server logic runs as expected', () => {
     it('generates capi endpoint url', () => {

--- a/src/capi.test.ts
+++ b/src/capi.test.ts
@@ -1,4 +1,5 @@
 import { capiEndpoint } from './capi';
+import { date } from '@storybook/addon-knobs';
 
 describe('server logic runs as expected', () => {
     it('generates capi endpoint url', () => {
@@ -6,6 +7,6 @@ describe('server logic runs as expected', () => {
         const key = 'TEST_KEY';
         const capiUrl = capiEndpoint(articleId, key);
 
-        expect(capiUrl).toEqual('https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue%2CdisplayHint%2CstarRating%2Ccommentable%2CliveBloggingNow&show-tags=all&show-blocks=all&show-elements=all&show-related=true');
+        expect(capiUrl).toEqual('https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue%2CdisplayHint%2CstarRating%2Ccommentable%2CliveBloggingNow%2ClastModified&show-tags=all&show-blocks=all&show-elements=all&show-related=true')               
     });
 });

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -128,7 +128,8 @@ const capiEndpoint = (articleId: string, key: string): string => {
         'displayHint',
         'starRating',
         'commentable',
-        'liveBloggingNow'
+        'liveBloggingNow',
+        'lastModified'
     ];
 
     const params = new URLSearchParams({

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -212,11 +212,13 @@ const iconStyles = (format: Format): SerializedStyles => {
 
 const commentIconStyle = (): SerializedStyles => {
     return css`
-        width: 1.9rem;
+        width: 2.0rem;
         height: 1.4375rem;
         display: inline-block;
-        fill: ${opinion[400]};
-        vertical-align : text-top;
+        fill: #E05E00;
+        vertical-align: text-top;
+        margin-top: -3px;
+        margin-right: -2px;
     `;
 }
 

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -6,7 +6,7 @@ import { remSpace, breakpoints, palette } from '@guardian/src-foundations';
 import { Option, withDefault, map, fromNullable, OptionKind } from '@guardian/types/option';
 import { makeRelativeDate, formatSeconds } from 'date';
 import { pipe2 } from 'lib';
-import { text, neutral, background } from '@guardian/src-foundations/palette';
+import { text, neutral, background, opinion } from '@guardian/src-foundations/palette';
 import { Design, Display, Format } from '@guardian/types/Format';
 import { Image } from 'image';
 import { darkModeCss } from 'styles';
@@ -14,7 +14,7 @@ import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItem
 import { getPillarStyles, pillarFromString } from 'pillarStyles';
 import Img from 'components/img';
 import { border } from 'editorialPalette';
-import { SvgCamera, SvgVideo, SvgAudio } from '@guardian/src-icons';
+import { SvgCamera, SvgVideo, SvgAudio, SvgQuote } from '@guardian/src-icons';
 import { stars } from 'components/starRating';
 
 
@@ -93,7 +93,7 @@ const headingStyles = (itemType: RelatedItemType): SerializedStyles => {
         `;
     } else {
         return css`
-            ${headline.xxxsmall()};
+            ${headline.xxsmall()}
             margin: 0 0 ${remSpace[2]} 0;
         `;
     }
@@ -175,7 +175,10 @@ const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles
         }
 
         case RelatedItemType.COMMENT: {
-            return css``;
+            return css`
+                background-color : ${opinion[800]};
+                ${headline.xxsmall()}
+            `;
         }
 
         default: {
@@ -207,6 +210,16 @@ const iconStyles = (format: Format): SerializedStyles => {
     `;
 }
 
+const commentIconStyle = (): SerializedStyles => {
+    return css`
+        width: 1.9rem;
+        height: 1.4375rem;
+        display: inline-block;
+        fill: ${opinion[400]};
+        vertical-align : text-top;
+    `;
+}
+
 const icon = (itemType: RelatedItemType, format: Format): ReactElement | null => {
     switch (itemType){
         case RelatedItemType.GALLERY:
@@ -217,6 +230,14 @@ const icon = (itemType: RelatedItemType, format: Format): ReactElement | null =>
             return <span css={iconStyles(format)}>< SvgVideo /></span>
         default:
             return null;
+    }
+}
+
+const quotationComment = (itemType: RelatedItemType, format: Format): ReactElement | null => {
+    if (itemType === RelatedItemType.COMMENT){
+        return <span css={commentIconStyle}>< SvgQuote /></span>;
+    } else {
+        return null
     }
 }
 
@@ -273,7 +294,10 @@ const Card = ({ relatedItem, image }: Props): JSX.Element => {
         <li css={[listStyles(relatedItem.type, format), cardStyles(relatedItem.type, format)]}>
             <a css={anchorStyles} href={relatedItem.link}>
                 <section css={headingWrapperStyles}>
-                    <h3 css={headingStyles(relatedItem.type)}>{relatedItem.title}</h3>
+                    <h3 css={headingStyles(relatedItem.type)}>
+                        {quotationComment(relatedItem.type, format)}
+                        {relatedItem.title}
+                    </h3>
                     {starRating}
                 </section>
                 <section>

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -215,7 +215,7 @@ const commentIconStyle = (): SerializedStyles => {
         width: 2.0rem;
         height: 1.4375rem;
         display: inline-block;
-        fill: #E05E00;
+        fill: ${opinion[400]};;
         vertical-align: text-top;
         margin-top: -3px;
         margin-right: -2px;


### PR DESCRIPTION
## Why are you doing this?

Styling needed for comment related cards to be consistent with headline and svgquote.
Date added is not rendering within the card also. 

## Changes

- Added background colour, font headline small, added co;our and size for quotation svg.
- Adde pillar styles for border-top to be active
- Rendered a new component tag `quotationComment` to be generated only when its a comment card
- Added specific styling for commentIconStyle to make quotation inline with headline text
- added endpoint for lastModified date in capi.ts to get date from capi (lastModified)

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/91160831-d1228b00-e6c1-11ea-8f5f-c87b5c2413e9.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/91191762-15775080-e6ed-11ea-9cef-15b948e2a732.png" width="300px" /> |
