### PR TITLE
Live-125: Changed dateline colour neutral.20

### DIFF
--- a/src/components/dateline.stories.tsx
+++ b/src/components/dateline.stories.tsx
@@ -5,15 +5,16 @@ import { date, withKnobs } from '@storybook/addon-knobs';
 import { some } from '@guardian/types/option';
 import Dateline from './dateline';
 import { Pillar } from '@guardian/types/Format';
+import { selectPillar } from 'storybookHelpers';
 
-type DefaultProps = {
-    pillar: Pillar
-}
 
 // ----- Stories ----- //
 
-const Default: FC<DefaultProps> = ({pillar}:DefaultProps) =>
-    <Dateline pillar={pillar} date={some(new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))))} />
+const Default: FC = () =>
+    <Dateline 
+        pillar={selectPillar(Pillar.Opinion)} 
+        date={some(new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))))} 
+    />
 
 
 // ----- Exports ----- //

--- a/src/components/dateline.stories.tsx
+++ b/src/components/dateline.stories.tsx
@@ -2,7 +2,6 @@
 
 import React, { FC } from 'react';
 import { date, withKnobs } from '@storybook/addon-knobs';
-
 import { some } from '@guardian/types/option';
 import Dateline from './dateline';
 import { Pillar } from '@guardian/types/Format';

--- a/src/components/dateline.stories.tsx
+++ b/src/components/dateline.stories.tsx
@@ -5,12 +5,16 @@ import { date, withKnobs } from '@storybook/addon-knobs';
 
 import { some } from '@guardian/types/option';
 import Dateline from './dateline';
+import { Pillar } from '@guardian/types/Format';
 
+type DefaultProps = {
+    pillar: Pillar
+}
 
 // ----- Stories ----- //
 
-const Default: FC = () =>
-    <Dateline date={some(new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))))} />
+const Default: FC<DefaultProps> = ({pillar}:DefaultProps) =>
+    <Dateline pillar={pillar} date={some(new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))))} />
 
 
 // ----- Exports ----- //

--- a/src/components/dateline.tsx
+++ b/src/components/dateline.tsx
@@ -1,20 +1,21 @@
 // ----- Imports ----- //
 
 import React, { FC, ReactElement } from 'react';
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography';
-import { neutral } from '@guardian/src-foundations/palette';
-
+import { text, neutral } from '@guardian/src-foundations/palette';
 import { Option, withDefault, map } from '@guardian/types/option';
 import { darkModeCss as darkMode } from 'styles';
 import { formatDate } from 'date';
 import { pipe2 } from 'lib';
+import { Pillar } from '@guardian/types/Format';
 
 
 // ----- Component ----- //
 
 interface Props {
     date: Option<Date>;
+    pillar: Pillar;
 }
 
 const darkStyles = darkMode`
@@ -23,15 +24,31 @@ const darkStyles = darkMode`
 
 const styles = css`
     ${textSans.xsmall()}
+    color: ${text.supporting};
+
+    ${darkStyles}
+`;
+
+const commentDatelinStyles = css`
+    ${textSans.xsmall()}
     color: ${neutral[20]};
 
     ${darkStyles}
 `;
 
-const Dateline: FC<Props> = ({ date }) =>
+const getDatelineStyles = (pillar: Pillar): SerializedStyles => {
+    switch(pillar){
+        case Pillar.Opinion:
+            return commentDatelinStyles;
+        default:
+            return styles;
+    }
+}
+
+const Dateline: FC<Props> = ({ date, pillar }) =>
     pipe2(
         date,
-        map(d => <time css={styles} data-date={d} className="date">{ formatDate(d) }</time>),
+        map(d => <time css={getDatelineStyles(pillar)} data-date={d} className="date">{ formatDate(d) }</time>),
         withDefault<ReactElement | null>(null),
     )
 

--- a/src/components/dateline.tsx
+++ b/src/components/dateline.tsx
@@ -3,7 +3,7 @@
 import React, { FC, ReactElement } from 'react';
 import { css } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography';
-import { text, neutral } from '@guardian/src-foundations/palette';
+import { neutral } from '@guardian/src-foundations/palette';
 
 import { Option, withDefault, map } from '@guardian/types/option';
 import { darkModeCss as darkMode } from 'styles';
@@ -23,7 +23,7 @@ const darkStyles = darkMode`
 
 const styles = css`
     ${textSans.xsmall()}
-    color: ${text.supporting};
+    color: ${neutral[20]};
 
     ${darkStyles}
 `;

--- a/src/components/dateline.tsx
+++ b/src/components/dateline.tsx
@@ -29,7 +29,7 @@ const styles = css`
     ${darkStyles}
 `;
 
-const commentDatelinStyles = css`
+const commentDatelineStyles = css`
     ${textSans.xsmall()}
     color: ${neutral[20]};
 
@@ -39,7 +39,7 @@ const commentDatelinStyles = css`
 const getDatelineStyles = (pillar: Pillar): SerializedStyles => {
     switch(pillar){
         case Pillar.Opinion:
-            return commentDatelinStyles;
+            return commentDatelineStyles;
         default:
             return styles;
     }

--- a/src/components/liveblog/metadata.tsx
+++ b/src/components/liveblog/metadata.tsx
@@ -97,7 +97,7 @@ const Metadata = ({ item }: Props): JSX.Element => {
                         />
                         <div className="author">
                             { byline }
-                            <Dateline date={item.publishDate} />
+                            <Dateline date={item.publishDate} pillar={item.pillar}/>
                             <div className="follow">Get alerts on this story</div>
                         </div>
                     </div>

--- a/src/components/media/byline.tsx
+++ b/src/components/media/byline.tsx
@@ -58,7 +58,7 @@ function Byline({ pillar, publicationDate, className, item }: Props): JSX.Elemen
             <div>
                 <div className="author">
                     { byline }
-                    <Dateline date={publicationDate} />
+                    <Dateline date={publicationDate} pillar={item.pillar}/>
                 </div>
             </div>
         </div>

--- a/src/components/metadata.tsx
+++ b/src/components/metadata.tsx
@@ -4,13 +4,13 @@ import React, { FC } from 'react';
 import { css } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
 import { Display, Design } from '@guardian/types/Format';
-
 import { Item } from 'item';
 import Dateline from 'components/dateline';
 import Follow from 'components/follow';
 import CommentCount from 'components/commentCount';
 import Avatar from 'components/avatar';
 import Byline from 'components/byline';
+
 
 
 // ----- Component ----- //
@@ -41,7 +41,7 @@ const MetadataWithByline: FC<Props> = ({ item }: Props) =>
         <Avatar {...item} />
         <div css={css(textStyles, withBylineTextStyles)}>
             <Byline {...item} />
-            <Dateline date={item.publishDate} />
+            <Dateline date={item.publishDate} pillar={item.pillar} />
             <Follow {...item} />
         </div>
         <CommentCount count={item.commentCount} {...item} />
@@ -50,7 +50,7 @@ const MetadataWithByline: FC<Props> = ({ item }: Props) =>
 const ShortMetadata: FC<Props> = ({ item }: Props) =>
     <div css={styles}>
         <div css={textStyles}>
-            <Dateline date={item.publishDate} />
+            <Dateline date={item.publishDate} pillar={item.pillar} />
             <Follow {...item} />
         </div>
         <CommentCount count={item.commentCount} {...item} />

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -208,9 +208,6 @@ const iconStyles = (format: Format): SerializedStyles => {
 }
 
 const icon = (itemType: RelatedItemType, format: Format): ReactElement | null => {
-    // console.log(itemType)
-    // console.log(format);
-    
     switch (itemType){
         case RelatedItemType.GALLERY:
             return <span css={iconStyles(format)}>< SvgCamera /></span>;

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -208,6 +208,9 @@ const iconStyles = (format: Format): SerializedStyles => {
 }
 
 const icon = (itemType: RelatedItemType, format: Format): ReactElement | null => {
+    // console.log(itemType)
+    // console.log(format);
+    
     switch (itemType){
         case RelatedItemType.GALLERY:
             return <span css={iconStyles(format)}>< SvgCamera /></span>;


### PR DESCRIPTION
## Why are you doing this?

Contrast of dateline colour needs to be clearer upon rendering to stand out on background.

## Changes

- Changed dateline colour to neutral.20
- Omitted text from import - deprecated 

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/91309283-4e283000-e7a8-11ea-9036-0fffd18403cc.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/91309353-65ffb400-e7a8-11ea-8cab-6b8ffcd0c29c.png" width="300px" /> |
