### PR TITLE
Live:353- Sponsor offline links colour as kicker

### DIFF
--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -25,7 +25,7 @@ const styles = (format: Format,
         ${textSans.small()}
 
         img {
-            content: url("${darkModeImage ?? lightModeImage}");
+            content: url("${lightModeImage}");
             display: block;
             margin: ${remSpace[2]} 0;
             max-height: 60px;
@@ -49,7 +49,7 @@ const styles = (format: Format,
             }
 
             a {
-                color: ${inverted}
+                color: ${inverted};
             }
         `}
     `;
@@ -66,7 +66,7 @@ export const cleanImageUrl = (url: string): string =>
         .replace(/\(/g, '%28')
         .replace(/\)/g, '%29')
 
-const Logo: FC<Props> = ({ branding, format }: Props) => {    
+const Logo: FC<Props> = ({ branding, format }: Props) => {
     const lightLogo = cleanImageUrl(branding.logo);
     const darkLogo = cleanImageUrl(branding.altLogo ?? branding.logo);
 

--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -23,6 +23,7 @@ const styles = (format: Format, lightModeImage: string, darkModeImage?: string):
         ${textSans.small()}
 
         img {
+            content: url("${darkModeImage ?? lightModeImage}");
             display: block;
             margin: ${remSpace[2]} 0;
             max-height: 60px;

--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -9,37 +9,48 @@ import { Item, getFormat } from 'item';
 import { pipe2 } from 'lib';
 import { map, withDefault } from '@guardian/types/option';
 import { textSans } from '@guardian/src-foundations/typography';
+import { getPillarStyles } from 'pillarStyles';
 
 interface Props {
     branding: Branding;
     format: Format;
 }
 
-const styles = (lightModeImage: string, darkModeImage?: string): SerializedStyles => css`
-    margin: ${remSpace[9]} 0;
-    ${textSans.small()}
+const styles = (format: Format, lightModeImage: string, darkModeImage?: string): SerializedStyles => {
+    const { kicker, inverted } = getPillarStyles(format.pillar);
+    return css`
+        margin: ${remSpace[9]} 0;
+        ${textSans.small()}
 
-    img {
-        content: url("${lightModeImage}");
-        display: block;
-        margin: ${remSpace[2]} 0;
-        max-height: 60px;
-    }
-
-    label {
-        color: ${text.supporting};
-    }
-
-    ${darkModeCss`
         img {
-            content: url("${darkModeImage ?? lightModeImage}");
+            display: block;
+            margin: ${remSpace[2]} 0;
+            max-height: 60px;
         }
 
         label {
-            color: ${neutral[86]};
+            color: ${text.supporting};
         }
-    `}
-`;
+
+        a {
+            color: ${kicker};
+        }
+
+        ${darkModeCss`
+            img {
+                content: url("${darkModeImage ?? lightModeImage}");
+            }
+
+            label {
+                color: ${neutral[86]};
+            }
+
+            a {
+                color: ${inverted}
+            }
+        `}
+    `;
+}
 
 const OptionalLogo = (item: Item): JSX.Element => pipe2(
     item.branding,
@@ -52,12 +63,12 @@ export const cleanImageUrl = (url: string): string =>
         .replace(/\(/g, '%28')
         .replace(/\)/g, '%29')
 
-const Logo: FC<Props> = ({ branding, format }: Props) => {
+const Logo: FC<Props> = ({ branding, format }: Props) => {    
     const lightLogo = cleanImageUrl(branding.logo);
     const darkLogo = cleanImageUrl(branding.altLogo ?? branding.logo);
 
     return (
-        <section css={styles(lightLogo, darkLogo)}>
+        <section css={styles(format, lightLogo, darkLogo)}>
             <label>{branding.label}</label>
             <a href={branding.sponsorUri}>
                 <img alt={branding.sponsorName} />

--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -16,7 +16,9 @@ interface Props {
     format: Format;
 }
 
-const styles = (format: Format, lightModeImage: string, darkModeImage?: string): SerializedStyles => {
+const styles = (format: Format, 
+                lightModeImage: string, 
+                darkModeImage?: string): SerializedStyles => {
     const { kicker, inverted } = getPillarStyles(format.pillar);
     return css`
         margin: ${remSpace[9]} 0;


### PR DESCRIPTION
## Why are you doing this?

Currently when offline the alt text defaults to the HTML blue.
We would like the alt text to be consistent with the Pillar colour, as well as inverted when in dark mode.
## Changes

- Added kicker colour from Pillar, for text to render when offline/missing logo
- Included inverted colour for dark mode
- Included format prop in Logo component to read Pillar type

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/91844845-127de200-ec50-11ea-88e7-8c8ced166e15.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/91844891-26c1df00-ec50-11ea-8bc3-2b716992306b.png" width="300px" /> |
