### PR TITLE
Live -454: refactored components from JSX to FC

### DIFF
--- a/src/components/advertisementFeature/article.tsx
+++ b/src/components/advertisementFeature/article.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, FC } from 'react';
 import { css } from '@emotion/core';
 import { neutral, background } from '@guardian/src-foundations/palette';
 import { from, breakpoints } from '@guardian/src-foundations/mq';
@@ -48,7 +48,7 @@ interface Props {
     children: ReactNode[];
 }
 
-const AdvertisementFeature = ({ item, children }: Props): JSX.Element => {
+const AdvertisementFeature: FC<Props> = ({ item, children }) => {
     return <main css={[Styles, DarkStyles]}>
         <article css={BorderStyles}>
             <header>

--- a/src/components/comment/article.tsx
+++ b/src/components/comment/article.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, FC } from 'react';
 import { css } from '@emotion/core';
 import { neutral, opinion, background } from '@guardian/src-foundations/palette';
 import { from, breakpoints } from '@guardian/src-foundations/mq';
@@ -62,7 +62,7 @@ interface Props {
     children: ReactNode[];
 }
 
-const Comment = ({ item, children }: Props): JSX.Element =>
+const Comment: FC<Props> = ({ item, children }) =>
     <main css={[Styles, DarkStyles]}>
         <article css={BorderStyles}>
             <header>

--- a/src/components/comment/cutout.tsx
+++ b/src/components/comment/cutout.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React, { ReactElement } from 'react';
+import React, { ReactElement, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 
 import { Contributor, isSingleContributor } from 'contributor';
@@ -38,7 +38,7 @@ interface Props {
     format: Format;
 }
 
-const Cutout = ({ contributors, className, format }: Props): JSX.Element | null => {
+const Cutout: FC<Props> = ({ contributors, className, format }) => {
     const [contributor] = contributors;
 
     if (!isSingleContributor(contributors)) {

--- a/src/components/follow.tsx
+++ b/src/components/follow.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography';
 
@@ -37,8 +37,7 @@ function getStyles({ pillar }: Format): SerializedStyles {
     return styles(kicker, inverted);
 }
 
-function Follow({ contributors, ...format }: Props): JSX.Element | null {
-
+const Follow: FC<Props> = ({ contributors, ...format }) => {
     const [contributor] = contributors;
 
     if (

--- a/src/components/headerVideo.tsx
+++ b/src/components/headerVideo.tsx
@@ -53,7 +53,7 @@ interface Props {
     format: Format;
 }
 
-const HeaderVideo: FC<Props> = ({ video, format }: Props): JSX.Element =>
+const HeaderVideo: FC<Props> = ({ video, format }) =>
     <div
         css={styles(format)}
         data-posterUrl={video.posterUrl}

--- a/src/components/interactive/article.tsx
+++ b/src/components/interactive/article.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, FC } from 'react';
 
 // ----- Component ----- //
 
@@ -8,7 +8,7 @@ interface Props {
     children: ReactNode[];
 }
 
-const Interactive = ({ children }: Props): JSX.Element =>
+const Interactive:FC<Props> = ({ children }) =>
     <main>
         <article>
             {children}

--- a/src/components/interactive/article.tsx
+++ b/src/components/interactive/article.tsx
@@ -8,7 +8,7 @@ interface Props {
     children: ReactNode[];
 }
 
-const Interactive:FC<Props> = ({ children }) =>
+const Interactive: FC<Props> = ({ children }) =>
     <main>
         <article>
             {children}

--- a/src/components/liveblog/article.tsx
+++ b/src/components/liveblog/article.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import LiveblogSeries from 'components/liveblog/series';
 import LiveblogHeadline from 'components/liveblog/headline';
@@ -48,7 +48,7 @@ interface LiveblogArticleProps {
     item: Liveblog;
 }
 
-const LiveblogArticle = ({ item }: LiveblogArticleProps): JSX.Element => {
+const LiveblogArticle: FC<LiveblogArticleProps> = ({ item }) => {
     const format = getFormat(item);
 
     return (

--- a/src/components/liveblog/avatar.tsx
+++ b/src/components/liveblog/avatar.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React, { ReactElement } from 'react';
+import React, { ReactElement, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 
 import { Contributor, isSingleContributor } from 'contributor';
@@ -37,7 +37,7 @@ interface AvatarProps {
     bgColour: string;
 }
 
-function Avatar({ contributors, bgColour }: AvatarProps): JSX.Element | null {
+const Avatar: FC<AvatarProps> = ({ contributors, bgColour }) => {
     const [contributor] = contributors;
 
     if (!isSingleContributor(contributors)) {

--- a/src/components/liveblog/block.tsx
+++ b/src/components/liveblog/block.tsx
@@ -75,7 +75,7 @@ const LiveblogBlock: FC<LiveblogBlockProps> = ({
     firstPublishedDate,
     lastModifiedDate,
 }) => {
-    const relativeFirstPublished: FC<Option<Date>> = (date) => pipe2(
+    const relativeFirstPublished = (date: Option<Date>): JSX.Element | null  => pipe2(
         date,
         map(date => <time>{makeRelativeDate(date)}</time>),
         withDefault<JSX.Element | null>(null),

--- a/src/components/liveblog/block.tsx
+++ b/src/components/liveblog/block.tsx
@@ -75,7 +75,7 @@ const LiveblogBlock: FC<LiveblogBlockProps> = ({
     firstPublishedDate,
     lastModifiedDate,
 }) => {
-    const relativeFirstPublished = (date: Option<Date>): JSX.Element | null  => pipe2(
+    const relativeFirstPublished = (date: Option<Date>): JSX.Element | null => pipe2(
         date,
         map(date => <time>{makeRelativeDate(date)}</time>),
         withDefault<JSX.Element | null>(null),

--- a/src/components/liveblog/block.tsx
+++ b/src/components/liveblog/block.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState, useEffect } from 'react';
+import React, { ReactNode, useState, useEffect, FC } from 'react';
 import { basePx } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
 import { neutral, brandAlt } from '@guardian/src-foundations/palette';
@@ -59,7 +59,7 @@ interface TitleProps {
     highlighted: boolean;
 }
 
-const Title = ({ title, highlighted }: TitleProps): JSX.Element | null => {
+const Title: FC<TitleProps> = ({ title, highlighted } ) => {
     const TitleStyles = css`
         padding: 0.1rem 0.125rem;
         background-color: ${brandAlt[400]};
@@ -67,15 +67,15 @@ const Title = ({ title, highlighted }: TitleProps): JSX.Element | null => {
     return title ? <h3><span css={highlighted ? TitleStyles : null}>{title}</span></h3> : null;
 }
 
-const LiveblogBlock = ({
+const LiveblogBlock: FC<LiveblogBlockProps> = ({
     pillar,
     highlighted,
     title,
     children,
     firstPublishedDate,
     lastModifiedDate,
-}: LiveblogBlockProps): JSX.Element => {
-    const relativeFirstPublished = (date: Option<Date>): JSX.Element | null => pipe2(
+}) => {
+    const relativeFirstPublished: FC<Option<Date>> = (date) => pipe2(
         date,
         map(date => <time>{makeRelativeDate(date)}</time>),
         withDefault<JSX.Element | null>(null),

--- a/src/components/liveblog/block.tsx
+++ b/src/components/liveblog/block.tsx
@@ -59,7 +59,7 @@ interface TitleProps {
     highlighted: boolean;
 }
 
-const Title: FC<TitleProps> = ({ title, highlighted } ) => {
+const Title: FC<TitleProps> = ({ title, highlighted }) => {
     const TitleStyles = css`
         padding: 0.1rem 0.125rem;
         background-color: ${brandAlt[400]};

--- a/src/components/liveblog/body.tsx
+++ b/src/components/liveblog/body.tsx
@@ -24,7 +24,8 @@ const styles = css`
 `
 interface LoadMoreProps { 
     total: number; 
-    pillar: Pillar }
+    pillar: Pillar;
+}
 
 const LoadMore: FC<LoadMoreProps> = ({total, pillar}) => 
     total > 7

--- a/src/components/liveblog/body.tsx
+++ b/src/components/liveblog/body.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, FC } from 'react';
 import LiveblogBlock from './block';
 import LiveblogLoadMore from './loadMore';
 import { Pillar, Format } from '@guardian/types/Format';
@@ -22,13 +22,16 @@ const styles = css`
         margin-left: ${remSpace[2]};
     }
 `
+interface LoadMoreProps { 
+    total: number; 
+    pillar: Pillar }
 
-const LoadMore = ({ total, pillar }: { total: number; pillar: Pillar }): JSX.Element | null =>
+const LoadMore: FC<LoadMoreProps> = ({total, pillar}) => 
     total > 7
         ? <LiveblogLoadMore onLoadMore={(): Promise<void> => Promise.resolve()} pillar={pillar}/>
         : null;
 
-const LiveblogBody = (props: LiveblogBodyProps): JSX.Element => {
+const LiveblogBody: FC<LiveblogBodyProps> = (props) => {
     const { format, blocks: initialBlocks, totalBodyBlocks } = props;
     const [blocks] = useState(initialBlocks);
 

--- a/src/components/liveblog/commentCount.tsx
+++ b/src/components/liveblog/commentCount.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { SerializedStyles, css } from '@emotion/core';
 import { basePx, icons } from 'styles';
 import { neutral } from '@guardian/src-foundations/palette';
@@ -35,7 +35,7 @@ const CommentCountStyles = (colour: string): SerializedStyles => css`
     }
 `
 
-export const CommentCount = ({ count, colour, className }: CommentCountProps): JSX.Element => {
+export const CommentCount: FC<CommentCountProps> = ({ count, colour, className }) => {
     return <div css={[CommentCountStyles(colour), className]}>
         <span></span>
         <button>{count}</button>

--- a/src/components/liveblog/headline.tsx
+++ b/src/components/liveblog/headline.tsx
@@ -21,7 +21,7 @@ interface LiveblogHeadlineProps {
     pillar: Pillar;
 }
 
-const LiveblogHeadline:FC<LiveblogHeadlineProps> = ({ headline, pillar }) =>
+const LiveblogHeadline: FC<LiveblogHeadlineProps> = ({ headline, pillar }) =>
     <LeftColumn className={LiveblogHeadlineStyles(getPillarStyles(pillar))}>
         <h1>{ headline }</h1>
     </LeftColumn>

--- a/src/components/liveblog/headline.tsx
+++ b/src/components/liveblog/headline.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { neutral } from '@guardian/src-foundations/palette';
 import LeftColumn from 'components/shared/leftColumn';
@@ -21,7 +21,7 @@ interface LiveblogHeadlineProps {
     pillar: Pillar;
 }
 
-const LiveblogHeadline = ({ headline, pillar }: LiveblogHeadlineProps): JSX.Element =>
+const LiveblogHeadline:FC<LiveblogHeadlineProps> = ({ headline, pillar }) =>
     <LeftColumn className={LiveblogHeadlineStyles(getPillarStyles(pillar))}>
         <h1>{ headline }</h1>
     </LeftColumn>

--- a/src/components/liveblog/keyEvents.tsx
+++ b/src/components/liveblog/keyEvents.tsx
@@ -148,7 +148,7 @@ interface LiveblogKeyEventsProps {
     blocks: LiveBlock[];
 }
 
-const LiveblogKeyEvents:FC<LiveblogKeyEventsProps> = ({ pillar, blocks }) => {
+const LiveblogKeyEvents: FC<LiveblogKeyEventsProps> = ({ pillar, blocks }) => {
     const keyEvents = blocks.filter(elem => elem.isKeyEvent).slice(0, 7);
     return (
         <section css={LiveblogKeyEventsStyles(getPillarStyles(pillar))}>

--- a/src/components/liveblog/keyEvents.tsx
+++ b/src/components/liveblog/keyEvents.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { icons, basePx } from 'styles';
 import { css, SerializedStyles } from '@emotion/core'
 import { neutral } from '@guardian/src-foundations/palette';
@@ -148,7 +148,7 @@ interface LiveblogKeyEventsProps {
     blocks: LiveBlock[];
 }
 
-const LiveblogKeyEvents = ({ pillar, blocks }: LiveblogKeyEventsProps): JSX.Element => {
+const LiveblogKeyEvents:FC<LiveblogKeyEventsProps> = ({ pillar, blocks }) => {
     const keyEvents = blocks.filter(elem => elem.isKeyEvent).slice(0, 7);
     return (
         <section css={LiveblogKeyEventsStyles(getPillarStyles(pillar))}>

--- a/src/components/liveblog/loadMore.tsx
+++ b/src/components/liveblog/loadMore.tsx
@@ -10,7 +10,7 @@ interface Props {
     onLoadMore: () => Promise<void>;
 }
 
-const LiveblogLoadMore:FC<Props> = ({ pillar, onLoadMore }) => {
+const LiveblogLoadMore: FC<Props> = ({ pillar, onLoadMore }) => {
     const theme = {
         button: {
             textPrimary: pillarColours[pillar].soft,

--- a/src/components/liveblog/loadMore.tsx
+++ b/src/components/liveblog/loadMore.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { pillarColours } from 'pillarStyles';
 import { Pillar } from '@guardian/types/Format';
 import { SvgPlus } from "@guardian/src-icons"
@@ -10,7 +10,7 @@ interface Props {
     onLoadMore: () => Promise<void>;
 }
 
-const LiveblogLoadMore = ({ pillar, onLoadMore }: Props): JSX.Element => {
+const LiveblogLoadMore:FC<Props> = ({ pillar, onLoadMore }) => {
     const theme = {
         button: {
             textPrimary: pillarColours[pillar].soft,

--- a/src/components/liveblog/metadata.tsx
+++ b/src/components/liveblog/metadata.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, FC } from 'react';
 import { basePx } from 'styles';
 import { Keyline } from '../shared/keyline';
 import { css, SerializedStyles } from '@emotion/core';
@@ -76,7 +76,7 @@ interface Props {
     item: Liveblog;
 }
 
-const Metadata = ({ item }: Props): JSX.Element => {
+const Metadata:FC<Props> = ({ item }) => {
     const pillarStyles = getPillarStyles(item.pillar);
 
     const byline = pipe2(

--- a/src/components/liveblog/metadata.tsx
+++ b/src/components/liveblog/metadata.tsx
@@ -76,7 +76,7 @@ interface Props {
     item: Liveblog;
 }
 
-const Metadata:FC<Props> = ({ item }) => {
+const Metadata: FC<Props> = ({ item }) => {
     const pillarStyles = getPillarStyles(item.pillar);
 
     const byline = pipe2(

--- a/src/components/liveblog/series.tsx
+++ b/src/components/liveblog/series.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { neutral } from '@guardian/src-foundations/palette';
 import { Series } from '../../capi';
@@ -23,7 +23,7 @@ interface LiveblogSeriesProps {
     pillar: Pillar;
 }
 
-const LiveblogSeries = (props: LiveblogSeriesProps): JSX.Element | null =>
+const LiveblogSeries: FC<LiveblogSeriesProps> = (props) =>
     pipe2(
         props.series,
         map(series =>

--- a/src/components/liveblog/standfirst.tsx
+++ b/src/components/liveblog/standfirst.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 import LeftColumn from 'components/shared/leftColumn';
@@ -34,7 +34,7 @@ interface LiveblogStandfirstProps {
     format: Format;
 }
 
-const LiveblogStandfirst = ({ standfirst, format }: LiveblogStandfirstProps): JSX.Element | null =>
+const LiveblogStandfirst: FC<LiveblogStandfirstProps> = ({ standfirst, format }) =>
     pipe2(
         standfirst,
         map(doc =>

--- a/src/components/media/article.tsx
+++ b/src/components/media/article.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, FC } from 'react';
 import { css } from '@emotion/core';
 import { background } from '@guardian/src-foundations/palette';
 import { from, breakpoints } from '@guardian/src-foundations/mq';
@@ -39,7 +39,7 @@ interface Props {
     children: ReactNode[];
 }
 
-const Media = ({ item, children }: Props): JSX.Element =>
+const Media: FC<Props> = ({ item, children }) =>
      <main css={[Styles]}>
         <article css={BorderStyles}>
             <header>

--- a/src/components/media/articleBody.tsx
+++ b/src/components/media/articleBody.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { adStyles, darkModeCss } from 'styles';
 import { background, neutral } from '@guardian/src-foundations/palette';
@@ -33,12 +33,12 @@ interface ArticleBodyProps {
     format: Format;
 }
 
-const ArticleBodyMedia = ({
+const ArticleBodyMedia: FC<ArticleBodyProps> = ({
     pillar,
     className,
     children,
     format
-}: ArticleBodyProps): JSX.Element =>
+}) =>
     <div css={[ArticleBodyStyles(format),
         ArticleBodyDarkStyles(getPillarStyles(pillar)),
         ...className]}>

--- a/src/components/media/articleSeries.tsx
+++ b/src/components/media/articleSeries.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { Series } from 'capi';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
@@ -20,7 +20,7 @@ interface ArticleSeriesProps {
     pillar: Pillar;
 }
 
-const ArticleSeries = (props: ArticleSeriesProps): JSX.Element | null =>
+const ArticleSeries: FC<ArticleSeriesProps> = (props) =>
     pipe2(
         props.series,
         map(series =>

--- a/src/components/media/byline.tsx
+++ b/src/components/media/byline.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Pillar } from '@guardian/types/Format';
@@ -45,8 +45,7 @@ interface Props {
     item: Item;
 }
 
-function Byline({ pillar, publicationDate, className, item }: Props): JSX.Element {
-
+const Byline: FC<Props> = ({ pillar, publicationDate, className, item }) => {
     const byline = pipe2(
         item.bylineHtml,
         map(html => <address>{ renderText(html, getFormat(item)) }</address>),

--- a/src/components/media/tags.tsx
+++ b/src/components/media/tags.tsx
@@ -44,7 +44,7 @@ const Tags: FC<TagsProps> = ({ tags, background }) => (
         {tags.map((tag, index) => {
             return <li key={index}>
                 <a href={tag.webUrl}>
-                    {tag.webTitle}FRED
+                    {tag.webTitle}
                 </a>
             </li>
         })}

--- a/src/components/media/tags.tsx
+++ b/src/components/media/tags.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { neutral } from '@guardian/src-foundations/palette';
 import { remSpace } from "@guardian/src-foundations";
@@ -39,12 +39,12 @@ interface TagsProps {
     background?: string;
 }
 
-const Tags = ({ tags, background }: TagsProps): JSX.Element => (
+const Tags: FC<TagsProps> = ({ tags, background }) => (
     <ul css={tagsStyles(background)}>
         {tags.map((tag, index) => {
             return <li key={index}>
                 <a href={tag.webUrl}>
-                    {tag.webTitle}
+                    {tag.webTitle}FRED
                 </a>
             </li>
         })}

--- a/src/components/shared/articleBody.tsx
+++ b/src/components/shared/articleBody.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { darkModeCss, adStyles } from 'styles';
 import { neutral, background } from '@guardian/src-foundations/palette';
@@ -44,11 +44,11 @@ const ArticleBodyDarkStyles: SerializedStyles = darkModeCss`
     }
 `;
 
-const ArticleBody = ({
+const ArticleBody: FC<ArticleBodyProps> = ({
     className,
     children,
     format
-}: ArticleBodyProps): JSX.Element =>
+}) =>
     <div css={[ArticleBodyStyles(format), ArticleBodyDarkStyles, ...className]}>
         {children}
     </div>

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -104,7 +104,7 @@ const imageWrapperStyles = css`
     position: relative;
 `;
 
-const relativeFirstPublished: FC<Option<Date>> = (date) => pipe2(
+const relativeFirstPublished = (date: Option<Date>): JSX.Element | null => pipe2(
     date,
     map(date => <time css={[timeStyles, dateStyles]}>{makeRelativeDate(date)}</time>),
     withDefault<JSX.Element | null>(null),

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, FC } from 'react';
 import { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
 import { css, SerializedStyles } from '@emotion/core';
 import { headline, textSans } from '@guardian/src-foundations/typography';
@@ -104,14 +104,13 @@ const imageWrapperStyles = css`
     position: relative;
 `;
 
-const relativeFirstPublished = (date: Option<Date>): JSX.Element | null => pipe2(
+const relativeFirstPublished: FC<Option<Date>> = (date) => pipe2(
     date,
     map(date => <time css={[timeStyles, dateStyles]}>{makeRelativeDate(date)}</time>),
     withDefault<JSX.Element | null>(null),
 );
 
 const cardStyles = (itemType: RelatedItemType, format: Format): SerializedStyles => {
-    
     switch (itemType) {
         case RelatedItemType.FEATURE: {
             const { kicker } = getPillarStyles(format.pillar);
@@ -265,7 +264,7 @@ const durationMedia = (duration: Option<string>): ReactElement | null => {
     )
 }
 
-const Card = ({ relatedItem, image }: Props): JSX.Element => {
+const Card: FC<Props> = ({ relatedItem, image }) => {
     const format = {
         pillar: pillarFromString(relatedItem.pillar.id),
         design: Design.Article,

--- a/src/components/shared/keyline.tsx
+++ b/src/components/shared/keyline.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { darkModeCss, wideContentWidth, wideColumnWidth } from 'styles';
 import { neutral } from '@guardian/src-foundations/palette';
@@ -50,7 +50,7 @@ type Props = {
     design: Design;
 };
 
-export const Keyline = ({ design }: Props): JSX.Element => {
+export const Keyline: FC<Props> = ({ design }) => {
     const SelectedKeylineStyles = ((design): SerializedStyles => {
         switch (design) {
             case Design.Live:

--- a/src/components/shared/leftColumn.tsx
+++ b/src/components/shared/leftColumn.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { from } from '@guardian/src-foundations/mq';
 import { wideContentWidth, wideColumnWidth } from 'styles';
@@ -49,8 +49,8 @@ interface LeftColumnProps {
 
 // ----- Component ----- //
 
-const LeftColumn =
-    ({ children, columnContent = null, className = null }: LeftColumnProps): JSX.Element =>
+const LeftColumn: FC<LeftColumnProps> =
+    ({ children, columnContent = null, className = null } ) =>
         <div css={[LeftColumnStyles, className]}>
             <div className="column-content">{columnContent}</div>
             <div className="main-content">{children}</div>

--- a/src/components/shared/leftColumn.tsx
+++ b/src/components/shared/leftColumn.tsx
@@ -50,7 +50,7 @@ interface LeftColumnProps {
 // ----- Component ----- //
 
 const LeftColumn: FC<LeftColumnProps> =
-    ({ children, columnContent = null, className = null } ) =>
+    ({ children, columnContent = null, className = null }) =>
         <div css={[LeftColumnStyles, className]}>
             <div className="column-content">{columnContent}</div>
             <div className="main-content">{children}</div>

--- a/src/components/shared/relatedContent.tsx
+++ b/src/components/shared/relatedContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Option, map, withDefault } from '@guardian/types/option';
 import { pipe2 } from 'lib';
 import Card from 'components/shared/card';
@@ -43,7 +43,7 @@ const listStyles = css`
     }
 `;
 
-const RelatedContent = ({ content }: Props): JSX.Element | null => {
+const RelatedContent: FC<Props> = ({ content }) => {
     return pipe2(
         content,
         map(({ title, relatedItems, resizedImages }) => {

--- a/src/components/shared/tags.tsx
+++ b/src/components/shared/tags.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { darkModeCss } from '../../styles';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -67,7 +67,7 @@ const tagsDarkStyles = darkModeCss`
     }
 `;
 
-const Tags = ({ tags, format }: TagsProps): JSX.Element => (
+const Tags: FC<TagsProps> = ({ tags, format }) => (
     <ul css={[tagsStyles(format), tagsDarkStyles]}>
         {tags.map((tag, index) => {
             return <li key={index}>

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { neutral, background } from '@guardian/src-foundations/palette';
 import { from, breakpoints } from '@guardian/src-foundations/mq';
@@ -78,7 +78,7 @@ interface Props {
     children: ReactNode[];
 }
 
-const Standard = ({ item, children }: Props): JSX.Element => {
+const Standard: FC<Props> = ({ item, children }) => {
     // client side code won't render an Epic if there's an element with this id
     const epicContainer = item.shouldHideReaderRevenue
         ? <div id="epic-container"></div>

--- a/src/headerMedia.tsx
+++ b/src/headerMedia.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Image as ImageData } from 'image';
 import { Video as VideoData } from 'video';
 import HeaderImage from 'components/headerImage';
@@ -20,7 +20,7 @@ interface HeaderMediaProps {
     item: Item;
 }
 
-const HeaderMedia = ({ item }: HeaderMediaProps): JSX.Element => {
+const HeaderMedia: FC<HeaderMediaProps> = ({ item }) => {
     const format = getFormat(item);
     return pipe2(
         item.mainMedia,


### PR DESCRIPTION
## Why are you doing this?

Currently many react components are constructed using JSX.Element with the type definition in the parameter. There is inconsistency across the code base in the way components are constructed.

## Changes

- Used FC<Props> to replace JSX.Elements
- imported FC within React in imports


