### PR TITLE
created pullquote component in new file updating icon with svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "src"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!(@guardian/src-foundations|@guardian/types)/)"
+      "node_modules/(?!(@guardian/src-foundations|@guardian/types|@guardian/src-icons)/)"
     ]
   },
   "author": "",

--- a/src/components/pullquote.tsx
+++ b/src/components/pullquote.tsx
@@ -1,0 +1,74 @@
+import { FC, ReactNode } from 'react';
+import { css, SerializedStyles } from '@emotion/core';
+import { Option, map, withDefault } from '@guardian/types/option';
+import { darkModeCss } from 'styles';
+import { getPillarStyles } from 'pillarStyles';
+import { Format } from '@guardian/types/Format';
+import { headline } from '@guardian/src-foundations/typography';
+import { remSpace } from '@guardian/src-foundations';
+import { pipe2 } from 'lib';
+import { SvgQuote } from '@guardian/src-icons/quote';
+import React from 'react';
+
+
+const styles = (format: Format): SerializedStyles => {
+    const { kicker, inverted } = getPillarStyles(format.pillar);
+    return css`
+        color: ${kicker};
+        margin: 0;
+        ${headline.xsmall({ fontWeight: 'light' })};
+        ${darkModeCss`color: ${inverted};`}
+
+    `;
+};
+
+const quoteStyles =  (format: Format): SerializedStyles => {
+    const { kicker, inverted } = getPillarStyles(format.pillar);
+
+    return css`
+        margin: ${remSpace[4]} 0 ${remSpace[2]} 0;
+
+        svg {
+            margin-bottom: -0.6rem;
+            height: 2.3rem;
+            margin-left: -0.3rem;
+            line-height: 1.2;
+            fill: ${kicker};
+            ${darkModeCss`fill: ${inverted};`}
+        }
+`;}
+
+const citeStyles = css`
+    font-style: normal;
+`;
+
+type Props = {
+    quote: string;
+    format: Format;
+    attribution: Option<string>;
+};
+
+const blockQuoteStyles = css`
+    margin-left: 0;
+`
+
+const Pullquote: FC<Props> = ({ quote, attribution, format }) => {
+    const quoteElement = (
+        <p css={quoteStyles(format)}>
+            <SvgQuote/>
+            {quote}
+        </p>
+    );
+    const children = pipe2(
+        attribution,
+        map(attribution => ([quoteElement, <cite css={citeStyles}>{attribution}</cite>])),
+        withDefault<ReactNode>([quoteElement]));
+
+    return (
+        <aside css= {styles(format)}>
+            <blockquote css={blockQuoteStyles}>{children}</blockquote> 
+        </aside>
+    );
+}
+
+export default Pullquote;

--- a/src/components/pullquote.tsx
+++ b/src/components/pullquote.tsx
@@ -61,7 +61,8 @@ const Pullquote: FC<Props> = ({ quote, attribution, format }) => {
     );
     const children = pipe2(
         attribution,
-        map(attribution => ([quoteElement, <cite css={citeStyles}>{attribution}</cite>])),
+        map(attribution => 
+            ([quoteElement, <cite key={attribution} css={citeStyles}>{attribution}</cite>])),
         withDefault<ReactNode>([quoteElement]));
 
     return (

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -217,13 +217,15 @@ describe('Renders different types of elements', () => {
     test('ElementKind.Pullquote', () => {
         const nodes = render(pullquoteElement())
         const pullquote = nodes.flat()[0];
-        expect(getHtml(pullquote)).toContain('<blockquote><p>quote</p></blockquote>');
+        expect(getHtml(pullquote)).toContain('quote');
+        expect(getHtml(pullquote)).not.toContain('attribution');
     })
 
     test('ElementKind.Pullquote with attribution', () => {
         const nodes = render(pullquoteWithAttributionElement())
         const pullquote = nodes.flat()[0];
-        expect(getHtml(pullquote)).toContain('<blockquote><p>quote</p><cite>attribution</cite></blockquote>');
+        expect(getHtml(pullquote)).toContain('attribution');
+        expect(getHtml(pullquote)).toContain('quote');
     })
 
     test('ElementKind.RichLink', () => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -29,6 +29,8 @@ import LiveEventLink from 'components/liveEventLink';
 import CalloutForm from 'components/calloutForm';
 import { fromUnsafe, Result, toOption } from '@guardian/types/result';
 import Bullet from 'components/bullet';
+import Pullquote  from 'components/pullquote';
+
 
 // ----- Renderer ----- //
 
@@ -288,63 +290,6 @@ const text = (doc: DocumentFragment, format: Format): ReactNode[] =>
 
 const standfirstText = (doc: DocumentFragment, format: Format): ReactNode[] =>
     Array.from(doc.childNodes).map(standfirstTextElement(format));
-
-const pullquoteStyles = (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.pillar);
-    return css`
-        color: ${kicker};
-        margin: 0;
-        ${headline.xsmall({ fontWeight: 'light' })};
-        ${darkModeCss`color: ${inverted};`}
-
-        blockquote {
-            margin-left: 0;
-        }
-
-        p {
-            margin: ${remSpace[4]} 0 ${remSpace[2]} 0;
-
-            &::before {
-                ${icons}
-                font-size: 1.5rem;
-                line-height: 1.2;
-                font-weight: 300;
-                content: '\\e11c';
-                display: inline-block;
-                margin-right: ${basePx(1)};
-            }
-        }
-
-        footer {
-            font-size: 1.8rem;
-            margin-top: 4px;
-
-            cite {
-                font-style: normal;
-            }
-        }
-    `;
-}
-
-type PullquoteProps = {
-    quote: string;
-    format: Format;
-    attribution: Option<string>;
-};
-
-
-const Pullquote: FC<PullquoteProps> = ({ quote, attribution, format }: PullquoteProps) => {
-    const children = pipe2(
-        attribution,
-        map(attribution => ([h('p', null, quote), h('cite', null, attribution)])),
-        withDefault([h('p', null, quote)]),
-    );
-
-    return styledH('aside',
-        { css: pullquoteStyles(format) },
-        h('blockquote', null, children)
-    );
-}
 
 const richLinkWidth = '8.75rem';
 


### PR DESCRIPTION
## Why are you doing this?

Currently pullquotes are using icons which cause issues when rendering in certain browser and ios/android versions, with strange fallback icons when not loading (square box).

Issues regarding Icons and how SVg are more desirable:
- Icon _Accessibility_: do not support screen readers,  SVG's, however are accessible to a screen reader (they are treated as images)
- Font icons are not as _scalable_ as they are font sized as opposed to vector based.
- In terms of _performance_ icons can increase HTTP server requests.for caching
- Icons are vulnerable to _anti-aliasing_ techniques causing blurring

In addition svg's allow for a  high degree of modifications without triggering additional server requests so can have a performance advantage

We could provide PNG icons as fallback, but since we have SVG's as part of source not necessary.




## Changes

- Created a new file to create pullquote component
- Customised styles for the new elements and svg
- converted h() to JSX elements

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/92267002-1754c700-eed8-11ea-83bb-a17c01d810fa.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/92266797-a9100480-eed7-11ea-91e5-0a2ae360890d.png" width="300px" /> |
