### PR TITLE
Seen article styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4335,9 +4335,9 @@
       "integrity": "sha512-2b3muMkENCqHgMQoUFAkJdqynmx+DYD1sCV0gZQkGmQrnkTOsBq5dagh0Q+MUYsCe8Mll1OIJ+Rmhd0vyFxrAw=="
     },
     "@guardian/bridget": {
-      "version": "0.66.0",
-      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-0.66.0.tgz",
-      "integrity": "sha512-S3Tr6zqfafVw1W944N7c9C1YLyjF5nkMR8GmjHUzldC5LWAmUz+FfpSSVaDrQvCZP+gcwvaPDix/emctRdUQFg=="
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-0.67.0.tgz",
+      "integrity": "sha512-KYH2U2K+uIsZzbq6hjTyJIq6x1E99NRH7g1qlRrOEJ6HT5/pOnSFQK4MTWMxbD6xF9+qK8YUiN4Pis9qcmSAcA=="
     },
     "@guardian/content-api-models": {
       "version": "15.9.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/apps-rendering-api-models": "^0.10.0",
     "@guardian/atoms-rendering": "^1.8.2",
-    "@guardian/bridget": "^0.66",
+    "@guardian/bridget": "^0.67",
     "@guardian/content-api-models": "^15.9.1",
     "@guardian/content-atom-model": "^3.2.2",
     "@guardian/node-riffraff-artifact": "^0.1.9",

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { notificationsClient, acquisitionsClient } from 'native/nativeApi';
+import { notificationsClient, acquisitionsClient, userClient } from 'native/nativeApi';
 import { Topic } from '@guardian/bridget/Topic';
 import { IMaybeEpic as MaybeEpic } from '@guardian/bridget/MaybeEpic';
 import { formatDate } from 'date';
@@ -203,6 +203,17 @@ function callouts(): void {
     })
 }
 
+function hasSeenCards(): void {
+    const articleIds = Array.from(document.querySelectorAll('.js-card'))
+        .map(card => card.getAttribute('data-article-id') ?? '');
+
+    void userClient.filterSeenArticles(articleIds).then(seenArticles => {
+        seenArticles.forEach(id => {
+            document.querySelector(`.js-card[data-article-id='${id}']`)?.classList.add('fade');
+        });
+    })
+}
+
 setup();
 ads();
 videos();
@@ -212,3 +223,4 @@ slideshow();
 formatDates();
 insertEpic();
 callouts();
+hasSeenCards();

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -42,6 +42,10 @@ const listStyles = (itemType: RelatedItemType, format: Format): SerializedStyles
         justify-content: space-between;
         border-top : ${borderColor(itemType, format)};
 
+        &.fade {
+            opacity: .7;
+        }
+
         img {
             width: 100%;
             height: 100%;
@@ -214,7 +218,7 @@ const commentIconStyle = (): SerializedStyles => {
         width: 2.0rem;
         height: 1.4375rem;
         display: inline-block;
-        fill: ${opinion[400]};;
+        fill: ${opinion[400]};
         vertical-align: text-top;
         margin-top: -3px;
         margin-right: -2px;
@@ -244,7 +248,7 @@ const quotationComment = (itemType: RelatedItemType, format: Format): ReactEleme
 
 const metadataStyles: SerializedStyles = css`
     padding: 0 ${remSpace[2]};
-    min-height: 1.5rem
+    min-height: 2rem;
 `;
 
 const durationMedia = (duration: Option<string>): ReactElement | null => {
@@ -290,9 +294,14 @@ const Card: FC<Props> = ({ relatedItem, image }) => {
         ? relativeFirstPublished(fromNullable(new Date(lastModified))) : null;
     const starRating = relatedItem.starRating && !Number.isNaN(parseInt(relatedItem.starRating))
         ? stars(parseInt(relatedItem.starRating)) : null;
+    const articleId = relatedItem.link.split('.com/').pop();
 
     return (
-        <li css={[listStyles(relatedItem.type, format), cardStyles(relatedItem.type, format)]}>
+        <li
+            className="js-card"
+            data-article-id={articleId}
+            css={[listStyles(relatedItem.type, format), cardStyles(relatedItem.type, format)]}
+        >
             <a css={anchorStyles} href={relatedItem.link}>
                 <section css={headingWrapperStyles}>
                     <h3 css={headingStyles(relatedItem.type)}>


### PR DESCRIPTION
## Why are you doing this?
Matches feature in template articles where cards are faded if a user has already read them.

## Changes

- Uses `filterSeenArticles` api
- Updates min-height style to ensure cards are same height

## Screenshots

The last two cards here have been viewed previously, the current opacity of .7 can be tweaked.

| Light | Dark |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/92386461-bf060b00-f10b-11ea-9e44-b297164215e0.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/92386536-df35ca00-f10b-11ea-8215-4139a042c9c5.png" width="300px" /> |

