### PR TITLE
Live:104 - converted star rating icon to svg

### DIFF
--- a/src/components/starRating.tsx
+++ b/src/components/starRating.tsx
@@ -22,7 +22,7 @@ const starStyles = css`
 ;
     svg {
         margin: 0 -0.125rem;
-        height: 2rem;
+        height: 1.75rem;
     }
 
     ${darkModeCss`

--- a/src/components/starRating.tsx
+++ b/src/components/starRating.tsx
@@ -1,32 +1,23 @@
 // ----- Imports ----- //
 
-import React, { ReactNode, ReactElement } from 'react';
+import React, { ReactNode, FC } from 'react';
 import { css } from '@emotion/core';
-import { brandAltBackground, text } from '@guardian/src-foundations/palette';
-import { remSpace } from '@guardian/src-foundations';
-
+import { brandAltBackground, brandAltLine } from '@guardian/src-foundations/palette';
+import { SvgStar } from '@guardian/src-icons';
 import { Item } from 'item';
-import { icons, darkModeCss } from 'styles';
+import { darkModeCss } from 'styles';
 import { Design } from '@guardian/types/Format';
 
 
 // ----- Subcomponents ----- //
 
 const starStyles = css`
-    ${icons}
     background-color: ${brandAltBackground.primary};
-    font-size: ${remSpace[5]};
-    line-height: 1;
     display: inline-block;
-    padding: 0 0.2rem ${remSpace[1]};
-    color: ${text.primary};
+    line-height: 0;
 
-    &:nth-of-type(1) {
-        padding-left: ${remSpace[1]};
-    }
-
-    &:nth-of-type(5) {
-        padding-right: ${remSpace[1]};
+    svg {
+        height: 2rem;
     }
 
     ${darkModeCss`
@@ -34,13 +25,19 @@ const starStyles = css`
     `}
 `;
 
-const empty = <span css={starStyles}>☆</span>;
+const emptyStyles = css`
+    fill: transparent;
+    stroke: ${brandAltLine.primary};
+`;
 
-const full = <span css={starStyles}>★</span>;
+const empty = <span css={[starStyles, emptyStyles]}><SvgStar/></span>;
+
+const full = <span css={starStyles}><SvgStar/></span>;
 
 export const stars = (rating: number): ReactNode =>
     [empty, empty, empty, empty, empty]
         .fill(full, 0, rating);
+
 
 
 // ----- Component ----- //
@@ -49,8 +46,8 @@ interface Props {
     item: Item;
 }
 
-const StarRating = ({ item }: Props): ReactElement =>
-    item.design === Design.Review ? <div>{stars(item.starRating)}</div> : <></>;
+const StarRating: FC<Props> = ({ item }) =>
+    item.design === Design.Review ? <div>{stars(item.starRating)}</div> : null;
 
 
 // ----- Exports ----- //

--- a/src/components/starRating.tsx
+++ b/src/components/starRating.tsx
@@ -21,7 +21,7 @@ const starStyles = css`
     }
 ;
     svg {
-        margin: 0 -2px;
+        margin: 0 -0.125rem;
         height: 2rem;
     }
 

--- a/src/components/starRating.tsx
+++ b/src/components/starRating.tsx
@@ -16,7 +16,12 @@ const starStyles = css`
     display: inline-block;
     line-height: 0;
 
+    &:nth-of-type(5) {
+        padding-right: 2px;
+    }
+;
     svg {
+        margin: 0 -2px;
         height: 2rem;
     }
 


### PR DESCRIPTION
## Why are you doing this?

Currently Star Rating is using icons which cause issues when rendering in certain browser and ios/android versions, with strange fallback icons when not loading (square box).


Issues regarding Icons and how SVg are more desirable:

Icon Accessibility: do not support screen readers, SVG's, however are accessible to a screen reader (they are treated as images)
Font icons are not as scalable as they are font sized as opposed to vector based.
In terms of performance icons can increase HTTP server requests.for caching
Icons are vulnerable to anti-aliasing techniques causing blurring
In addition svg's allow for a high degree of modifications without triggering additional server requests so can have a performance advantage

We could provide PNG icons as fallback, but since we have SVG's as part of source not necessary.

## Changes

- Customised styles for the new SVG element
- Included SvgStar instead of the icon as a tag

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/92469464-c2ad9680-f1cc-11ea-800f-aa6cf5d09de8.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/92469513-d527d000-f1cc-11ea-8198-90b99fc5367c.png" width="300px" /> |
