### PR TITLE
Bumped guardian/types To v0.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3930,7 +3930,7 @@
       }
     },
     "@guardian/types": {
-      "version": "github:guardian/types#3277ac1456496a98115a7bb80bb79d385ed8417d",
+      "version": "github:guardian/types#4581f9aa1eed6b75f7b117a78ea82b0d0e616b8a",
       "from": "github:guardian/types#semver:^0.4.0",
       "requires": {
         "typescript": "^3.8.3"


### PR DESCRIPTION
## Why are you doing this?

Keeps it up to date.

## Changes

- Bumped guardian/types to v0.4.4
