### PR TITLE
Live 603 icon svg headerimagecaption

### DIFF
--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -14,7 +14,7 @@ const captionId = 'header-image-caption';
 
 const HeaderImageCaptionStyles = css`
 	summary {
-		line-height: 30px;
+		/* line-height: 30px; */
         text-align: center;
         background-color: ${brandAlt[400]};
         color: ${neutral[7]};
@@ -30,11 +30,6 @@ const HeaderImageCaptionStyles = css`
 		
 		span {
 			font-size: 0;
-		}
-
-		svg {
-			position: absolute;
-			right: ${basePx(0.25)};
 		}
 
 		&::-webkit-details-marker {
@@ -61,6 +56,7 @@ const HeaderImageCaptionStyles = css`
 
 		${darkModeCss`
 			color: ${neutral[60]};
+			height: 5rem;
 		`}
 	}
 
@@ -79,13 +75,23 @@ interface Props {
 	credit: Option<string>;
 }
 
+const svgStyle = css`
+	line-height: 60px;
+	svg {
+		
+		width: ${basePx(3.5)};
+    	height: ${basePx(3.5)};
+	}
+	
+`;
+
 const HeaderImageCaption: FC<Props> = ({ caption, credit }: Props) =>
 	pipe2(
 		caption,
 		map(cap =>
 			<figcaption css={HeaderImageCaptionStyles}>
 				<details>
-					<summary><span><SvgCamera/>Click to see figure caption</span></summary>
+					<summary><span css={svgStyle}><SvgCamera/>Click to see figure caption</span></summary>
 					<span id={captionId}>{cap} {withDefault('')(credit)}</span>
 				</details>
 			</figcaption>

--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -14,23 +14,15 @@ const captionId = 'header-image-caption';
 
 const HeaderImageCaptionStyles = css`
 	summary {
-		/* line-height: 30px; */
         text-align: center;
         background-color: ${brandAlt[400]};
         color: ${neutral[7]};
         width: ${basePx(4)};
         height: ${basePx(4)};
-        display: inline-block;
         position: absolute;
         bottom: ${basePx(1)};
         right: ${basePx(1)};
 		border-radius: 100%;
-		z-index: 2;
-		outline: none;
-		
-		span {
-			font-size: 0;
-		}
 
 		&::-webkit-details-marker {
 			display: none;
@@ -70,20 +62,20 @@ const HeaderImageCaptionStyles = css`
 	}
 `;
 
+const svgStyle = css`
+	line-height: 55px;
+	font-size: 0;
+	svg {
+		width: ${basePx(2.7)};
+    	height: ${basePx(2.7)};
+	}
+`;
+
 interface Props {
 	caption: Option<string>;
 	credit: Option<string>;
 }
 
-const svgStyle = css`
-	line-height: 60px;
-	svg {
-		
-		width: ${basePx(3.5)};
-    	height: ${basePx(3.5)};
-	}
-	
-`;
 
 const HeaderImageCaption: FC<Props> = ({ caption, credit }: Props) =>
 	pipe2(

--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -48,7 +48,6 @@ const HeaderImageCaptionStyles = css`
 
 		${darkModeCss`
 			color: ${neutral[60]};
-			height: 5rem;
 		`}
 	}
 
@@ -63,11 +62,11 @@ const HeaderImageCaptionStyles = css`
 `;
 
 const svgStyle = css`
-	line-height: 55px;
+	line-height: 3.4375rem;
 	font-size: 0;
 	svg {
-		width: ${basePx(2.7)};
-    	height: ${basePx(2.7)};
+		width: 1.35rem;
+		height: 1.35rem;
 	}
 `;
 

--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -1,12 +1,14 @@
 import React, { FC, ReactElement } from 'react';
 import { css } from '@emotion/core';
-import { basePx, icons, wideContentWidth, darkModeCss } from 'styles';
+import { basePx, wideContentWidth, darkModeCss } from 'styles';
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, brandAlt } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { remSpace } from '@guardian/src-foundations';
 import { Option, map, withDefault } from '@guardian/types/option';
 import { pipe2 } from 'lib';
+import { SvgCamera } from '@guardian/src-icons';
+
 
 const captionId = 'header-image-caption';
 
@@ -30,12 +32,9 @@ const HeaderImageCaptionStyles = css`
 			font-size: 0;
 		}
 
-		&::before {
-			${icons}
-			content: "\\e044";
-			font-size: 16px;
+		svg {
 			position: absolute;
-			right: ${basePx(1)};
+			right: ${basePx(0.25)};
 		}
 
 		&::-webkit-details-marker {
@@ -86,7 +85,7 @@ const HeaderImageCaption: FC<Props> = ({ caption, credit }: Props) =>
 		map(cap =>
 			<figcaption css={HeaderImageCaptionStyles}>
 				<details>
-					<summary><span>Click to see figure caption</span></summary>
+					<summary><span><SvgCamera/>Click to see figure caption</span></summary>
 					<span id={captionId}>{cap} {withDefault('')(credit)}</span>
 				</details>
 			</figcaption>

--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -82,7 +82,11 @@ const HeaderImageCaption: FC<Props> = ({ caption, credit }: Props) =>
 		map(cap =>
 			<figcaption css={HeaderImageCaptionStyles}>
 				<details>
-					<summary><span css={svgStyle}><SvgCamera/>Click to see figure caption</span></summary>
+					<summary>
+						<span css={svgStyle}>
+							<SvgCamera/>Click to see figure caption
+						</span>
+					</summary>
 					<span id={captionId}>{cap} {withDefault('')(credit)}</span>
 				</details>
 			</figcaption>

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -10,6 +10,7 @@ import { none, some } from '@guardian/types/option';
 import Adapter from 'enzyme-adapter-react-16';
 import { Design, Display, Format } from '@guardian/types/Format';
 
+
 configure({ adapter: new Adapter() });
 const mockFormat: Format = {
     pillar: Pillar.News,
@@ -217,13 +218,13 @@ describe('Renders different types of elements', () => {
     test('ElementKind.Pullquote', () => {
         const nodes = render(pullquoteElement())
         const pullquote = nodes.flat()[0];
-        expect(getHtml(pullquote)).toContain('<blockquote><p>quote</p></blockquote>');
+        expect(getHtml(pullquote)).toContain('<aside><blockquote><p>quote</p></blockquote></aside>');
     })
 
     test('ElementKind.Pullquote with attribution', () => {
         const nodes = render(pullquoteWithAttributionElement())
         const pullquote = nodes.flat()[0];
-        expect(getHtml(pullquote)).toContain('<blockquote><p>quote</p><cite>attribution</cite></blockquote>');
+        expect(getHtml(pullquote)).toContain('<aside><blockquote><p>quote</p><cite>attribution</cite></blockquote></aside>');
     })
 
     test('ElementKind.RichLink', () => {

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -218,13 +218,13 @@ describe('Renders different types of elements', () => {
     test('ElementKind.Pullquote', () => {
         const nodes = render(pullquoteElement())
         const pullquote = nodes.flat()[0];
-        expect(getHtml(pullquote)).toContain('<aside><blockquote><p>quote</p></blockquote></aside>');
+        expect(getHtml(pullquote)).toContain('<blockquote><p>quote</p></blockquote>');
     })
 
     test('ElementKind.Pullquote with attribution', () => {
         const nodes = render(pullquoteWithAttributionElement())
         const pullquote = nodes.flat()[0];
-        expect(getHtml(pullquote)).toContain('<aside><blockquote><p>quote</p><cite>attribution</cite></blockquote></aside>');
+        expect(getHtml(pullquote)).toContain('<blockquote><p>quote</p><cite>attribution</cite></blockquote>');
     })
 
     test('ElementKind.RichLink', () => {


### PR DESCRIPTION
## Why are you doing this?

Currently Header Image Caption renders an icon of a camera using icons which cause issues when rendering in certain browser and ios/android versions, with strange fallback icons when not loading (square box).

Issues regarding Icons and how SVG are more desirable:

Icon Accessibility: do not support screen readers, SVG's, however are accessible to a screen reader (they are treated as images)
Font icons are not as scalable as they are font sized as opposed to vector based.
In terms of performance icons can increase HTTP server requests.for caching
Icons are vulnerable to anti-aliasing techniques causing blurring
In addition svg's allow for a high degree of modifications without triggering additional server requests so can have a performance advantage

We could provide PNG icons as fallback, but since we have SVG's as part of source not necessary.

## Changes

- Have eliminated use of icon and included the SvgCamera
- Modified the overall styling for header image captions
- Added a customised svg styling for the camera svg and added the styling to the surrounding span tag
- Have tried to keep the ration of image similar to mobile

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/92587226-4465f880-f28f-11ea-83c3-6f3234b75f25.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/92587612-cc4c0280-f28f-11ea-85a6-a2888dfe4e31.png" width="300px" /> |
