### PR TITLE
Guide and QandA atoms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3591,9 +3591,9 @@
       }
     },
     "@guardian/atoms-rendering": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-1.8.2.tgz",
-      "integrity": "sha512-2b3muMkENCqHgMQoUFAkJdqynmx+DYD1sCV0gZQkGmQrnkTOsBq5dagh0Q+MUYsCe8Mll1OIJ+Rmhd0vyFxrAw=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-1.9.0.tgz",
+      "integrity": "sha512-Pt3dK+fQOlKQDu6JqIPJS+fNSXyHEC/h3g+SLar5eMWUeBO+HpGPiEOnn6JOpZDg9ol6gQbqzf32rns3K1IhAg=="
     },
     "@guardian/bridget": {
       "version": "0.67.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "@guardian/apps-rendering-api-models": "^0.10.0",
-    "@guardian/atoms-rendering": "^1.8.2",
+    "@guardian/atoms-rendering": "1.9.0",
     "@guardian/bridget": "^0.67",
     "@guardian/content-api-models": "^15.9.1",
     "@guardian/content-atom-model": "^3.2.2",

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -38,6 +38,28 @@ function parseAtom(
             });
         }
 
+        case "guide": {
+            const atom = atoms.guides?.find(guide => guide.id === id);
+
+            if (atom?.data?.kind !== "guide" || !id) {
+                return err(`No atom matched this id: ${id}`);
+            }
+
+            const { title } = atom;
+            const { body } = atom.data.guide.items[0];
+
+            if (!title || !body) {
+                return err(`No title or body for atom: ${id}`);
+            }
+
+            return ok({
+                kind: ElementKind.GuideAtom,
+                html: body,
+                title,
+                id
+            });
+        }
+
         case "explainer": {
             const atom = atoms.explainers?.find(explainer => explainer.id === id);
 

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -60,6 +60,28 @@ function parseAtom(
             });
         }
 
+        case "qanda": {
+            const atom = atoms.qandas?.find(qanda => qanda.id === id);
+
+            if (atom?.data?.kind !== "qanda" || !id) {
+                return err(`No atom matched this id: ${id}`);
+            }
+
+            const { title } = atom;
+            const { body } = atom.data.qanda.item;
+
+            if (!title || !body) {
+                return err(`No title or body for atom: ${id}`);
+            }
+
+            return ok({
+                kind: ElementKind.QandaAtom,
+                html: body,
+                title,
+                id
+            });
+        }
+
         case "explainer": {
             const atom = atoms.explainers?.find(explainer => explainer.id === id);
 

--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -36,7 +36,8 @@ const enum ElementKind {
     InteractiveAtom,
     ExplainerAtom,
     MediaAtom,
-    GuideAtom
+    GuideAtom,
+    QandaAtom
 }
 
 type Image = ImageData & {
@@ -88,6 +89,13 @@ interface GuideAtom {
     id: string;
 }
 
+interface QandaAtom {
+    kind: ElementKind.QandaAtom;
+    html: string;
+    title: string;
+    id: string;
+}
+
 type BodyElement = {
     kind: ElementKind.Text;
     doc: DocumentFragment;
@@ -125,7 +133,7 @@ type BodyElement = {
     image?: string;
     price?: string;
     start?: string;
-} | Video | InteractiveAtom | ExplainerAtom | MediaAtom | GuideAtom;
+} | Video | InteractiveAtom | ExplainerAtom | MediaAtom | GuideAtom | QandaAtom;
 
 type Elements = BlockElement[] | undefined;
 
@@ -168,6 +176,7 @@ function toSerialisable(elem: BodyElement): JsonSerialisable {
         case ElementKind.Embed:
             return { ...elem };
         case ElementKind.GuideAtom:
+        case ElementKind.QandaAtom:
             return {};
         default:
             return elem;

--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -35,7 +35,8 @@ const enum ElementKind {
     Video,
     InteractiveAtom,
     ExplainerAtom,
-    MediaAtom
+    MediaAtom,
+    GuideAtom
 }
 
 type Image = ImageData & {
@@ -80,6 +81,13 @@ interface MediaAtom {
     caption: Option<DocumentFragment>;
 }
 
+interface GuideAtom {
+    kind: ElementKind.GuideAtom;
+    html: string;
+    title: string;
+    id: string;
+}
+
 type BodyElement = {
     kind: ElementKind.Text;
     doc: DocumentFragment;
@@ -117,7 +125,7 @@ type BodyElement = {
     image?: string;
     price?: string;
     start?: string;
-} | Video | InteractiveAtom | ExplainerAtom | MediaAtom;
+} | Video | InteractiveAtom | ExplainerAtom | MediaAtom | GuideAtom;
 
 type Elements = BlockElement[] | undefined;
 
@@ -159,6 +167,8 @@ function toSerialisable(elem: BodyElement): JsonSerialisable {
         case ElementKind.ExplainerAtom:
         case ElementKind.Embed:
             return { ...elem };
+        case ElementKind.GuideAtom:
+            return {};
         default:
             return elem;
     }

--- a/src/pillarStyles.ts
+++ b/src/pillarStyles.ts
@@ -84,7 +84,7 @@ function pillarFromString(pillar: string | undefined): Pillar {
 function pillarToString(pillar: Pillar): string {
     switch (pillar) {
         case Pillar.Opinion:
-            'opinion';
+            return 'opinion';
         case Pillar.Sport:
             return 'sport';
         case Pillar.Culture:

--- a/src/pillarStyles.ts
+++ b/src/pillarStyles.ts
@@ -81,6 +81,22 @@ function pillarFromString(pillar: string | undefined): Pillar {
     }
 }
 
+function pillarToString(pillar: Pillar): string {
+    switch (pillar) {
+        case Pillar.Opinion:
+            'opinion';
+        case Pillar.Sport:
+            return 'sport';
+        case Pillar.Culture:
+            return 'arts';
+        case Pillar.Lifestyle:
+            return 'lifestyle';
+        case Pillar.News:
+        default:
+            return 'news';
+    }
+}
+
 
 // ----- Exports ----- //
 
@@ -88,4 +104,5 @@ export {
     PillarStyles,
     getPillarStyles,
     pillarFromString,
+    pillarToString
 };

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -111,6 +111,13 @@ const audioElement = (): BodyElement =>
         width: "500"
     })
 
+const liveEventElement = (): BodyElement =>
+    ({
+        kind: ElementKind.LiveEvent,
+        linkText: "this links to a live event",
+        url: "https://theguardian.com"
+    })
+
 const atomElement = (): BodyElement =>
     ({
         kind: ElementKind.InteractiveAtom,
@@ -119,18 +126,27 @@ const atomElement = (): BodyElement =>
         js: some("console.log('init')"),
     })
 
-const liveEventElement = (): BodyElement =>
-    ({
-        kind: ElementKind.LiveEvent,
-        linkText: "this links to a live event",
-        url: "https://theguardian.com"
-    })
-
 const explainerElement = (): BodyElement =>
     ({
         kind: ElementKind.ExplainerAtom,
-        html: "<main>Some content</main>",
+        html: "<main>Explainer content</main>",
         title: "this is an explainer atom",
+        id: ""
+    })
+
+const guideElement = (): BodyElement =>
+    ({
+        kind: ElementKind.GuideAtom,
+        html: "<main>Guide content</main>",
+        title: "this is a guide atom",
+        id: ""
+    })
+
+const qandaElement = (): BodyElement =>
+    ({
+        kind: ElementKind.QandaAtom,
+        html: "<main>QandA content</main>",
+        title: "this is a qanda atom",
         id: ""
     })
 
@@ -269,6 +285,12 @@ describe('Renders different types of elements', () => {
         expect(getHtml(video)).toContain('src="https://www.youtube.com/" height="300" width="500" allowfullscreen="" title="Video element"');
     })
 
+    test('ElementKind.LiveEvent', () => {
+        const nodes = render(liveEventElement())
+        const liveEvent = nodes.flat()[0];
+        expect(getHtml(liveEvent)).toContain('<h1>this links to a live event</h1>');
+    })
+
     test('ElementKind.InteractiveAtom', () => {
         const nodes = render(atomElement())
         const atom = nodes.flat()[0];
@@ -277,16 +299,22 @@ describe('Renders different types of elements', () => {
         expect(getHtml(atom)).toContain('Some content');
     })
 
-    test('ElementKind.LiveEvent', () => {
-        const nodes = render(liveEventElement())
-        const liveEvent = nodes.flat()[0];
-        expect(getHtml(liveEvent)).toContain('<h1>this links to a live event</h1>');
-    })
-
     test('ElementKind.ExplainerAtom', () => {
         const nodes = render(explainerElement())
         const explainer = nodes.flat()[0];
-        expect(getHtml(explainer)).toContain('<main>Some content</main>');
+        expect(getHtml(explainer)).toContain('<main>Explainer content</main>');
+    })
+
+    test('ElementKind.GuideAtom', () => {
+        const nodes = render(guideElement())
+        const explainer = nodes.flat()[0];
+        expect(getHtml(explainer)).toContain('<main>Guide content</main>');
+    })
+
+    test('ElementKind.QandaAtom', () => {
+        const nodes = render(qandaElement())
+        const explainer = nodes.flat()[0];
+        expect(getHtml(explainer)).toContain('<main>QandA content</main>');
     })
 });
 

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -178,11 +178,15 @@ describe('renderer returns expected content', () => {
             '<em></em>',
             '<br>',
             '<ul><li></li></ul>',
-            '<mark></mark>'
+            '<mark></mark>',
+            '<p></p>',
+            '<span></span>',
+            '<a></a>',
+            'text'
         ];
 
-        expect(renderTextElement(elements).flat().length).toBe(7);
-        expect(renderTextElementWithoutStyles(elements).flat().length).toBe(7);
+        expect(renderTextElement(elements).flat().length).toBe(11);
+        expect(renderTextElementWithoutStyles(elements).flat().length).toBe(11);
     });
 
     test ('Renders caption node types', () => {
@@ -320,17 +324,17 @@ describe('Renders different types of elements', () => {
 
 describe('Paragraph tags rendered correctly', () => {
     test('Contains no styles in standfirsts', () => {
-        const fragment = JSDOM.fragment('<p>Parapraph tag</p><span>1</span>');
+        const fragment = JSDOM.fragment('<a href="#"><ul><li><strong><p>Standfirst link</p></strong></li></ul></a>');
         const nodes = renderStandfirstText(fragment, mockFormat);
         const html = getHtml(nodes.flat()[0]);
-        expect(html).toBe('<p>Parapraph tag</p>')
+        expect(html).toContain('<strong><p>Standfirst link</p></strong>');
     });
 
     test('Contains styles in article body', () => {
-        const fragment = JSDOM.fragment('<p>Parapraph tag</p><span>1</span>');
+        const fragment = JSDOM.fragment('<ul><li><strong><p>Standfirst link</p></strong></li></ul>');
         const nodes = renderText(fragment, mockFormat);
         const html = getHtml(nodes.flat()[0]);
-        expect(html).not.toBe('<p>Parapraph tag</p>')
+        expect(html).not.toContain('<strong><p>Standfirst link</p></strong>');
     });
 });
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -6,7 +6,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { neutral, text as textColour } from '@guardian/src-foundations/palette';
 import { Option, fromNullable, some, none, andThen, map, withDefault } from '@guardian/types/option';
 import { basePx, darkModeCss, icons } from 'styles';
-import { getPillarStyles } from 'pillarStyles';
+import { getPillarStyles, pillarToString } from 'pillarStyles';
 import { Format } from '@guardian/types/Format';
 import { BodyElement, ElementKind } from 'bodyElement';
 import { BodyImageProps, Role } from 'image';
@@ -24,7 +24,7 @@ import InteractiveAtom, {atomCss, atomScript} from 'components/atoms/interactive
 import { Design } from '@guardian/types/Format';
 import Blockquote from 'components/blockquote';
 import { isElement, pipe, pipe2 } from 'lib';
-import { ExplainerAtom } from '@guardian/atoms-rendering';
+import { ExplainerAtom, GuideAtom } from '@guardian/atoms-rendering';
 import LiveEventLink from 'components/liveEventLink';
 import CalloutForm from 'components/calloutForm';
 import { fromUnsafe, Result, toOption } from '@guardian/types/result';
@@ -236,6 +236,8 @@ const textElement = (format: Format) => (node: Node, key: number): ReactNode => 
             return h(Blockquote, { key, format }, children);
         case 'STRONG':
             return h('strong', { key }, children);
+        case 'B':
+            return h('b', { key }, children);
         case 'EM':
             return h('em', { key }, children);
         case 'BR':
@@ -548,6 +550,16 @@ const render = (format: Format, excludeStyles = false) =>
 
         case ElementKind.ExplainerAtom: {
             return h(ExplainerAtom, { ...element })
+        }
+
+        case ElementKind.GuideAtom: {
+            return h(GuideAtom, {
+                ...element,
+                pillar: pillarToString(format.pillar),
+                likeHandler: () => {},
+                dislikeHandler: () => {},
+                expandCallback: () => {}
+            })
         }
 
         case ElementKind.InteractiveAtom: {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -556,9 +556,9 @@ const render = (format: Format, excludeStyles = false) =>
             return h(GuideAtom, {
                 ...element,
                 pillar: pillarToString(format.pillar),
-                likeHandler: () => {},
-                dislikeHandler: () => {},
-                expandCallback: () => {}
+                likeHandler: () => { console.log("like clicked"); },
+                dislikeHandler: () => { console.log("dislike clicked"); },
+                expandCallback: () => { console.log("expand clicked"); }
             })
         }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -24,7 +24,7 @@ import InteractiveAtom, {atomCss, atomScript} from 'components/atoms/interactive
 import { Design } from '@guardian/types/Format';
 import Blockquote from 'components/blockquote';
 import { isElement, pipe, pipe2 } from 'lib';
-import { ExplainerAtom, GuideAtom } from '@guardian/atoms-rendering';
+import { ExplainerAtom, GuideAtom, QandaAtom } from '@guardian/atoms-rendering';
 import LiveEventLink from 'components/liveEventLink';
 import CalloutForm from 'components/calloutForm';
 import { fromUnsafe, Result, toOption } from '@guardian/types/result';
@@ -554,6 +554,16 @@ const render = (format: Format, excludeStyles = false) =>
 
         case ElementKind.GuideAtom: {
             return h(GuideAtom, {
+                ...element,
+                pillar: pillarToString(format.pillar),
+                likeHandler: () => { console.log("like clicked"); },
+                dislikeHandler: () => { console.log("dislike clicked"); },
+                expandCallback: () => { console.log("expand clicked"); }
+            })
+        }
+
+        case ElementKind.QandaAtom: {
+            return h(QandaAtom, {
                 ...element,
                 pillar: pillarToString(format.pillar),
                 likeHandler: () => { console.log("like clicked"); },


### PR DESCRIPTION
## Why are you doing this?
Implement guide atoms using component from atoms-rendering.
The like/dislike event handlers rely of client side rehydration and also the Ophan tracking work so that hasn't been implemented so far.

Users can still open and close the expandable box. 

Guide atoms: http://theguardian.com/sport/blog/2020/sep/08/talking-horses-racing-with-pride-launched-as-racings-lgbt-network
QA atoms: http://theguardian.com/environment/2020/aug/25/the-aliens-to-watch-how-the-humble-earthworm-is-altering-the-arctic-aoe

I've made a PR to atoms-rendering to avoid a style issue currently seen in dark mode https://github.com/guardian/atoms-rendering/pull/62.

## Changes

- Bump atoms-rendering to 1.9.0 - Had some issues with 1.10.0 which are being looked into
- Render guide atoms
- Render qa atoms

## Screenshots

<img src="https://user-images.githubusercontent.com/11618797/92599183-cbbc6780-f2a1-11ea-86af-655971770c89.png" width="300px" />
