### PR TITLE
Add link to fontSize.css

### DIFF
--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -60,7 +60,7 @@ const assetHashes = (assets: string[]): string =>
 
 const buildCsp = ({ styles, scripts }: Assets, twitter: boolean): string => `
     default-src 'self';
-    style-src ${assetHashes(styles)} https://interactive.guim.co.uk ${twitter ? 'https://platform.twitter.com' : ''};
+    style-src 'self' ${assetHashes(styles)} https://interactive.guim.co.uk ${twitter ? 'https://platform.twitter.com' : ''};
     img-src 'self' https://static.theguardian.com https://*.guim.co.uk ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:' : ''};
     script-src 'self' ${assetHashes(scripts)} http://www.instagram.com/embed.js https://interactive.guim.co.uk https://s16.tiktokcdn.com https://www.tiktok.com/embed.js ${twitter ? 'https://platform.twitter.com https://cdn.syndication.twimg.com' : ''};
     frame-src https://www.theguardian.com https://www.scribd.com https://www.instagram.com https://www.tiktok.com https://interactive.guim.co.uk https://open.spotify.com https://www.youtube-nocookie.com https://player.vimeo.com/ ${twitter ? 'https://platform.twitter.com https://syndication.twitter.com https://twitter.com' : ''};

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -94,7 +94,7 @@ function renderHead(
 
     return `
         ${renderToString(meta)}
-        <link rel="stylesheet" types="text/css" href="/fontSize.css"/>
+        <link rel="stylesheet" type="text/css" href="/fontSize.css">
         <style>${generalStyles}</style>
         <style data-emotion-css="${emotionIds.join(' ')}">${itemStyles}</style>
         <script id="targeting-params" type="application/json">

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -94,6 +94,7 @@ function renderHead(
 
     return `
         ${renderToString(meta)}
+        <link rel="stylesheet" types="text/css" href="/fontSize.css"/>
         <style>${generalStyles}</style>
         <style data-emotion-css="${emotionIds.join(' ')}">${itemStyles}</style>
         <script id="targeting-params" type="application/json">


### PR DESCRIPTION
## Why are you doing this?

So that the Android native layer can intercept this request for `fontSize.css` and provide the correct "base" font size for the page.

@JamieB-gu I think putting `/fontSize.css` should cause the request to go to the MAPI domain as we discussed?

## Changes

- Add a stylesheet link to the head of all pages.

This PR is a replacement for #346 