### PR TITLE
Don't Ask CAPI For 'fontSize.css`

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -267,6 +267,7 @@ app.get('/:articleId(*)/live-blocks', liveBlocks);
 app.get('/healthcheck', (_req, res) => res.send("Ok"));
 
 app.get('/favicon.ico', (_, res) => res.status(404).end());
+app.get('/fontSize.css', (_, res) => res.status(404).end());
 
 app.get('/*', bodyParser.raw(), serveArticle);
 


### PR DESCRIPTION
## Why are you doing this?

In local development we were requesting `/fontSize.css` from CAPI. This is only a relevant resource when running in the Android client (see #703). We should serve a `404` for this from our dev server, as we do for the favicon.

## Changes

- Serve 404 for Android `fontSize.css` stylesheet
