### PR TITLE
Live: Continued upgrade from Enzyme testing to avatar, follow and headerimgcap

### DIFF
--- a/src/components/follow.test.tsx
+++ b/src/components/follow.test.tsx
@@ -1,25 +1,23 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { configure, shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
 
 import Follow from './follow';
 import { Pillar, Design, Display } from '@guardian/types/Format';
 import { none } from '@guardian/types/option';
 import { Contributor } from 'contributor';
+import { act } from 'react-dom/test-utils';
+import { render, unmountComponentAtNode } from 'react-dom';
+import renderer from 'react-test-renderer';
 
 
 // ----- Setup ----- //
-
-configure({ adapter: new Adapter() });
 
 const followFormat = {
     pillar: Pillar.News,
     design: Design.Article,
     display: Display.Standard,
 };
-
 
 // ----- Tests ----- //
 
@@ -33,22 +31,28 @@ describe('Follow component renders as expected', () => {
                 image: none,
             },
         ];
-        const follow = shallow(
-            <Follow contributors={contributors} {...followFormat} />
-        );
 
-        expect(follow.text()).toBe("Follow George Monbiot");
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+
+        act(() => {
+            render(<Follow contributors= {contributors} {...followFormat}/>, container);
+        });
+
+        expect(container.textContent).toBe("Follow George Monbiot");
+
+        unmountComponentAtNode(container);
+        container.remove();
     })
 
     it('Renders null if no apiUrl', () => {
         const contributors: Contributor[] = [
             { name: "George Monbiot", id: "test", apiUrl: "", image: none },
         ];
-        const follow = shallow(
-            <Follow contributors={contributors} {...followFormat} />
-        );
 
-        expect(follow.html()).toBe(null);
+        const follow = renderer.create(<Follow contributors= {contributors} {...followFormat}/>);
+
+        expect(follow.root.children).toHaveLength(0);
     })
 
     it('Renders null if more than one contributor', () => {
@@ -66,10 +70,9 @@ describe('Follow component renders as expected', () => {
                 image: none,
             },
         ];
-        const follow = shallow(
-            <Follow contributors={contributors} {...followFormat} />
-        );
 
-        expect(follow.html()).toBe(null);
+        const follow = renderer.create(<Follow contributors= {contributors} {...followFormat}/>);
+
+        expect(follow.root.children).toHaveLength(0);
     })
 });

--- a/src/components/headerImageCaption.test.tsx
+++ b/src/components/headerImageCaption.test.tsx
@@ -1,19 +1,25 @@
+
 import React from 'react';
-import { configure, shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
 import HeaderImageCaption, { captionId } from 'components/headerImageCaption';
 import { some } from '@guardian/types/option';
+import renderer from 'react-test-renderer';
+import { matchers } from 'jest-emotion';
 
-configure({ adapter: new Adapter() });
+
+expect.extend(matchers);
 
 describe('HeaderImageCaption component renders as expected', () => {
-    it('Caption formatted correctly', () => {
-        const headerImageCaption = shallow(
+    it('Formats the Caption correctly', () => {
+        const headerImageCaption = renderer.create(
             <HeaderImageCaption
                 caption={some('Here is a caption.')}
                 credit={some('Photograph: cameraman')}
             />
         );
-        expect(headerImageCaption.find(`#${captionId}`).text()).toBe("Here is a caption. Photograph: cameraman")
+
+        const header = headerImageCaption.root.findByProps({id: captionId});
+        const headerText = header.children.join('');
+
+        expect(headerText).toBe('Here is a caption. Photograph: cameraman');
     })
 });

--- a/src/components/liveblog/avatar.test.tsx
+++ b/src/components/liveblog/avatar.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { configure, shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
 import Avatar from 'components/liveblog/avatar';
 import { Contributor } from 'contributor';
 import { none, some } from '@guardian/types/option';
-import { isObject } from 'lib';
+import renderer from 'react-test-renderer';
+import { matchers } from 'jest-emotion';
 
-configure({ adapter: new Adapter() });
+expect.extend(matchers);
 
 describe('Avatar component renders as expected', () => {
     const contributors: Contributor[] = [{
@@ -27,19 +26,14 @@ describe('Avatar component renders as expected', () => {
         }),
     }]
     it('Adds correct alt attribute', () => {
-        const avatar = shallow(<Avatar contributors={contributors} bgColour="" />);
-        expect(avatar.find('img').prop('alt')).toBe("Web Title")
+        const avatar = renderer.create(<Avatar contributors={contributors} bgColour="" />);
+        expect(avatar.root.findByType('img').props.alt).toBe("Web Title")
     })
 
     it('Uses background colour prop', () => {
-        const avatar = shallow<typeof Avatar>(<Avatar contributors={contributors} bgColour="pink" />);
-        const cssProp = avatar.prop('css');
+        const avatar = renderer.create(<Avatar contributors={contributors} bgColour="pink" />);
 
-        if (isObject(cssProp)) {
-            expect(cssProp.styles).toContain("background-color:pink");
-        } else {
-            fail('No styles found');
-        }
+        expect(avatar.toJSON()).toHaveStyleRule('background-color', 'pink')
     })
 
     it('Renders null if more than one contributor', () => {
@@ -47,7 +41,9 @@ describe('Avatar component renders as expected', () => {
             { name: "Contributor 1", id: "test", apiUrl: 'test', image: none },
             { name: "Contributor 2", id: "test", apiUrl: 'test', image: none },
         ]
-        const avatar = shallow(<Avatar contributors={contributors} bgColour="" />);
-        expect(avatar.html()).toBe(null)
+
+        const avatar = renderer.create(<Avatar contributors={contributors} bgColour="" />);
+
+        expect(avatar.root.children).toHaveLength(0);
     })
 });


### PR DESCRIPTION
## Why are you doing this?

- Continuation of PR:  https://github.com/guardian/apps-rendering/pull/731 to upgrade more unit tests within the AR code base
- Currently testing with Enzyme adds a layer of complexity to testing in terms of its API
- Particularly when testing components for CSS with CSS Emotion
- Integrates well with Jest
- Jest configured incorrectly and not working with CSS Emotion


## Changes

- Upgraded tests for `Follow` and `HeaderImageCaption` components
- used `import { render, unmountComponentAtNode } from 'react-dom';` to implement tests to easily check for text content within `Follow` component

Paired with @JamieB-gu 