### PR TITLE
check for window type rather than catching exception

### DIFF
--- a/src/native/thrift/nativeConnection.ts
+++ b/src/native/thrift/nativeConnection.ts
@@ -63,11 +63,9 @@ export class NativeConnection<Context = void> extends ThriftConnection {
 
     constructor(Transport: ITransportConstructor, Protocol: IProtocolConstructor) {
         super(Transport, Protocol);
-        try {
+        if (typeof window !== 'undefined') {
             window.nativeConnections = window.nativeConnections || {};
             window.nativeConnections[this.connectionId] = this
-        } catch(error) {
-            console.error(error);
         }
     }
     


### PR DESCRIPTION
## Why are you doing this?
This check is needed to render the Epic component server side in node.js where the `window` object isn't available.

This should stop a number of errors seen in the server console.