### PR TITLE
only stop rendering interactives with no content

### DIFF
--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -36,8 +36,8 @@ function parseAtom(
 
             const { html, css, mainJS: js } = atom?.data?.interactive;
 
-            if (!html || !css) {
-                return err(`No html or css for atom: ${id}`);
+            if (!html && !css && !js) {
+                return err(`No content for atom: ${id}`);
             }
 
             return ok({

--- a/src/components/atoms/interactiveAtom.tsx
+++ b/src/components/atoms/interactiveAtom.tsx
@@ -59,6 +59,11 @@ const InteractiveAtom: FC<InteractiveAtomProps> = (props: InteractiveAtomProps):
     </>
 }
 
+InteractiveAtom.defaultProps = {
+    html: "",
+    styles: ""
+};
+
 export default InteractiveAtom;
 export {
     atomCss,


### PR DESCRIPTION
## Why are you doing this?
Some interactives may not have any html so won't be rendered like http://localhost:8080/world/2020/apr/29/revealed-the-inside-story-of-uk-covid-19-coronavirus-crisis.

This change wouldn't fix this example, as it's attempting to control parts of the page which it shouldn't do on an article of `type: article`.

There might be valid cases for generating interactives using just css or javascript though.