### PR TITLE
Add screenshots workflow

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,79 @@
+name: Screenshots
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main    
+
+jobs:
+  screenshots:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: node-    
+    - name: install
+      run: npm ci
+    - name: run
+      run: |
+        npm run watch & 
+        sleep 60s
+      env: 
+        APIS_IMG_SALT: ${{ secrets.APIS_IMG_SALT }}  
+        CAPI_KEY: ${{ secrets.CAPI_KEY }}
+    - name: Take screenshot of apps-rendering
+      uses: "lannonbr/puppeteer-screenshot-action@1.3.0"
+      with:
+        url: http://localhost:8080/
+    - name: Upload screenshot
+      run: aws s3 cp screenshots/screenshot*.png s3://gu-mobile-pr-images/${{ github.sha }}/screenshot.png --acl public-read
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.CI_IMAGE_UPLOADER_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_IMAGE_UPLOADER_SECRET_ACCESS_KEY }}
+    - name: Prepare image urls
+      id: image-urls
+      if: ${{ github.ref != 'main' }}
+      run: |
+        MAIN_COMMIT_SHA=$(git show-ref main --hash)
+        echo "::set-output name=before::https://gu-mobile-pr-images.s3-eu-west-1.amazonaws.com/$MAIN_COMMIT_SHA/screenshot.png"
+        echo "::set-output name=after::https://gu-mobile-pr-images.s3-eu-west-1.amazonaws.com/${{ github.sha }}/screenshot.png"
+    - name: Search for previous screenshot comment
+      uses: peter-evans/find-comment@v1
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body-includes: <!-- github-actions-screenshots -->
+    - name: Create comment if necessary
+      if: ${{ github.ref != 'main' && steps.fc.outputs.comment-id == '' }} 
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          <!-- github-actions-screenshots -->
+          | Before | After |
+          | --- | --- |
+          | <img src="${{ steps.image-urls.outputs.before }}" width="300px" /> | <img src="${{ steps.image-urls.outputs.after }}" width="300px" /> |
+    - name: Update comment if necessary
+      if: ${{ github.ref != 'main' && steps.fc.outputs.comment-id != '' }} 
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        body: |
+          <!-- github-actions-screenshots -->
+          | Before | After |
+          | --- | --- |
+          | <img src="${{ steps.image-urls.outputs.before }}" width="300px" /> | <img src="${{ steps.image-urls.outputs.after }}" width="300px" /> |
+        edit-mode: replace


### PR DESCRIPTION
## Why are you doing this?

This PR adds functionality for automatically capturing screenshots from a running version of each pull-request branch and comparing them with screenshots captured from the main branch. It builds upon the work started in https://github.com/guardian/apps-rendering/pull/684, which allows us to run the application within the GitHub Actions infrastructure.

During my [original experiment](https://github.com/guardian/apps-rendering/pull/754) I was planning to replace the PR deployment workflow with this new one, but I noticed that a few people are [already using PR deployments](https://github.com/guardian/apps-rendering/pulls?q=is%3Apr+label%3A%22PR+Deployment%22+) in their current form (🎉). Perhaps it is useful to keep both as they have slightly different use-cases. 

https://theguardian.atlassian.net/browse/LIVE-605

## Changes

- Add new workflow file

## Screenshots

See below 🤞 
