### PR TITLE
remove adverts overflowing article body

### DIFF
--- a/src/ads.tsx
+++ b/src/ads.tsx
@@ -9,7 +9,7 @@ function getAdIndices(): number[] {
     const firstAdIndex = 3;
     const totalAds = 15;
 
-    const indiciesAfterFirstAd = [...Array(totalAds-1).keys()]
+    const indiciesAfterFirstAd = [...Array(totalAds - 1).keys()]
         .map(index => firstAdIndex + (adEveryNParagraphs * ++index))
     return [firstAdIndex, ...indiciesAfterFirstAd];
 }

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -81,8 +81,14 @@ function insertAds(): void {
 function ads(): void {
     void userClient.isPremium().then(premiumUser => {
         if (!premiumUser) {
-            Array.from(document.querySelectorAll('.ad-placeholder'))
-                .forEach(placeholder => placeholder.classList.remove('hidden'))
+            const articleLength = document.querySelector('.js-article')?.getBoundingClientRect().bottom ?? Infinity;
+            const placeholders = Array.from(document.querySelectorAll('.ad-placeholder'));
+            placeholders
+                .forEach(placeholder => placeholder.classList.remove('hidden'));
+            placeholders
+                .filter(slot => slot.getBoundingClientRect().bottom > articleLength)
+                .forEach(slot => slot.remove());
+
             insertAds();
             Array.from(document.querySelectorAll('.ad-labels, .upgrade-banner button'))
                 .forEach(adLabel => {

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -94,7 +94,7 @@ const Standard: FC<Props> = ({ item, children }) => {
         </div>
 
     return <main css={[Styles, DarkStyles]}>
-        <article css={BorderStyles}>
+        <article className="js-article" css={BorderStyles}>
             <header>
                 <HeaderMedia item={item} />
                 <Series item={item} />


### PR DESCRIPTION
## Why are you doing this?
Adverts can overflow the main article body and cover the related content section. This PR adds client side JavaScript to detect when ads are overflowing and removes them from the DOM before the Bridget request is made to populate them. This should only be required on iPad articles when the adverts are absolutely positioned.

TODO:
- add `js-article` to all article types with adverts

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/95746768-43115c80-0c8f-11eb-90cc-46df71b77cf6.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/95746786-4b699780-0c8f-11eb-9eb8-9238fdd666a1.png" width="300px" /> |
