### PR TITLE
Enforce Naming Conventions

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -1,4 +1,4 @@
-module.exports =  {
+module.exports = {
     parser: '@typescript-eslint/parser',
     extends: [
         'eslint:recommended',
@@ -15,7 +15,7 @@ module.exports =  {
         sourceType: 'module',
         ecmaFeatures: {
             // Allows for the parsing of JSX
-            jsx:  true,
+            jsx: true,
         },
         project: 'tsconfig.json',
     },
@@ -38,6 +38,45 @@ module.exports =  {
                 ignoreStrings: true,
                 ignoreTemplateLiterals: true,
                 ignoreUrls: true,
+            },
+        ],
+        // Enforce TypeScript naming conventions
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
+        '@typescript-eslint/naming-convention': [
+            'error',
+
+            /**
+             * Normal functions are 'camelCase', React components are 'PascalCase'
+             * Example:
+             *   function getName(id: string) {}
+             *   function HelloWorld(props: Props) {}
+             */
+            {
+                'selector': 'function',
+                'format': [ 'camelCase', 'PascalCase' ],
+            },
+
+            /** Normal variables are 'camelCase', React components are 'PascalCase',
+             * constants are 'UPPER_CASE'
+             * Example:
+             *   const fullName: string = ''
+             *   const HelloWorld: FC<Props> = props => {}
+             *   const IMAGE_WIDTH: number = 8
+             */
+            {
+                'selector': 'variable',
+                'format': [ 'camelCase', 'UPPER_CASE', 'PascalCase' ],
+            },
+
+            /** All types, including enum members, are 'PascalCase'
+             * Example:
+             *   interface ComponentProps {}
+             *   type SpamAndEggs = 'spam' | 'eggs'
+             *   enum SpamAndEggs { Spam, Eggs }
+             */
+            {
+                'selector': [ 'typeLike', 'enumMember' ],
+                'format': [ 'PascalCase' ],
             },
         ],
         '@typescript-eslint/no-unused-vars': 'off',


### PR DESCRIPTION
## Why are you doing this?

Applied `typescript-eslint` naming conventions. Not too strict as yet, so shouldn't cause any problems for our existing codebase. Docs [here](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md).

## Changes

- Functions are `camelCase` or `PascalCase`
- Variables are `camelCase`, `UPPER_CASE` or `PascalCase`
- Types, including enum members, are `PascalCase`
