### PR TITLE
align epic button

### DIFF
--- a/src/components/shared/epic.tsx
+++ b/src/components/shared/epic.tsx
@@ -42,12 +42,6 @@ const styles: SerializedStyles = css`
         margin-top: ${remSpace[9]};
     }
 
-    svg {
-        margin-left: ${remSpace[2]};
-        margin-top: -${remSpace[1]};
-        vertical-align: middle;
-    }
-
     mark {
         background: ${brandAltBackground.primary};
         padding: .1rem .125rem;
@@ -55,7 +49,7 @@ const styles: SerializedStyles = css`
 `;
 
 const darkStyles: SerializedStyles = darkModeCss`
-    color: ${neutral[60]};
+    color: ${neutral[93]};
     background-color: ${neutral[20]};
     border-top: 1px solid ${brandAlt[200]};
 


### PR DESCRIPTION
## Why are you doing this?
- Match the designs by using a brighter font colour in dark mode
- Align SVG icons in epic buttons. A newer src-icons version has fixed the alignment

Design:
<img width="260" alt="Screen Shot 2020-10-13 at 12 57 54" src="https://user-images.githubusercontent.com/11618797/95857956-43bff680-0d54-11eb-831b-f2dac1b5d5f5.png">


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/95857773-022f4b80-0d54-11eb-88f0-f8db1c1e5b57.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/95857797-0f4c3a80-0d54-11eb-9c2d-106034618eee.png" width="300px" /> |
