### PR TITLE
Refactor serveArticle

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -118,6 +118,20 @@ function resourceList(script: Option<string>): string[] {
     return pipe2(script, map(toArray), withDefault(emptyList));
 }
 
+async function serveArticle(request: RenderingRequest, res: ExpressResponse): Promise<void> {
+    const imageSalt = await getConfigValue('apis.img.salt');
+
+    if (imageSalt === undefined) {
+        throw new Error('Could not get image salt');
+    }
+
+    const { html, clientScript } = render(imageSalt, request, getAssetLocation);
+
+    res.set('Link', getPrefetchHeader(resourceList(clientScript)));
+    res.write(html);
+    res.end();
+}
+
 async function serveArticlePost(
     { body }: Request,
     res: ExpressResponse,
@@ -125,31 +139,17 @@ async function serveArticlePost(
 ): Promise<void> {
     try {
         const renderingRequest = await mapiDecoder(body);
-        const imageSalt = await getConfigValue('apis.img.salt');
-
-        if (imageSalt === undefined) {
-            throw new Error('Could not get image salt');
-        }
-
-        const { html, clientScript } = render(imageSalt, renderingRequest, getAssetLocation);
-        res.set('Link', getPrefetchHeader(resourceList(clientScript)));
-        res.write(html);
-        res.end();
+        
+        serveArticle(renderingRequest, res);
     } catch (e) {
         logger.error(`This error occurred`, e);
         next(e);
     }
 }
 
-async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
+async function serveArticleGet(req: Request, res: ExpressResponse): Promise<void> {
     try {
         const articleId = req.params[0] || defaultId;
-        const imageSalt = await getConfigValue('apis.img.salt');
-
-        if (imageSalt === undefined) {
-            throw new Error('Could not get image salt');
-        }
-
         const capiContent = await askCapiFor(articleId);
 
         either(
@@ -164,15 +164,8 @@ async function serveArticle(req: Request, res: ExpressResponse): Promise<void> {
                     commentCount: 30,
                     relatedContent
                 };
-                const { html, clientScript } = render(
-                    imageSalt,
-                    mockedRenderingRequest,
-                    getAssetLocation
-                );
 
-                res.set('Link', getPrefetchHeader(resourceList(clientScript)));
-                res.write(html);
-                res.end();
+                serveArticle(mockedRenderingRequest, res);
             },
         )(capiContent);
     } catch (e) {
@@ -266,7 +259,7 @@ app.get('/healthcheck', (_req, res) => res.send("Ok"));
 app.get('/favicon.ico', (_, res) => res.status(404).end());
 app.get('/fontSize.css', (_, res) => res.status(404).end());
 
-app.get('/*', bodyParser.raw(), serveArticle);
+app.get('/*', bodyParser.raw(), serveArticleGet);
 
 app.post('/article', bodyParser.raw(), serveArticlePost);
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -140,7 +140,7 @@ async function serveArticlePost(
     try {
         const renderingRequest = await mapiDecoder(body);
         
-        serveArticle(renderingRequest, res);
+        void serveArticle(renderingRequest, res);
     } catch (e) {
         logger.error(`This error occurred`, e);
         next(e);
@@ -165,7 +165,7 @@ async function serveArticleGet(req: Request, res: ExpressResponse): Promise<void
                     relatedContent
                 };
 
-                serveArticle(mockedRenderingRequest, res);
+                void serveArticle(mockedRenderingRequest, res);
             },
         )(capiContent);
     } catch (e) {


### PR DESCRIPTION
## Why are you doing this?

Our current `serveArticle` and `serveArticlePost` functions do similar things. However I noticed a discrepancy in #821, where one of them wasn't setting a `charset`.

This change pulls the common code into a shared `serveArticle` function, so that DEV and PROD use the same code wherever they're doing the same thing. This should make DEV and PROD as similar as possible.

## Changes

- Renamed previous `serveArticle` function to `serveArticleGet`
- Created new `serveArticle` function to share common DEV and PROD code
