### PR TITLE
Upgrade @guardian/types to use Theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4313,8 +4313,8 @@
       }
     },
     "@guardian/types": {
-      "version": "github:guardian/types#375df68b6cf8be9a56e80a430dfca5a7ca186cd2",
-      "from": "github:guardian/types#semver:^0.5.1",
+      "version": "github:guardian/types#da18ca13c822c9eed91ec9b6722c344c6f8088b4",
+      "from": "github:guardian/types#semver:^0.5.2",
       "requires": {
         "typescript": "^3.8.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4313,8 +4313,9 @@
       }
     },
     "@guardian/types": {
-      "version": "github:guardian/types#a4d7cb1f9fd472ad2f133bf6ae9821a37ed2f340",
-      "from": "github:guardian/types#semver:^0.4.5",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-0.5.0.tgz",
+      "integrity": "sha512-LNPdWq+W5IHhfjm6kv+Vs5POHGazwolVbMD7J4OQowdbUlybkeH9tpRqg1hnmKppixTIy3X+khzfUKdUN/rXIA==",
       "requires": {
         "typescript": "^3.8.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4313,9 +4313,8 @@
       }
     },
     "@guardian/types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-0.5.0.tgz",
-      "integrity": "sha512-LNPdWq+W5IHhfjm6kv+Vs5POHGazwolVbMD7J4OQowdbUlybkeH9tpRqg1hnmKppixTIy3X+khzfUKdUN/rXIA==",
+      "version": "github:guardian/types#375df68b6cf8be9a56e80a430dfca5a7ca186cd2",
+      "from": "github:guardian/types#semver:^0.5.1",
       "requires": {
         "typescript": "^3.8.3"
       },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@guardian/src-radio": "^2.4.0",
     "@guardian/src-text-area": "^2.5.0",
     "@guardian/src-text-input": "^2.4.0",
-    "@guardian/types": "github:guardian/types#semver:^0.4.5",
+    "@guardian/types": "0.5.0",
     "@types/jsdom": "^16.2.4",
     "@types/uuid": "^8.3.0",
     "aws-sdk": "^2.772.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@guardian/src-radio": "^2.4.0",
     "@guardian/src-text-area": "^2.5.0",
     "@guardian/src-text-input": "^2.4.0",
-    "@guardian/types": "github:guardian/types#semver:^0.5.1",
+    "@guardian/types": "github:guardian/types#semver:^0.5.2",
     "@types/jsdom": "^16.2.4",
     "@types/uuid": "^8.3.0",
     "aws-sdk": "^2.772.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@guardian/src-radio": "^2.4.0",
     "@guardian/src-text-area": "^2.5.0",
     "@guardian/src-text-input": "^2.4.0",
-    "@guardian/types": "0.5.0",
+    "@guardian/types": "github:guardian/types#semver:^0.5.1",
     "@types/jsdom": "^16.2.4",
     "@types/uuid": "^8.3.0",
     "aws-sdk": "^2.772.0",

--- a/src/ads.test.ts
+++ b/src/ads.test.ts
@@ -9,7 +9,7 @@ import { ElementKind, BodyElement } from 'bodyElement';
 const shouldHideAdverts = false;
 const insertAdPlaceholders = getAdPlaceholderInserter(shouldHideAdverts);
 const mockFormat: Format = {
-    pillar: Pillar.News,
+    theme: Pillar.News,
     design: Design.Article,
     display: Display.Standard,
 };

--- a/src/components/anchor.stories.tsx
+++ b/src/components/anchor.stories.tsx
@@ -21,7 +21,7 @@ const Default: FC = () =>
         format={{
             design: Design.Article,
             display: Display.Standard,
-            pillar: selectPillar(Pillar.News)
+            theme: selectPillar(Pillar.News)
         }}
         href={link()}
     >

--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -6,7 +6,7 @@ import { Format, Design } from '@guardian/types/Format';
 import { neutral } from '@guardian/src-foundations/palette';
 
 import { darkModeCss } from 'styles';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { palette } from '@guardian/src-foundations';
 
 
@@ -29,7 +29,7 @@ const styles = css`
 `;
 
 const colour = (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.theme);
+    const { kicker, inverted } = getThemeStyles(format.theme);
     switch (format.design) {
         case Design.AdvertisementFeature:
             return css`

--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -29,7 +29,7 @@ const styles = css`
 `;
 
 const colour = (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.pillar);
+    const { kicker, inverted } = getPillarStyles(format.theme);
     switch (format.design) {
         case Design.AdvertisementFeature:
             return css`

--- a/src/components/atoms/interactiveAtom.tsx
+++ b/src/components/atoms/interactiveAtom.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactElement, createElement as h } from 'react';
 import { css, jsx as styledH, SerializedStyles } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Format } from '@guardian/types/Format';
-import { getPillarStyles, PillarStyles } from 'pillarStyles';
+import { getThemeStyles, ThemeStyles } from 'themeStyles';
 import { Option, map, withDefault } from '@guardian/types/option';
 import { pipe2 } from 'lib';
 import { pageFonts } from "styles";
@@ -15,11 +15,11 @@ export interface InteractiveAtomProps {
     format: Format;
 }
 
-const InteractiveAtomStyles = (pillarStyles: PillarStyles): SerializedStyles => css`
+const InteractiveAtomStyles = (themeStyles: ThemeStyles): SerializedStyles => css`
     margin: 0;
 
     a {
-        color: ${pillarStyles.kicker};
+        color: ${themeStyles.kicker};
         text-decoration: none;
         border-bottom: 0.0625rem solid ${neutral[86]};
     }
@@ -43,7 +43,7 @@ const atomScript = `
 
 const InteractiveAtom: FC<InteractiveAtomProps> = (props: InteractiveAtomProps): ReactElement => {
     const { html, styles, js, format } = props;
-    const pillarStyles = getPillarStyles(format.theme);
+    const pillarStyles = getThemeStyles(format.theme);
     const style = h('style', { dangerouslySetInnerHTML: { __html: styles } });
     const script = pipe2(
         js,

--- a/src/components/atoms/interactiveAtom.tsx
+++ b/src/components/atoms/interactiveAtom.tsx
@@ -43,7 +43,7 @@ const atomScript = `
 
 const InteractiveAtom: FC<InteractiveAtomProps> = (props: InteractiveAtomProps): ReactElement => {
     const { html, styles, js, format } = props;
-    const pillarStyles = getPillarStyles(format.pillar);
+    const pillarStyles = getPillarStyles(format.theme);
     const style = h('style', { dangerouslySetInnerHTML: { __html: styles } });
     const script = pipe2(
         js,

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -5,7 +5,7 @@ import { css, SerializedStyles } from '@emotion/core';
 
 import { Contributor, isSingleContributor } from 'contributor';
 import { Format } from '@guardian/types/Format';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import Img from 'components/img';
 import { remSpace } from '@guardian/src-foundations';
 import { map, withDefault } from '@guardian/types/option';
@@ -34,7 +34,7 @@ const styles = (background: string): SerializedStyles => css`
 `;
 
 const getStyles = ({ theme }: Format): SerializedStyles => {
-    const colours = getPillarStyles(theme);
+    const colours = getThemeStyles(theme);
     return styles(colours.inverted);
 }
 

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -33,8 +33,8 @@ const styles = (background: string): SerializedStyles => css`
     margin-top: ${remSpace[1]};
 `;
 
-const getStyles = ({ pillar }: Format): SerializedStyles => {
-    const colours = getPillarStyles(pillar);
+const getStyles = ({ theme }: Format): SerializedStyles => {
+    const colours = getPillarStyles(theme);
     return styles(colours.inverted);
 }
 

--- a/src/components/blockquote.tsx
+++ b/src/components/blockquote.tsx
@@ -4,7 +4,7 @@ import React, { FC, ReactNode } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { Format } from '@guardian/types/Format';
 import { icons, darkModeCss } from 'styles';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { neutral } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 
@@ -27,7 +27,7 @@ const styles = (format: Format): SerializedStyles => css`
         font-style: normal;
         font-size: 2.5rem;
         content: '\\e11c';
-        color: ${getPillarStyles(format.theme).kicker};
+        color: ${getThemeStyles(format.theme).kicker};
     }
 
     ${darkModeCss`

--- a/src/components/blockquote.tsx
+++ b/src/components/blockquote.tsx
@@ -27,7 +27,7 @@ const styles = (format: Format): SerializedStyles => css`
         font-style: normal;
         font-size: 2.5rem;
         content: '\\e11c';
-        color: ${getPillarStyles(format.pillar).kicker};
+        color: ${getPillarStyles(format.theme).kicker};
     }
 
     ${darkModeCss`

--- a/src/components/bullet.stories.tsx
+++ b/src/components/bullet.stories.tsx
@@ -15,7 +15,7 @@ const Default: FC = () =>
         format={{
             design: Design.Article,
             display: Display.Standard,
-            pillar: selectPillar(Pillar.News),
+            theme: selectPillar(Pillar.News),
         }}
         text="• Lorem ipsum"
     />

--- a/src/components/bullet.tsx
+++ b/src/components/bullet.tsx
@@ -5,9 +5,8 @@ import { css, SerializedStyles } from '@emotion/core';
 import { Format } from '@guardian/types/Format';
 import { body } from '@guardian/src-foundations/typography';
 import { remSpace } from '@guardian/src-foundations';
-
 import { darkModeCss } from 'styles';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 
 
 // ----- Component ----- //
@@ -25,7 +24,7 @@ const styles = css`
 `;
 
 const bulletStyles = (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.theme);
+    const { kicker, inverted } = getThemeStyles(format.theme);
 
     return css`
         color: transparent;

--- a/src/components/bullet.tsx
+++ b/src/components/bullet.tsx
@@ -25,7 +25,7 @@ const styles = css`
 `;
 
 const bulletStyles = (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.pillar);
+    const { kicker, inverted } = getPillarStyles(format.theme);
 
     return css`
         color: transparent;

--- a/src/components/byline.stories.tsx
+++ b/src/components/byline.stories.tsx
@@ -38,7 +38,7 @@ const mockBylineHtml = (): Option<DocumentFragment> =>
 
 const Default: FC = () =>
     <Byline
-        pillar={selectPillar(Pillar.News)}
+        theme={selectPillar(Pillar.News)}
         design={Design.Article}
         display={Display.Standard}
         bylineHtml={mockBylineHtml()}
@@ -46,7 +46,7 @@ const Default: FC = () =>
 
 const Comment: FC = () =>
     <Byline
-        pillar={selectPillar(Pillar.Opinion)}
+        theme={selectPillar(Pillar.Opinion)}
         design={Design.Comment}
         display={Display.Standard}
         bylineHtml={mockBylineHtml()}
@@ -54,7 +54,7 @@ const Comment: FC = () =>
 
 const Labs: FC = () =>
     <Byline
-        pillar={selectPillar(Pillar.News)}
+        theme={selectPillar(Pillar.News)}
         design={Design.AdvertisementFeature}
         display={Display.Standard}
         bylineHtml={mockBylineHtml()}

--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -7,7 +7,7 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 import { Design, Format } from '@guardian/types/Format';
 import { Option, withDefault, map } from '@guardian/types/option';
 import { neutral, palette } from '@guardian/src-foundations';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { getHref } from 'renderer';
 import { darkModeCss } from 'styles';
 import { pipe2 } from 'lib';
@@ -75,7 +75,7 @@ const advertisementFeatureAnchorStyles = css`
 `;
 
 const getStyles = (format: Format): SerializedStyles => {
-    const { kicker } = getPillarStyles(format.theme);
+    const { kicker } = getThemeStyles(format.theme);
 
     switch (format.design) {
         case Design.Comment:
@@ -90,7 +90,7 @@ const getStyles = (format: Format): SerializedStyles => {
 }
 
 const getAnchorStyles = (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.theme);
+    const { kicker, inverted } = getThemeStyles(format.theme);
 
     switch (format.design) {
         case Design.Comment:

--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -75,7 +75,7 @@ const advertisementFeatureAnchorStyles = css`
 `;
 
 const getStyles = (format: Format): SerializedStyles => {
-    const { kicker } = getPillarStyles(format.pillar);
+    const { kicker } = getPillarStyles(format.theme);
 
     switch (format.design) {
         case Design.Comment:
@@ -90,7 +90,7 @@ const getStyles = (format: Format): SerializedStyles => {
 }
 
 const getAnchorStyles = (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.pillar);
+    const { kicker, inverted } = getPillarStyles(format.theme);
 
     switch (format.design) {
         case Design.Comment:

--- a/src/components/calloutForm.tsx
+++ b/src/components/calloutForm.tsx
@@ -5,7 +5,7 @@ import { neutral, remSpace, text } from '@guardian/src-foundations';
 import { Button } from '@guardian/src-button';
 import { SvgMinus, SvgPlus } from '@guardian/src-icons';
 import { Format } from '@guardian/types/Format';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { headline, textSans, body } from '@guardian/src-foundations/typography';
 import { TextInput } from '@guardian/src-text-input';
 import { TextArea } from '@guardian/src-text-area';
@@ -139,7 +139,7 @@ const renderField = ({ type, label, mandatory, options, id }: FormField): ReactE
 
 const CalloutForm: FC<CalloutProps> = (props: CalloutProps) => {
     const { campaign, format, description } = props;
-    const { kicker } = getPillarStyles(format.theme);
+    const { kicker } = getThemeStyles(format.theme);
 
     return (
         <details className="js-callout" css={calloutStyles}>

--- a/src/components/calloutForm.tsx
+++ b/src/components/calloutForm.tsx
@@ -139,7 +139,7 @@ const renderField = ({ type, label, mandatory, options, id }: FormField): ReactE
 
 const CalloutForm: FC<CalloutProps> = (props: CalloutProps) => {
     const { campaign, format, description } = props;
-    const { kicker } = getPillarStyles(format.pillar);
+    const { kicker } = getPillarStyles(format.theme);
 
     return (
         <details className="js-callout" css={calloutStyles}>

--- a/src/components/commentCount.stories.tsx
+++ b/src/components/commentCount.stories.tsx
@@ -14,7 +14,7 @@ import { some } from '@guardian/types/option';
 const Default: FC = () =>
     <CommentCount
         count={some(number('Count', 1234, { min: 0 }))}
-        pillar={selectPillar(Pillar.News)}
+        theme={selectPillar(Pillar.News)}
         design={Design.Article}
         display={Display.Standard}
         commentable={boolean('Commentable', true)}

--- a/src/components/commentCount.tsx
+++ b/src/components/commentCount.tsx
@@ -7,7 +7,7 @@ import { border, neutral } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 import { Option, map, withDefault } from '@guardian/types/option';
 import { Format } from '@guardian/types/Format';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { pipe2 } from 'lib';
 import { darkModeCss } from 'styles';
 
@@ -39,13 +39,13 @@ const bubbleStyles = (colour: string): SerializedStyles => css`
 `;
 
 const getStyles = ({ theme }: Format): SerializedStyles => {
-    const colours = getPillarStyles(theme);
+    const colours = getThemeStyles(theme);
 
     return styles(colours.kicker);
 }
 
 const getBubbleStyles = ({ theme }: Format): SerializedStyles => {
-    const colours = getPillarStyles(theme);
+    const colours = getThemeStyles(theme);
 
     return bubbleStyles(colours.kicker);
 }

--- a/src/components/commentCount.tsx
+++ b/src/components/commentCount.tsx
@@ -38,14 +38,14 @@ const bubbleStyles = (colour: string): SerializedStyles => css`
     fill: ${colour};
 `;
 
-const getStyles = ({ pillar }: Format): SerializedStyles => {
-    const colours = getPillarStyles(pillar);
+const getStyles = ({ theme }: Format): SerializedStyles => {
+    const colours = getPillarStyles(theme);
 
     return styles(colours.kicker);
 }
 
-const getBubbleStyles = ({ pillar }: Format): SerializedStyles => {
-    const colours = getPillarStyles(pillar);
+const getBubbleStyles = ({ theme }: Format): SerializedStyles => {
+    const colours = getPillarStyles(theme);
 
     return bubbleStyles(colours.kicker);
 }

--- a/src/components/dateline.stories.tsx
+++ b/src/components/dateline.stories.tsx
@@ -12,7 +12,7 @@ import { selectPillar } from 'storybookHelpers';
 
 const Default: FC = () =>
     <Dateline
-        pillar={selectPillar(Pillar.Opinion)}
+        theme={selectPillar(Pillar.Opinion)}
         date={some(new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))))}
     />
 

--- a/src/components/dateline.tsx
+++ b/src/components/dateline.tsx
@@ -8,14 +8,14 @@ import { Option, withDefault, map } from '@guardian/types/option';
 import { darkModeCss as darkMode } from 'styles';
 import { formatDate } from 'date';
 import { pipe2 } from 'lib';
-import { Pillar } from '@guardian/types/Format';
+import { Pillar, Theme } from '@guardian/types/Format';
 
 
 // ----- Component ----- //
 
 interface Props {
     date: Option<Date>;
-    pillar: Pillar;
+    theme: Theme;
 }
 
 const darkStyles = darkMode`
@@ -36,8 +36,8 @@ const commentDatelineStyles = css`
     ${darkStyles}
 `;
 
-const getDatelineStyles = (pillar: Pillar): SerializedStyles => {
-    switch(pillar){
+const getDatelineStyles = (theme: Theme): SerializedStyles => {
+    switch(theme){
         case Pillar.Opinion:
             return commentDatelineStyles;
         default:
@@ -45,10 +45,10 @@ const getDatelineStyles = (pillar: Pillar): SerializedStyles => {
     }
 }
 
-const Dateline: FC<Props> = ({ date, pillar }) =>
+const Dateline: FC<Props> = ({ date, theme }) =>
     pipe2(
         date,
-        map(d => <time css={getDatelineStyles(pillar)} data-date={d} className="date">{ formatDate(d) }</time>),
+        map(d => <time css={getDatelineStyles(theme)} data-date={d} className="date">{ formatDate(d) }</time>),
         withDefault<ReactElement | null>(null),
     )
 

--- a/src/components/figCaption.stories.tsx
+++ b/src/components/figCaption.stories.tsx
@@ -13,7 +13,7 @@ import { Option, none, some } from '@guardian/types/option';
 // ----- Setup ----- //
 
 const format: Format = {
-    pillar: Pillar.News,
+    theme: Pillar.News,
     design: Design.Article,
     display: Display.Standard,
 };

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -6,8 +6,7 @@ import { textSans, headline } from '@guardian/src-foundations/typography';
 import { text, neutral } from '@guardian/src-foundations/palette';
 import { remSpace, palette } from '@guardian/src-foundations';
 import { Format, Design } from '@guardian/types/Format';
-
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { Option, map, withDefault } from '@guardian/types/option';
 import { renderTextElement, getHref } from 'renderer';
 import { darkModeCss } from 'styles';
@@ -44,7 +43,7 @@ const Triangle: FC<TriangleProps> = ({ format }: TriangleProps) => {
         case Design.AdvertisementFeature:
             return triangleSvg(palette.labs[300]);
         default: {
-            const { kicker, inverted } = getPillarStyles(format.theme);
+            const { kicker, inverted } = getThemeStyles(format.theme);
             return triangleSvg(kicker, inverted);
         }
     }

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -44,7 +44,7 @@ const Triangle: FC<TriangleProps> = ({ format }: TriangleProps) => {
         case Design.AdvertisementFeature:
             return triangleSvg(palette.labs[300]);
         default: {
-            const { kicker, inverted } = getPillarStyles(format.pillar);
+            const { kicker, inverted } = getPillarStyles(format.theme);
             return triangleSvg(kicker, inverted);
         }
     }

--- a/src/components/follow.stories.tsx
+++ b/src/components/follow.stories.tsx
@@ -21,7 +21,7 @@ const Default: FC = () =>
                 image: none,
             }
         ]}
-        pillar={selectPillar(Pillar.News)}
+        theme={selectPillar(Pillar.News)}
         design={Design.Article}
         display={Display.Standard}
     />

--- a/src/components/follow.test.tsx
+++ b/src/components/follow.test.tsx
@@ -14,7 +14,7 @@ import renderer from 'react-test-renderer';
 // ----- Setup ----- //
 
 const followFormat = {
-    pillar: Pillar.News,
+    theme: Pillar.News,
     design: Design.Article,
     display: Display.Standard,
 };

--- a/src/components/follow.tsx
+++ b/src/components/follow.tsx
@@ -5,7 +5,7 @@ import { css, SerializedStyles } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography';
 
 import { Format } from '@guardian/types/Format';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { Contributor, isSingleContributor } from 'contributor';
 import { darkModeCss } from 'styles';
 import { Design } from '@guardian/types/Format';
@@ -32,7 +32,7 @@ const styles = (kicker: string, inverted: string): SerializedStyles => css`
 `;
 
 function getStyles({ theme }: Format): SerializedStyles {
-    const { kicker, inverted } = getPillarStyles(theme);
+    const { kicker, inverted } = getThemeStyles(theme);
 
     return styles(kicker, inverted);
 }

--- a/src/components/follow.tsx
+++ b/src/components/follow.tsx
@@ -31,8 +31,8 @@ const styles = (kicker: string, inverted: string): SerializedStyles => css`
     `}
 `;
 
-function getStyles({ pillar }: Format): SerializedStyles {
-    const { kicker, inverted } = getPillarStyles(pillar);
+function getStyles({ theme }: Format): SerializedStyles {
+    const { kicker, inverted } = getPillarStyles(theme);
 
     return styles(kicker, inverted);
 }

--- a/src/components/headline.stories.tsx
+++ b/src/components/headline.stories.tsx
@@ -32,14 +32,14 @@ const Analysis = (): ReactElement =>
     <Headline item={{
         ...analysis,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: selectPillar(Pillar.News),
+        theme: selectPillar(Pillar.News),
     }} />
 
 const Feature = (): ReactElement =>
     <Headline item={{
         ...feature,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: selectPillar(Pillar.News),
+        theme: selectPillar(Pillar.News),
     }} />
 
 const Review = (): ReactElement =>

--- a/src/components/media/article.tsx
+++ b/src/components/media/article.tsx
@@ -46,7 +46,7 @@ const Media: FC<Props> = ({ item, children }) =>
             <header>
                 <HeaderMedia item={item} />
                 <div css={articleWidthStyles}>
-                    <Series series={item.series} pillar={item.pillar} />
+                    <Series series={item.series} theme={item.theme} />
                 </div>
                 <Headline item={item} />
                 <div css={articleWidthStyles}>
@@ -54,14 +54,13 @@ const Media: FC<Props> = ({ item, children }) =>
                 </div>
                 <section>
                     <Byline
-                        pillar={item.pillar}
                         publicationDate={item.publishDate}
                         className={articleWidthStyles}
                         item={item}
                     />
                 </section>
             </header>
-            <Body pillar={item.pillar} className={[articleWidthStyles]} format={item}>
+            <Body theme={item.theme} className={[articleWidthStyles]} format={item}>
                 {children}
             </Body>
             <section css={articleWidthStyles}>

--- a/src/components/media/articleBody.tsx
+++ b/src/components/media/articleBody.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { adStyles, darkModeCss } from 'styles';
 import { background, neutral } from '@guardian/src-foundations/palette';
-import { getPillarStyles, PillarStyles } from 'pillarStyles';
+import { getThemeStyles, ThemeStyles } from 'themeStyles';
 import { Theme } from '@guardian/types/Format';
 import { remSpace } from "@guardian/src-foundations";
 import { Format } from '@guardian/types/Format';
@@ -16,7 +16,7 @@ const ArticleBodyStyles = (format: Format): SerializedStyles => css`
     ${adStyles(format)}
 `;
 
-const ArticleBodyDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => darkModeCss`
+const ArticleBodyDarkStyles = ({ inverted }: ThemeStyles): SerializedStyles => darkModeCss`
     a {
         color: ${inverted};
     }
@@ -40,7 +40,7 @@ const ArticleBodyMedia: FC<ArticleBodyProps> = ({
     format
 }) =>
     <div css={[ArticleBodyStyles(format),
-        ArticleBodyDarkStyles(getPillarStyles(theme)),
+        ArticleBodyDarkStyles(getThemeStyles(theme)),
         ...className]}>
         {children}
     </div>

--- a/src/components/media/articleBody.tsx
+++ b/src/components/media/articleBody.tsx
@@ -3,7 +3,7 @@ import { css, SerializedStyles } from '@emotion/core'
 import { adStyles, darkModeCss } from 'styles';
 import { background, neutral } from '@guardian/src-foundations/palette';
 import { getPillarStyles, PillarStyles } from 'pillarStyles';
-import { Pillar } from '@guardian/types/Format';
+import { Theme } from '@guardian/types/Format';
 import { remSpace } from "@guardian/src-foundations";
 import { Format } from '@guardian/types/Format';
 
@@ -27,20 +27,20 @@ const ArticleBodyDarkStyles = ({ inverted }: PillarStyles): SerializedStyles => 
 `;
 
 interface ArticleBodyProps {
-    pillar: Pillar;
+    theme: Theme;
     className: SerializedStyles[];
     children: ReactNode[];
     format: Format;
 }
 
 const ArticleBodyMedia: FC<ArticleBodyProps> = ({
-    pillar,
+    theme,
     className,
     children,
     format
 }) =>
     <div css={[ArticleBodyStyles(format),
-        ArticleBodyDarkStyles(getPillarStyles(pillar)),
+        ArticleBodyDarkStyles(getPillarStyles(theme)),
         ...className]}>
         {children}
     </div>

--- a/src/components/media/articleSeries.tsx
+++ b/src/components/media/articleSeries.tsx
@@ -1,13 +1,13 @@
 import React, { ReactElement, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { Series } from 'capi';
-import { PillarStyles, getPillarStyles } from 'pillarStyles';
+import { ThemeStyles, getThemeStyles } from 'themeStyles';
 import { Theme } from '@guardian/types/Format';
 import { headline } from '@guardian/src-foundations/typography';
 import { Option, map, withDefault } from '@guardian/types/option';
 import { pipe2 } from 'lib';
 
-const ArticleSeriesStyles = ({ inverted }: PillarStyles): SerializedStyles => css`    
+const ArticleSeriesStyles = ({ inverted }: ThemeStyles): SerializedStyles => css`
     a {
         ${headline.xxxsmall({ lineHeight: 'loose', fontWeight: 'bold' })}
         color: ${inverted};
@@ -24,7 +24,7 @@ const ArticleSeries: FC<ArticleSeriesProps> = (props) =>
     pipe2(
         props.series,
         map(series =>
-            <nav css={ArticleSeriesStyles(getPillarStyles(props.theme))}>
+            <nav css={ArticleSeriesStyles(getThemeStyles(props.theme))}>
                 <a href={series.webUrl}>{series.webTitle}</a>
             </nav>
         ),

--- a/src/components/media/articleSeries.tsx
+++ b/src/components/media/articleSeries.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core'
 import { Series } from 'capi';
 import { PillarStyles, getPillarStyles } from 'pillarStyles';
-import { Pillar } from '@guardian/types/Format';
+import { Theme } from '@guardian/types/Format';
 import { headline } from '@guardian/src-foundations/typography';
 import { Option, map, withDefault } from '@guardian/types/option';
 import { pipe2 } from 'lib';
@@ -17,14 +17,14 @@ const ArticleSeriesStyles = ({ inverted }: PillarStyles): SerializedStyles => cs
 
 interface ArticleSeriesProps {
     series: Option<Series>;
-    pillar: Pillar;
+    theme: Theme;
 }
 
 const ArticleSeries: FC<ArticleSeriesProps> = (props) =>
     pipe2(
         props.series,
         map(series =>
-            <nav css={ArticleSeriesStyles(getPillarStyles(props.pillar))}>
+            <nav css={ArticleSeriesStyles(getPillarStyles(props.theme))}>
                 <a href={series.webUrl}>{series.webTitle}</a>
             </nav>
         ),

--- a/src/components/media/byline.tsx
+++ b/src/components/media/byline.tsx
@@ -3,7 +3,6 @@
 import React, { ReactNode, FC } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
-import { Pillar } from '@guardian/types/Format';
 import { Option, map, withDefault } from '@guardian/types/option';
 import { Item, getFormat } from 'item';
 import { textSans } from "@guardian/src-foundations/typography";
@@ -39,13 +38,12 @@ const styles: SerializedStyles = css`
 // ----- Component ----- //
 
 interface Props {
-    pillar: Pillar;
     publicationDate: Option<Date>;
     className: SerializedStyles;
     item: Item;
 }
 
-const Byline: FC<Props> = ({ pillar, publicationDate, className, item }) => {
+const Byline: FC<Props> = ({ publicationDate, className, item }) => {
     const byline = pipe2(
         item.bylineHtml,
         map(html => <address>{ renderText(html, getFormat(item)) }</address>),
@@ -57,7 +55,7 @@ const Byline: FC<Props> = ({ pillar, publicationDate, className, item }) => {
             <div>
                 <div className="author">
                     { byline }
-                    <Dateline date={publicationDate} pillar={item.pillar}/>
+                    <Dateline date={publicationDate} theme={item.theme}/>
                 </div>
             </div>
         </div>

--- a/src/components/metadata.tsx
+++ b/src/components/metadata.tsx
@@ -41,7 +41,7 @@ const MetadataWithByline: FC<Props> = ({ item }: Props) =>
         <Avatar {...item} />
         <div css={css(textStyles, withBylineTextStyles)}>
             <Byline {...item} />
-            <Dateline date={item.publishDate} pillar={item.pillar} />
+            <Dateline date={item.publishDate} theme={item.theme} />
             <Follow {...item} />
         </div>
         <CommentCount count={item.commentCount} {...item} />
@@ -50,7 +50,7 @@ const MetadataWithByline: FC<Props> = ({ item }: Props) =>
 const ShortMetadata: FC<Props> = ({ item }: Props) =>
     <div css={styles}>
         <div css={textStyles}>
-            <Dateline date={item.publishDate} pillar={item.pillar} />
+            <Dateline date={item.publishDate} theme={item.theme} />
             <Follow {...item} />
         </div>
         <CommentCount count={item.commentCount} {...item} />

--- a/src/components/paragraph.stories.tsx
+++ b/src/components/paragraph.stories.tsx
@@ -11,13 +11,13 @@ import { Design, Display, Pillar } from '@guardian/types/Format';
 const standard = {
     design: Design.Article,
     display: Display.Standard,
-    pillar: Pillar.News
+    theme: Pillar.News
 }
 
 const labs = {
     design: Design.AdvertisementFeature,
     display: Display.Standard,
-    pillar: Pillar.News
+    theme: Pillar.News
 }
 
 const Default: FC = () =>

--- a/src/components/pullquote.tsx
+++ b/src/components/pullquote.tsx
@@ -2,7 +2,7 @@ import { FC, ReactNode } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { Option, map, withDefault } from '@guardian/types/option';
 import { darkModeCss } from 'styles';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { Format } from '@guardian/types/Format';
 import { headline } from '@guardian/src-foundations/typography';
 import { remSpace } from '@guardian/src-foundations';
@@ -12,7 +12,7 @@ import React from 'react';
 
 
 const styles = (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.theme);
+    const { kicker, inverted } = getThemeStyles(format.theme);
     return css`
         color: ${kicker};
         margin: 0;
@@ -23,7 +23,7 @@ const styles = (format: Format): SerializedStyles => {
 };
 
 const quoteStyles =  (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.theme);
+    const { kicker, inverted } = getThemeStyles(format.theme);
 
     return css`
         margin: ${remSpace[4]} 0 ${remSpace[2]} 0;

--- a/src/components/pullquote.tsx
+++ b/src/components/pullquote.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 
 
 const styles = (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.pillar);
+    const { kicker, inverted } = getPillarStyles(format.theme);
     return css`
         color: ${kicker};
         margin: 0;
@@ -23,7 +23,7 @@ const styles = (format: Format): SerializedStyles => {
 };
 
 const quoteStyles =  (format: Format): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.pillar);
+    const { kicker, inverted } = getPillarStyles(format.theme);
 
     return css`
         margin: ${remSpace[4]} 0 ${remSpace[2]} 0;

--- a/src/components/series.tsx
+++ b/src/components/series.tsx
@@ -7,8 +7,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { remSpace, palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { Format, Display, Design } from '@guardian/types/Format';
-
-import { PillarStyles, getPillarStyles } from 'pillarStyles';
+import { ThemeStyles, getThemeStyles } from 'themeStyles';
 import { darkModeCss, wideContentWidth, articleWidthStyles } from 'styles';
 import { Item } from 'item';
 import { pipe2 } from 'lib';
@@ -21,7 +20,7 @@ interface Props {
     item: Item;
 }
 
-const immersiveStyles = ({ kicker }: PillarStyles, isLabs: boolean): SerializedStyles => css`
+const immersiveStyles = ({ kicker }: ThemeStyles, isLabs: boolean): SerializedStyles => css`
     padding: ${remSpace[1]} ${remSpace[2]};
     background-color: ${isLabs ? palette.labs[300] : kicker};
     position: absolute;
@@ -44,7 +43,7 @@ const font = (isLabs: boolean): string =>
         ? textSans.medium({ lineHeight: 'loose', fontWeight: 'bold' })
         : headline.xxxsmall({ lineHeight: 'loose', fontWeight: 'bold' })
 
-const linkStyles = ({ kicker, inverted }: PillarStyles, isLabs: boolean): SerializedStyles => css`
+const linkStyles = ({ kicker, inverted }: ThemeStyles, isLabs: boolean): SerializedStyles => css`
     ${font(isLabs)}
     color: ${isLabs ? palette.labs[300] : kicker};
     text-decoration: none;
@@ -68,13 +67,13 @@ const getLinkStyles = ({ display, theme, design }: Format): SerializedStyles => 
         return immersiveLinkStyles(isLabs);
     }
 
-    return linkStyles(getPillarStyles(theme), isLabs);
+    return linkStyles(getThemeStyles(theme), isLabs);
 }
 
 const getStyles = ({ display, theme, design }: Format): SerializedStyles => {
     if (display === Display.Immersive) {
         const isLabs = design === Design.AdvertisementFeature;
-        return immersiveStyles(getPillarStyles(theme), isLabs);
+        return immersiveStyles(getThemeStyles(theme), isLabs);
     }
 
     return articleWidthStyles;

--- a/src/components/series.tsx
+++ b/src/components/series.tsx
@@ -61,20 +61,20 @@ const immersiveLinkStyles = (isLabs: boolean): SerializedStyles => css`
     ${font(isLabs)}
 `;
 
-const getLinkStyles = ({ display, pillar, design }: Format): SerializedStyles => {
+const getLinkStyles = ({ display, theme, design }: Format): SerializedStyles => {
     const isLabs = design === Design.AdvertisementFeature;
 
     if (display === Display.Immersive) {
         return immersiveLinkStyles(isLabs);
     }
 
-    return linkStyles(getPillarStyles(pillar), isLabs);
+    return linkStyles(getPillarStyles(theme), isLabs);
 }
 
-const getStyles = ({ display, pillar, design }: Format): SerializedStyles => {
+const getStyles = ({ display, theme, design }: Format): SerializedStyles => {
     if (display === Display.Immersive) {
         const isLabs = design === Design.AdvertisementFeature;
-        return immersiveStyles(getPillarStyles(pillar), isLabs);
+        return immersiveStyles(getPillarStyles(theme), isLabs);
     }
 
     return articleWidthStyles;

--- a/src/components/shared/bylineCard.tsx
+++ b/src/components/shared/bylineCard.tsx
@@ -9,7 +9,7 @@ import { pipe2 } from 'lib';
 import { neutral, opinion, text } from '@guardian/src-foundations/palette';
 import { Design, Display, Format } from '@guardian/types/Format';
 import { darkModeCss } from 'styles';
-import { getPillarStyles, pillarFromString } from 'pillarStyles';
+import { getThemeStyles, themeFromString } from 'themeStyles';
 import { SvgQuote } from '@guardian/src-icons';
 import { makeRelativeDate } from 'date';
 
@@ -18,7 +18,7 @@ interface Props {
 }
 
 const borderColor = (format: Format): SerializedStyles => {
-    return css`1px solid ${getPillarStyles(format.theme).kicker}`
+    return css`1px solid ${getThemeStyles(format.theme).kicker}`
 }
 
 const listStyles = (format: Format): SerializedStyles => {
@@ -167,7 +167,7 @@ const footerStyles = css`
 
 const BylineCard: FC<Props> = ({ relatedItem }) => {
     const format = {
-        theme: pillarFromString(relatedItem.pillar.id),
+        theme: themeFromString(relatedItem.pillar.id),
         design: Design.Article,
         display: Display.Standard
     }

--- a/src/components/shared/bylineCard.tsx
+++ b/src/components/shared/bylineCard.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 const borderColor = (format: Format): SerializedStyles => {
-    return css`1px solid ${getPillarStyles(format.pillar).kicker}`
+    return css`1px solid ${getPillarStyles(format.theme).kicker}`
 }
 
 const listStyles = (format: Format): SerializedStyles => {
@@ -167,7 +167,7 @@ const footerStyles = css`
 
 const BylineCard: FC<Props> = ({ relatedItem }) => {
     const format = {
-        pillar: pillarFromString(relatedItem.pillar.id),
+        theme: pillarFromString(relatedItem.pillar.id),
         design: Design.Article,
         display: Display.Standard
     }

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -11,7 +11,7 @@ import { Design, Display, Format } from '@guardian/types/Format';
 import { Image } from 'image';
 import { darkModeCss } from 'styles';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
-import { getPillarStyles, pillarFromString } from 'pillarStyles';
+import { getThemeStyles, themeFromString } from 'themeStyles';
 import { border } from 'editorialPalette';
 import { SvgCamera, SvgVideo, SvgAudio, SvgQuote } from '@guardian/src-icons';
 import { stars } from 'components/starRating';
@@ -27,7 +27,7 @@ const borderColor = (type: RelatedItemType, format: Format): SerializedStyles =>
     if (type === RelatedItemType.ADVERTISEMENT_FEATURE){
         return css`1px solid ${palette.labs[300]}`
     } else {
-        return css`1px solid ${getPillarStyles(format.theme).kicker}`
+        return css`1px solid ${getThemeStyles(format.theme).kicker}`
     }
 }
 
@@ -141,7 +141,7 @@ const relativeFirstPublished = (date: Option<Date>, type: RelatedItemType): JSX.
 const cardStyles = (type: RelatedItemType, format: Format): SerializedStyles => {
     switch (type) {
         case RelatedItemType.FEATURE: {
-            const { kicker } = getPillarStyles(format.theme);
+            const { kicker } = getThemeStyles(format.theme);
 
             return css`
                 h2 {
@@ -181,9 +181,9 @@ const cardStyles = (type: RelatedItemType, format: Format): SerializedStyles => 
         }
 
         case RelatedItemType.LIVE: {
-            const { kicker, liveblogDarkBackground } = getPillarStyles(format.theme);
+            const { liveblogBackground, liveblogDarkBackground } = getThemeStyles(format.theme);
             return css`
-                background: ${kicker};
+                background: ${liveblogBackground};
                 h3, time {
                     color: ${text.ctaPrimary};
                 }
@@ -226,7 +226,7 @@ const parentIconStyles: SerializedStyles = css`
 `;
 
 const iconStyles = (format: Format): SerializedStyles => {
-    const { inverted } = getPillarStyles(format.theme);
+    const { inverted } = getThemeStyles(format.theme);
     return css`
         width: 1.5rem;
         height: 1.5rem;
@@ -310,7 +310,7 @@ const cardByline = (type: RelatedItemType, byline?: string): ReactElement | null
 const cardImage = (image: Option<Image>, relatedItem: RelatedItem): ReactElement | null => {
     const sizes = `(min-width: ${breakpoints.phablet}px) 620px, 100%`;
     const format = {
-        theme: pillarFromString(relatedItem.pillar.id),
+        theme: themeFromString(relatedItem.pillar.id),
         design: Design.Article,
         display: Display.Standard
     }
@@ -330,7 +330,7 @@ const cardImage = (image: Option<Image>, relatedItem: RelatedItem): ReactElement
 
 const Card: FC<Props> = ({ relatedItem, image }) => {
     const format = {
-        theme: pillarFromString(relatedItem.pillar.id),
+        theme: themeFromString(relatedItem.pillar.id),
         design: Design.Article,
         display: Display.Standard
     }

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -27,7 +27,7 @@ const borderColor = (type: RelatedItemType, format: Format): SerializedStyles =>
     if (type === RelatedItemType.ADVERTISEMENT_FEATURE){
         return css`1px solid ${palette.labs[300]}`
     } else {
-        return css`1px solid ${getPillarStyles(format.pillar).kicker}`
+        return css`1px solid ${getPillarStyles(format.theme).kicker}`
     }
 }
 
@@ -141,7 +141,7 @@ const relativeFirstPublished = (date: Option<Date>, type: RelatedItemType): JSX.
 const cardStyles = (type: RelatedItemType, format: Format): SerializedStyles => {
     switch (type) {
         case RelatedItemType.FEATURE: {
-            const { kicker } = getPillarStyles(format.pillar);
+            const { kicker } = getPillarStyles(format.theme);
 
             return css`
                 h2 {
@@ -181,7 +181,7 @@ const cardStyles = (type: RelatedItemType, format: Format): SerializedStyles => 
         }
 
         case RelatedItemType.LIVE: {
-            const { kicker, liveblogDarkBackground } = getPillarStyles(format.pillar);
+            const { kicker, liveblogDarkBackground } = getPillarStyles(format.theme);
             return css`
                 background: ${kicker};
                 h3, time {
@@ -226,7 +226,7 @@ const parentIconStyles: SerializedStyles = css`
 `;
 
 const iconStyles = (format: Format): SerializedStyles => {
-    const { inverted } = getPillarStyles(format.pillar);
+    const { inverted } = getPillarStyles(format.theme);
     return css`
         width: 1.5rem;
         height: 1.5rem;
@@ -310,7 +310,7 @@ const cardByline = (type: RelatedItemType, byline?: string): ReactElement | null
 const cardImage = (image: Option<Image>, relatedItem: RelatedItem): ReactElement | null => {
     const sizes = `(min-width: ${breakpoints.phablet}px) 620px, 100%`;
     const format = {
-        pillar: pillarFromString(relatedItem.pillar.id),
+        theme: pillarFromString(relatedItem.pillar.id),
         design: Design.Article,
         display: Display.Standard
     }
@@ -330,7 +330,7 @@ const cardImage = (image: Option<Image>, relatedItem: RelatedItem): ReactElement
 
 const Card: FC<Props> = ({ relatedItem, image }) => {
     const format = {
-        pillar: pillarFromString(relatedItem.pillar.id),
+        theme: pillarFromString(relatedItem.pillar.id),
         design: Design.Article,
         display: Display.Standard
     }

--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -9,7 +9,7 @@ import { Item, getFormat } from 'item';
 import { pipe2 } from 'lib';
 import { map, withDefault } from '@guardian/types/option';
 import { textSans } from '@guardian/src-foundations/typography';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 
 interface Props {
     branding: Branding;
@@ -19,7 +19,7 @@ interface Props {
 const styles = (format: Format,
     lightModeImage: string,
     darkModeImage?: string): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.theme);
+    const { kicker, inverted } = getThemeStyles(format.theme);
     return css`
         margin: ${remSpace[9]} 0;
         ${textSans.small()}

--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -19,7 +19,7 @@ interface Props {
 const styles = (format: Format,
     lightModeImage: string,
     darkModeImage?: string): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(format.pillar);
+    const { kicker, inverted } = getPillarStyles(format.theme);
     return css`
         margin: ${remSpace[9]} 0;
         ${textSans.small()}

--- a/src/components/shared/tags.test.tsx
+++ b/src/components/shared/tags.test.tsx
@@ -12,7 +12,7 @@ const tagsProps = [{
 }];
 
 const mockFormat: Format = {
-    pillar: Pillar.News,
+    theme: Pillar.News,
     design: Design.Comment,
     display: Display.Standard,
 };

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -15,7 +15,7 @@ import Body from 'components/shared/articleBody';
 import Tags from 'components/shared/tags';
 import { darkModeCss, articleWidthStyles, relatedContentStyles, lineStyles } from 'styles';
 import { Standard as StandardItem, Review as ReviewItem, Item } from 'item';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { Display } from '@guardian/types/Format';
 import { remSpace } from '@guardian/src-foundations';
 import RelatedContent from 'components/shared/relatedContent';
@@ -47,7 +47,7 @@ const BorderStyles = css`
 `;
 
 const itemStyles = (item: Item): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(item.theme);
+    const { kicker, inverted } = getThemeStyles(item.theme);
 
     switch (item.display) {
         case Display.Immersive:

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -47,7 +47,7 @@ const BorderStyles = css`
 `;
 
 const itemStyles = (item: Item): SerializedStyles => {
-    const { kicker, inverted } = getPillarStyles(item.pillar);
+    const { kicker, inverted } = getPillarStyles(item.theme);
 
     switch (item.display) {
         case Display.Immersive:

--- a/src/components/standfirst.stories.tsx
+++ b/src/components/standfirst.stories.tsx
@@ -33,7 +33,7 @@ const Default = (): ReactElement =>
         ...article,
         standfirst,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: selectPillar(Pillar.News),
+        theme: selectPillar(Pillar.News),
     }} />
 
 const Review = (): ReactElement =>
@@ -41,7 +41,7 @@ const Review = (): ReactElement =>
         ...review,
         standfirst,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: selectPillar(Pillar.Culture),
+        theme: selectPillar(Pillar.Culture),
     }} />
 
 const Feature = (): ReactElement =>
@@ -49,7 +49,7 @@ const Feature = (): ReactElement =>
         ...feature,
         standfirst,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: selectPillar(Pillar.Sport),
+        theme: selectPillar(Pillar.Sport),
     }} />
 
 const Comment = (): ReactElement =>
@@ -57,7 +57,7 @@ const Comment = (): ReactElement =>
         ...comment,
         standfirst,
         display: boolean('Immersive', false) ? Display.Immersive : Display.Standard,
-        pillar: selectPillar(Pillar.Opinion),
+        theme: selectPillar(Pillar.Opinion),
     }} />
 
 

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -41,7 +41,7 @@ const textHeadlinePrimary = (format: Format): Colour => {
     }
 
     if (format.design === Design.Feature) {
-        switch (format.pillar) {
+        switch (format.theme) {
             case Pillar.Opinion:
                 return opinion[300];
             case Pillar.Sport:

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -78,7 +78,7 @@ const backgroundHeadlinePrimaryInverse = (_: Format): Colour =>
     coreBackground.inverse;
 
 const borderPrimary = (format: Format): Colour => {
-    switch (format.pillar) {
+    switch (format.theme) {
         case Pillar.Opinion:
             return opinion[400];
         case Pillar.Sport:

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -8,7 +8,7 @@ import { none, some } from '@guardian/types/option';
 // ----- Fixture ----- //
 
 const fields = {
-    pillar: Pillar.News,
+    theme: Pillar.News,
     display: Display.Standard,
     body: [],
     headline: 'Reclaimed lakes and giant airports: how Mexico City might have looked',

--- a/src/item.ts
+++ b/src/item.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { pillarFromString } from 'pillarStyles';
+import { themeFromString } from 'themeStyles';
 import { Content } from '@guardian/content-api-models/v1/content';
 import { Tag } from '@guardian/content-api-models/v1/tag';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
@@ -142,7 +142,7 @@ function getDisplay(content: Content): Display {
 const itemFields = (context: Context, request: RenderingRequest): ItemFields => {
     const { content, branding, commentCount, relatedContent } = request;
     return {
-        theme: pillarFromString(content?.pillarId),
+        theme: themeFromString(content?.pillarId),
         display: getDisplay(content),
         headline: content?.fields?.headline ?? "",
         standfirst: pipe2(content?.fields?.standfirst, fromNullable, map(context.docParser)),

--- a/src/item.ts
+++ b/src/item.ts
@@ -104,7 +104,7 @@ type ItemFieldsWithBody =
 // ----- Functions ----- //
 
 const getFormat = (item: Item): Format =>
-    ({ design: item.design, display: item.display, pillar: item.pillar });
+    ({ design: item.design, display: item.display, theme: item.theme });
 
 // The main image for the page is meant to be shown as showcase.
 function isShowcaseImage(content: Content): boolean {
@@ -142,7 +142,7 @@ function getDisplay(content: Content): Display {
 const itemFields = (context: Context, request: RenderingRequest): ItemFields => {
     const { content, branding, commentCount, relatedContent } = request;
     return {
-        pillar: pillarFromString(content?.pillarId),
+        theme: pillarFromString(content?.pillarId),
         display: getDisplay(content),
         headline: content?.fields?.headline ?? "",
         standfirst: pipe2(content?.fields?.standfirst, fromNullable, map(context.docParser)),
@@ -269,7 +269,7 @@ const fromCapi = (context: Context) => (request: RenderingRequest): Item => {
         return {
             design: Design.Comment,
             ...item,
-            pillar: item.pillar === Pillar.News ? Pillar.Opinion : item.pillar
+            theme: item.theme === Pillar.News ? Pillar.Opinion : item.theme
         };
     } else if (isFeature(tags)) {
         return {

--- a/src/pillarStyles.ts
+++ b/src/pillarStyles.ts
@@ -2,7 +2,7 @@
 
 import * as palette from '@guardian/src-foundations/palette';
 
-import { Pillar } from '@guardian/types/Format';
+import { Pillar, Special, Theme } from '@guardian/types/Format';
 
 
 // ----- Types ----- //
@@ -17,7 +17,7 @@ interface PillarStyles {
 }
 
 type PillarColours = {
-    [ pillar in Pillar ]: PillarStyles;
+    [ theme in Theme ]: PillarStyles;
 };
 
 export const pillarColours: PillarColours = {
@@ -60,10 +60,18 @@ export const pillarColours: PillarColours = {
         inverted: palette.lifestyle[500],
         liveblogBackground: palette.lifestyle[300],
         liveblogDarkBackground: palette.lifestyle[200]
+    },
+    [Special.SpecialReport]: {
+        kicker: palette.lifestyle[400],
+        featureHeadline: palette.lifestyle[300],
+        soft: palette.lifestyle[800],
+        inverted: palette.lifestyle[500],
+        liveblogBackground: palette.lifestyle[300],
+        liveblogDarkBackground: palette.lifestyle[200]
     }
 }
 
-const getPillarStyles = (pillar: Pillar): PillarStyles => pillarColours[pillar];
+const getPillarStyles = (pillar: Theme): PillarStyles => pillarColours[pillar];
 
 function pillarFromString(pillar: string | undefined): Pillar {
     switch (pillar) {

--- a/src/pillarStyles.ts
+++ b/src/pillarStyles.ts
@@ -62,12 +62,12 @@ export const pillarColours: PillarColours = {
         liveblogDarkBackground: palette.lifestyle[200]
     },
     [Special.SpecialReport]: {
-        kicker: palette.lifestyle[400],
-        featureHeadline: palette.lifestyle[300],
-        soft: palette.lifestyle[800],
-        inverted: palette.lifestyle[500],
-        liveblogBackground: palette.lifestyle[300],
-        liveblogDarkBackground: palette.lifestyle[200]
+        kicker: palette.specialReport[400],
+        featureHeadline: palette.specialReport[300],
+        soft: palette.specialReport[800],
+        inverted: palette.specialReport[500],
+        liveblogBackground: palette.specialReport[300],
+        liveblogDarkBackground: palette.specialReport[200]
     }
 }
 

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -12,7 +12,7 @@ import { unmountComponentAtNode, render as renderDom } from 'react-dom';
 
 
 const mockFormat: Format = {
-    pillar: Pillar.News,
+    theme: Pillar.News,
     design: Design.Article,
     display: Display.Standard,
 };

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -6,8 +6,8 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { neutral, text as textColour } from '@guardian/src-foundations/palette';
 import { Option, fromNullable, some, none, andThen, map, withDefault } from '@guardian/types/option';
 import { basePx, darkModeCss, icons } from 'styles';
-import { getPillarStyles, pillarToString } from 'pillarStyles';
-import { Format, Pillar, Special, Theme } from '@guardian/types/Format';
+import { getThemeStyles, themeToPillar } from 'themeStyles';
+import { Format } from '@guardian/types/Format';
 import { BodyElement, ElementKind } from 'bodyElement';
 import { BodyImageProps, Role } from 'image';
 import { headline, textSans } from '@guardian/src-foundations/typography';
@@ -260,7 +260,7 @@ const linkColourFromFormat = (format: Format): string => {
         return palette.labs[300];
     }
 
-    const { kicker, inverted } = getPillarStyles(format.theme);
+    const { kicker, inverted } = getThemeStyles(format.theme);
     return format.design === Design.Media ? inverted : kicker
 }
 
@@ -397,13 +397,6 @@ const imageComponentFromRole = (role: Role): FC<BodyImageProps> => {
     }
 }
 
-const themeToPillar = (theme: Theme): Pillar => {
-    if (theme === Special.SpecialReport) {
-        return Pillar.News;
-    }
-    return theme;
-}
-
 const render = (format: Format, excludeStyles = false) =>
     (element: BodyElement, key: number): ReactNode => {
         switch (element.kind) {
@@ -507,7 +500,7 @@ const render = (format: Format, excludeStyles = false) =>
             case ElementKind.GuideAtom: {
                 return h(GuideAtom, {
                     ...element,
-                    pillar: pillarToString(themeToPillar(format.theme)),
+                    pillar: themeToPillar(format.theme),
                     likeHandler: () => { console.log("like clicked"); },
                     dislikeHandler: () => { console.log("dislike clicked"); },
                     expandCallback: () => { console.log("expand clicked"); }
@@ -517,7 +510,7 @@ const render = (format: Format, excludeStyles = false) =>
             case ElementKind.QandaAtom: {
                 return h(QandaAtom, {
                     ...element,
-                    pillar: pillarToString(themeToPillar(format.theme)),
+                    pillar: themeToPillar(format.theme),
                     likeHandler: () => { console.log("like clicked"); },
                     dislikeHandler: () => { console.log("dislike clicked"); },
                     expandCallback: () => { console.log("expand clicked"); }
@@ -527,7 +520,7 @@ const render = (format: Format, excludeStyles = false) =>
             case ElementKind.ProfileAtom: {
                 return h(ProfileAtom, {
                     ...element,
-                    pillar: pillarToString(themeToPillar(format.theme)),
+                    pillar: themeToPillar(format.theme),
                     likeHandler: () => { console.log("like clicked"); },
                     dislikeHandler: () => { console.log("dislike clicked"); },
                     expandCallback: () => { console.log("expand clicked"); }
@@ -537,7 +530,7 @@ const render = (format: Format, excludeStyles = false) =>
             case ElementKind.TimelineAtom: {
                 return h(TimelineAtom, {
                     ...element,
-                    pillar: pillarToString(themeToPillar(format.theme)),
+                    pillar: themeToPillar(format.theme),
                     likeHandler: () => { console.log("like clicked"); },
                     dislikeHandler: () => { console.log("dislike clicked"); },
                     expandCallback: () => { console.log("expand clicked"); }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -7,7 +7,7 @@ import { neutral, text as textColour } from '@guardian/src-foundations/palette';
 import { Option, fromNullable, some, none, andThen, map, withDefault } from '@guardian/types/option';
 import { basePx, darkModeCss, icons } from 'styles';
 import { getPillarStyles, pillarToString } from 'pillarStyles';
-import { Format } from '@guardian/types/Format';
+import { Format, Pillar, Special, Theme } from '@guardian/types/Format';
 import { BodyElement, ElementKind } from 'bodyElement';
 import { BodyImageProps, Role } from 'image';
 import { headline, textSans } from '@guardian/src-foundations/typography';
@@ -260,7 +260,7 @@ const linkColourFromFormat = (format: Format): string => {
         return palette.labs[300];
     }
 
-    const { kicker, inverted } = getPillarStyles(format.pillar);
+    const { kicker, inverted } = getPillarStyles(format.theme);
     return format.design === Design.Media ? inverted : kicker
 }
 
@@ -397,6 +397,13 @@ const imageComponentFromRole = (role: Role): FC<BodyImageProps> => {
     }
 }
 
+const themeToPillar = (theme: Theme): Pillar => {
+    if (theme === Special.SpecialReport) {
+        return Pillar.News;
+    }
+    return theme;
+}
+
 const render = (format: Format, excludeStyles = false) =>
     (element: BodyElement, key: number): ReactNode => {
         switch (element.kind) {
@@ -500,7 +507,7 @@ const render = (format: Format, excludeStyles = false) =>
             case ElementKind.GuideAtom: {
                 return h(GuideAtom, {
                     ...element,
-                    pillar: pillarToString(format.pillar),
+                    pillar: pillarToString(themeToPillar(format.theme)),
                     likeHandler: () => { console.log("like clicked"); },
                     dislikeHandler: () => { console.log("dislike clicked"); },
                     expandCallback: () => { console.log("expand clicked"); }
@@ -510,7 +517,7 @@ const render = (format: Format, excludeStyles = false) =>
             case ElementKind.QandaAtom: {
                 return h(QandaAtom, {
                     ...element,
-                    pillar: pillarToString(format.pillar),
+                    pillar: pillarToString(themeToPillar(format.theme)),
                     likeHandler: () => { console.log("like clicked"); },
                     dislikeHandler: () => { console.log("dislike clicked"); },
                     expandCallback: () => { console.log("expand clicked"); }
@@ -520,7 +527,7 @@ const render = (format: Format, excludeStyles = false) =>
             case ElementKind.ProfileAtom: {
                 return h(ProfileAtom, {
                     ...element,
-                    pillar: pillarToString(format.pillar),
+                    pillar: pillarToString(themeToPillar(format.theme)),
                     likeHandler: () => { console.log("like clicked"); },
                     dislikeHandler: () => { console.log("dislike clicked"); },
                     expandCallback: () => { console.log("expand clicked"); }
@@ -530,7 +537,7 @@ const render = (format: Format, excludeStyles = false) =>
             case ElementKind.TimelineAtom: {
                 return h(TimelineAtom, {
                     ...element,
-                    pillar: pillarToString(format.pillar),
+                    pillar: pillarToString(themeToPillar(format.theme)),
                     likeHandler: () => { console.log("like clicked"); },
                     dislikeHandler: () => { console.log("dislike clicked"); },
                     expandCallback: () => { console.log("expand clicked"); }

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -1,5 +1,5 @@
 import { basePx, baseMultiply, darkModeCss } from './styles';
-import { getPillarStyles } from 'pillarStyles';
+import { getThemeStyles } from 'themeStyles';
 import { Pillar } from '@guardian/types/Format';
 
 describe('helper functions return correct styles', () => {
@@ -12,7 +12,7 @@ describe('helper functions return correct styles', () => {
     });
 
     test('Returns correct pillar styles for pillar', () => {
-        const pillarStyles = getPillarStyles(Pillar.News);
+        const pillarStyles = getThemeStyles(Pillar.News);
         const expectedNewsPillarStyles =  {
             kicker: '#C70000',
             featureHeadline: '#AB0613',

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -15,8 +15,6 @@ describe('helper functions return correct styles', () => {
         const pillarStyles = getThemeStyles(Pillar.News);
         const expectedNewsPillarStyles =  {
             kicker: '#C70000',
-            featureHeadline: '#AB0613',
-            soft: '#FFF4F2',
             inverted: '#FF5943',
             liveblogBackground: '#AB0613',
             liveblogDarkBackground: "#8B0000",

--- a/src/themeStyles.ts
+++ b/src/themeStyles.ts
@@ -1,80 +1,65 @@
 // ----- Imports ----- //
 
 import * as palette from '@guardian/src-foundations/palette';
-
 import { Pillar, Special, Theme } from '@guardian/types/Format';
 
 
 // ----- Types ----- //
 
-interface PillarStyles {
+interface ThemeStyles {
     kicker: string;
-    featureHeadline: string;
-    soft: string;
     inverted: string;
     liveblogBackground: string;
     liveblogDarkBackground: string;
 }
 
-type PillarColours = {
-    [ theme in Theme ]: PillarStyles;
+type ThemeColours = {
+    [ theme in Theme ]: ThemeStyles;
 };
 
-export const pillarColours: PillarColours = {
+export const themeColours: ThemeColours = {
     [Pillar.News]: {
         kicker: palette.news[400],
-        featureHeadline: palette.news[300],
-        soft: palette.news[800],
         inverted: palette.news[500],
         liveblogBackground: palette.news[300],
         liveblogDarkBackground: palette.news[200]
     },
     [Pillar.Opinion]: {
         kicker: palette.opinion[400],
-        featureHeadline: palette.opinion[300],
-        soft: palette.opinion[800],
         inverted: palette.opinion[500],
         liveblogBackground: palette.opinion[300],
         liveblogDarkBackground: palette.opinion[200]
     },
     [Pillar.Sport]: {
         kicker: palette.sport[400],
-        featureHeadline: palette.sport[300],
-        soft: palette.sport[800],
         inverted: palette.sport[500],
         liveblogBackground: palette.sport[300],
         liveblogDarkBackground: palette.sport[200]
     },
     [Pillar.Culture]: {
         kicker: palette.culture[400],
-        featureHeadline: palette.culture[300],
-        soft: palette.culture[800],
         inverted: palette.culture[500],
         liveblogBackground: palette.culture[300],
         liveblogDarkBackground: palette.culture[200]
     },
     [Pillar.Lifestyle]: {
         kicker: palette.lifestyle[400],
-        featureHeadline: palette.lifestyle[300],
-        soft: palette.lifestyle[800],
         inverted: palette.lifestyle[500],
         liveblogBackground: palette.lifestyle[300],
         liveblogDarkBackground: palette.lifestyle[200]
     },
     [Special.SpecialReport]: {
         kicker: palette.specialReport[400],
-        featureHeadline: palette.specialReport[300],
-        soft: palette.specialReport[800],
         inverted: palette.specialReport[500],
         liveblogBackground: palette.specialReport[300],
         liveblogDarkBackground: palette.specialReport[200]
     }
 }
 
-const getPillarStyles = (pillar: Theme): PillarStyles => pillarColours[pillar];
+const getThemeStyles = (theme: Theme): ThemeStyles => themeColours[theme];
 
-function pillarFromString(pillar: string | undefined): Pillar {
-    switch (pillar) {
+function themeFromString(theme: string | undefined): Pillar {
+    switch (theme) {
         case 'pillar/opinion':
             return Pillar.Opinion;
         case 'pillar/sport':
@@ -89,8 +74,8 @@ function pillarFromString(pillar: string | undefined): Pillar {
     }
 }
 
-function pillarToString(pillar: Pillar): string {
-    switch (pillar) {
+function themeToPillar(theme: Theme): string {
+    switch (theme) {
         case Pillar.Opinion:
             return 'opinion';
         case Pillar.Sport:
@@ -109,8 +94,8 @@ function pillarToString(pillar: Pillar): string {
 // ----- Exports ----- //
 
 export {
-    PillarStyles,
-    getPillarStyles,
-    pillarFromString,
-    pillarToString
+    ThemeStyles,
+    getThemeStyles,
+    themeFromString,
+    themeToPillar
 };


### PR DESCRIPTION
## Why are you doing this?
- Updates `@guardian/types` to `0.5.2`
- Rename pillar helper functions to `theme`
- Removed `featureHeadline` and `soft` colours that aren't being used
- This should let us start work on special reports
