### PR TITLE
added function for android presence check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3914,9 +3914,9 @@
       "requires": {
         "@emotion/core": "^10.0.35",
         "@guardian/src-foundations": "^2.5.0",
-        "@guardian/types": "github:guardian/types#da18ca13c822c9eed91ec9b6722c344c6f8088b4",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
+        "@guardian/types": "github:guardian/types#semver:^0.5.2",
+        "react": "^16.14.0",
+        "react-dom": "^16.14.0",
         "typescript": "^4.0.3"
       },
       "dependencies": {

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -10,9 +10,6 @@ import Epic from 'components/shared/epic';
 import ReactDOM from 'react-dom';
 import { ads, slideshow, videos, reportNativeElementPositionChanges } from 'client/nativeCommunication';
 import FooterCcpa from 'components/shared/footer';
-import { Footer } from '@guardian/src-footer';
-import { article } from 'fixtures/item';
-
 
 
 // ----- Run ----- //

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -124,9 +124,9 @@ function insertEpic(): void {
 
 function footerInit(): void {
     const isAndroid = /(android)/i.test(navigator.userAgent);
-    const footer = document.getElementById('articleFooter')
+    const footer = document.getElementById('articleFooter');
     if (footer && isAndroid){
-        ReactDOM.unmountComponentAtNode(footer)
+        footer.innerHTML = '';
     } else {
         isCCPA();
     }

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -10,6 +10,8 @@ import Epic from 'components/shared/epic';
 import ReactDOM from 'react-dom';
 import { ads, slideshow, videos, reportNativeElementPositionChanges } from 'client/nativeCommunication';
 import FooterCcpa from 'components/shared/footer';
+import { Footer } from '@guardian/src-footer';
+import { article } from 'fixtures/item';
 
 
 
@@ -123,7 +125,15 @@ function insertEpic(): void {
     }
 }
 
-
+function footerInit(): void {
+    const isAndroid = /(android)/i.test(navigator.userAgent);
+    const footer = document.getElementById('articleFooter')
+    if (footer && isAndroid){
+        ReactDOM.unmountComponentAtNode(footer)
+    } else {
+        isCCPA();
+    }
+}
 
 function isCCPA(): void {
     userClient.doesCcpaApply().then(isOptedIn => {
@@ -248,4 +258,4 @@ formatDates();
 insertEpic();
 callouts();
 hasSeenCards();
-isCCPA();
+footerInit();


### PR DESCRIPTION
## Why are you doing this?

At the moment two footers are being rendered on the Android platform, the SS as well as the native.
Max has asked to disable the footer component for Android
So we need the footer to still render for iOS by default

## Changes

- created a function to read whether the platform is Android and as a result run the isCcpa function which renders the ccpa link 

## Screenshots

| Before | After |
| --- | --- |
| <img src="" width="300px" /> | <img src="" width="300px" /> |
