### PR TITLE
Editions

### DIFF
--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -1,0 +1,62 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+import { css } from '@emotion/core';
+import { border } from '@guardian/src-foundations/palette';
+import { remSpace } from '@guardian/src-foundations';
+import { Lines } from '@guardian/src-ed-lines';
+import { Design } from '@guardian/types/Format';
+import { partition } from '@guardian/types/result';
+
+import { Item } from 'item';
+import { renderAll } from 'renderer';
+import Standfirst from 'components/editions/standfirst';
+import HeaderImage from 'components/editions/headerImage';
+import Series from 'components/editions/series';
+import Headline from 'components/editions/headline';
+import Byline from 'components/editions/byline';
+
+
+// ----- Component ----- //
+
+interface Props {
+    item: Item;
+}
+
+const headerStyles = css`
+    margin: 0 ${remSpace[3]} ${remSpace[4]};
+`;
+
+const bodyStyles = css`
+    border-top: 1px solid ${border.secondary};
+    padding: 0 ${remSpace[4]};
+`;
+
+const Article: FC<Props> = ({ item }) => {
+    if (item.design === Design.Live) {
+        return <p>Not implemented</p>
+    }
+    
+    return (
+        <main>
+            <article>
+                <header css={headerStyles}>
+                    <HeaderImage item={item} />
+                    <Series item={item} />
+                    <Headline item={item} />
+                    <Standfirst item={item} />
+                    <Lines />
+                    <Byline item={item} />
+                </header>
+                <section css={bodyStyles}>
+                    {renderAll(item, partition(item.body).oks)}
+                </section>
+            </article>
+        </main>
+    );
+}
+
+
+// ----- Exports ----- //
+
+export default Article;

--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -36,7 +36,7 @@ const Article: FC<Props> = ({ item }) => {
     if (item.design === Design.Live) {
         return <p>Not implemented</p>
     }
-    
+
     return (
         <main>
             <article>

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -1,0 +1,33 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+import { css } from '@emotion/core';
+import { body } from '@guardian/src-foundations/typography';
+import { news } from '@guardian/src-foundations/palette';
+
+import { Item } from 'item';
+import { maybeRender } from 'lib';
+
+
+// ----- Component ----- //
+
+const styles = css`
+    ${body.medium({ fontStyle: 'normal', fontWeight: 'bold' })}
+    color: ${news[400]};
+`;
+
+interface Props {
+    item: Item;
+}
+
+const Byline: FC<Props> = ({ item }) =>
+    maybeRender(item.bylineHtml, byline =>
+        <address css={styles}>
+            {byline.textContent}
+        </address>
+    )
+
+
+// ----- Exports ----- //
+
+export default Byline;

--- a/src/components/editions/headerImage.tsx
+++ b/src/components/editions/headerImage.tsx
@@ -1,0 +1,49 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+import { css } from '@emotion/core';
+import { remSpace } from '@guardian/src-foundations';
+
+import { Item } from 'item';
+import Img from 'components/img';
+import { MainMediaKind } from 'headerMedia';
+import { maybeRender } from 'lib';
+
+
+// ----- Component ----- //
+
+const styles = css`
+    margin: 0;
+`;
+
+const imgStyles = css`
+    display: block;
+    width: 100%;
+`;
+
+interface Props {
+    item: Item;
+}
+
+const HeaderImage: FC<Props> = ({ item }) =>
+    maybeRender(item.mainMedia, media => {
+        if (media.kind === MainMediaKind.Image) {
+            return (
+                <figure css={styles}>
+                    <Img
+                        image={media.image}
+                        sizes={`calc(100vw - (${remSpace[4]} * 2)`}
+                        format={item}
+                        className={imgStyles}
+                    />
+                </figure>
+            );
+        }
+
+        return null;
+    })
+
+
+// ----- Exports ----- //
+
+export default HeaderImage;

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -1,0 +1,29 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+import { css } from '@emotion/core';
+import { border } from '@guardian/src-foundations/palette';
+import { headline } from '@guardian/src-foundations/typography';
+
+import { Item } from 'item';
+
+
+// ----- Component ----- //
+
+const styles = css`
+    border-top: 1px solid ${border.secondary};
+    ${headline.small({ fontWeight: 'medium' })}
+    margin: 0;
+`;
+
+interface Props {
+    item: Item;
+}
+
+const Headline: FC<Props> = ({ item }) =>
+    <h1 css={styles}>{ item.headline }</h1>
+
+
+// ----- Exports ----- //
+
+export default Headline;

--- a/src/components/editions/series.tsx
+++ b/src/components/editions/series.tsx
@@ -27,7 +27,7 @@ const Series: FC<Props> = ({ item }) =>
     maybeRender(item.series, series =>
         <nav css={styles}>
             {series.webTitle}
-        </nav>                            
+        </nav>
     )
 
 

--- a/src/components/editions/series.tsx
+++ b/src/components/editions/series.tsx
@@ -15,7 +15,7 @@ import { maybeRender } from 'lib';
 const styles = css`
     ${titlepiece.small()}
     color: ${news[400]};
-    font-size: 17px;
+    font-size: 1.0625rem;
     padding: ${remSpace[1]} 0 ${remSpace[2]};
 `;
 

--- a/src/components/editions/series.tsx
+++ b/src/components/editions/series.tsx
@@ -1,0 +1,36 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+import { css } from '@emotion/core';
+import { titlepiece } from '@guardian/src-foundations/typography';
+import { news } from '@guardian/src-foundations/palette';
+import { remSpace } from '@guardian/src-foundations';
+
+import { Item } from 'item';
+import { maybeRender } from 'lib';
+
+
+// ----- Component ----- //
+
+const styles = css`
+    ${titlepiece.small()}
+    color: ${news[400]};
+    font-size: 17px;
+    padding: ${remSpace[1]} 0 ${remSpace[2]};
+`;
+
+interface Props {
+    item: Item;
+}
+
+const Series: FC<Props> = ({ item }) =>
+    maybeRender(item.series, series =>
+        <nav css={styles}>
+            {series.webTitle}
+        </nav>                            
+    )
+
+
+// ----- Exports ----- //
+
+export default Series;

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -1,0 +1,32 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+import { css } from '@emotion/core';
+import { body } from '@guardian/src-foundations/typography';
+import { remSpace } from '@guardian/src-foundations';
+
+import { Item } from 'item';
+import { maybeRender } from 'lib';
+import { renderStandfirstText } from 'renderer';
+
+
+// ----- Component ----- //
+
+const styles = css`
+    ${body.medium({ lineHeight: 'tight' })}
+    margin: ${remSpace[4]} 0 0;
+`;
+
+interface Props {
+    item: Item;
+}
+
+const Standfirst: FC<Props> = ({ item }) =>
+    maybeRender(item.standfirst, standfirst =>
+        <div css={styles}>{renderStandfirstText(standfirst, item)}</div>
+    )
+
+
+// ----- Exports ----- //
+
+export default Standfirst;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,3 +1,9 @@
+// ----- Imports ----- //
+
+import { ReactElement } from 'react';
+import { map, Option, withDefault } from '@guardian/types/option';
+
+
 // ----- Functions ----- //
 
 const compose = <A, B, C>(f: (_b: B) => C, g: (_a: A) => B) => (a: A): C => f(g(a));
@@ -39,6 +45,13 @@ function errorToString(error: unknown, fallback: string): string {
 const isObject = (a: unknown): a is Record<string, unknown> =>
     typeof a === 'object' && a !== null;
 
+const maybeRender = <A>(oa: Option<A>, f: (a: A) => ReactElement | null): ReactElement | null =>
+    pipe2(
+        oa,
+        map(f),
+        withDefault<ReactElement | null>(null),
+    )
+
 
 // ----- Exports ----- //
 
@@ -53,4 +66,5 @@ export {
     memoise,
     errorToString,
     isObject,
+    maybeRender,
 };

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -1,0 +1,79 @@
+// ----- Imports ----- //
+
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { JSDOM } from 'jsdom';
+import { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
+import { none, Option } from '@guardian/types/option';
+
+import { fromCapi } from 'item';
+import Article from 'components/editions/article';
+import { pageFonts } from 'styles';
+
+
+// ----- Types ----- //
+
+interface Page {
+    html: string;
+    clientScript: Option<string>;
+}
+
+
+// ----- Setup ----- //
+
+const docParser = JSDOM.fragment.bind(null);
+
+
+// ----- Functions ----- //
+
+const renderHead = (request: RenderingRequest): string =>
+    renderToString(
+        <>
+            <meta charSet="utf-8" />
+            <title>{request.content.webTitle}</title>
+            <meta name="viewport" content="initial-scale=1" />
+        </>
+    );
+
+const styles = `
+    ${pageFonts}
+
+    body {
+        margin: 0;
+    }
+`;
+
+const buildHtml = (head: string, body: string): string => `
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            ${head}
+            <style>${styles}</style>
+        </head>
+        <body>
+            ${body}
+        </body>
+    </html>
+`;
+
+function render(
+    imageSalt: string,
+    request: RenderingRequest,
+): Page {
+    const item = fromCapi({ docParser, salt: imageSalt })(request);
+
+    return {
+        html: buildHtml(
+            renderHead(request),
+            renderToString(<Article item={item} />),
+        ),
+        clientScript: none,
+    };
+}
+
+
+// ----- Exports ----- //
+
+export {
+    render,
+};


### PR DESCRIPTION
## Why are you doing this?

Initial support for rendering Editions articles. This introduces a query param `?editions` that's only available when running locally. It also includes some of the UI work for supporting a "standard" Editions article.

## Changes

- Added a `maybeRender` helper function for `Option`s
- Added a new Editions article
- Added Editions `Byline`, `HeaderImage`, `Headline`, `Series` and `Standfirst`
- Added an `editionsPage` module for building the HTML document
- Updated our server to accept an `editions` query param in dev

## Screenshots

**Note:** The camera icon on the App screenshots is an existing bug on Firefox - doesn't appear on Chrome and Safari.

| App | Editions |
| - | - |
| ![app](https://user-images.githubusercontent.com/53781962/97172027-50960e80-1786-11eb-9614-58f26002978a.jpg) | ![editions](https://user-images.githubusercontent.com/53781962/97171890-14fb4480-1786-11eb-8b7e-01e14aff7ae4.jpg) |
