### PR TITLE
Simplify Jest Ignore Pattern For Guardian Modules

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -39,6 +39,6 @@ module.exports = {
       'src',
     ],
     transformIgnorePatterns: [
-      'node_modules/(?!(@guardian/src-foundations|@guardian/types|@guardian/src-icons|@guardian/image-rendering)/)',
+      'node_modules/(?!@guardian)',
     ],
 };


### PR DESCRIPTION
## Why are you doing this?

Suggestion from @mxdvl, as described [here](https://github.com/guardian/apps-rendering/pull/844#discussion_r510870646).

FYI @gtrufitt @SiAdcock @sndrs 

## Changes

- Simplify Jest ignore pattern for `guardian` modules
