### PR TITLE
HorizontalRule Component

### DIFF
--- a/src/components/horizontalRule.stories.tsx
+++ b/src/components/horizontalRule.stories.tsx
@@ -1,0 +1,23 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+
+import HorizontalRule from './horizontalRule';
+
+
+// ----- Stories ----- //
+
+const Default: FC = () =>
+    <HorizontalRule />
+
+
+// ----- Exports ----- //
+
+export default {
+    component: HorizontalRule,
+    title: 'HorizontalRule',
+}
+
+export {
+    Default,
+}

--- a/src/components/horizontalRule.tsx
+++ b/src/components/horizontalRule.tsx
@@ -1,0 +1,32 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+import { css } from '@emotion/core';
+import { neutral } from '@guardian/src-foundations/palette';
+import { remSpace } from '@guardian/src-foundations';
+
+import { darkModeCss } from 'styles';
+
+
+// ----- Component ----- //
+
+const styles = css`
+    display: block;
+    width: 8.75rem;
+    height: 0.125rem;
+    margin: ${remSpace[12]} 0 ${remSpace[1]};
+    border: 0;
+    background-color: ${neutral[93]};
+
+    ${darkModeCss`
+        background-color: ${neutral[20]};
+    `}
+`;
+
+const HorizontalRule: FC = () =>
+    <hr css={styles} />
+
+
+// ----- Exports ----- //
+
+export default HorizontalRule;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -29,6 +29,7 @@ import Bullet from 'components/bullet';
 import Pullquote  from 'components/pullquote';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 import Credit from 'components/credit';
+import HorizontalRule from 'components/horizontalRule';
 
 
 // ----- Renderer ----- //
@@ -70,24 +71,6 @@ const getHref = (node: Node): Option<string> =>
         )),
     );
 
-const HorizontalRuleStyles = css`
-    display: block;
-    width: 8.75rem;
-    height: 0.125rem;
-    margin: 0;
-    border: 0;
-    margin-top: 3rem;
-    margin-bottom: 0.1875rem;
-    background-color: ${neutral[93]};
-    ${darkModeCss`
-        background-color: ${neutral[20]};
-    `}
-`;
-
-const HorizontalRule = (): ReactElement =>
-    styledH('hr', { css: HorizontalRuleStyles }, null);
-
-
 const transform = (text: string, format: Format): ReactElement | string => {
     if (text.includes('•')) {
         return h(Bullet, { format, text });
@@ -96,8 +79,6 @@ const transform = (text: string, format: Format): ReactElement | string => {
     }
     return text;
 };
-
-
 
 const listStyles: SerializedStyles = css`
     list-style: none;


### PR DESCRIPTION
## Why are you doing this?

Migrated `HorizontalRule` to standalone component. I'm trying to narrow the focus of the `renderer` file, and also introduce stories for components that don't have them.

## Changes

- Moved `HorizontalRule` to standalone file
- Added stories
