### PR TITLE
update to image rendering 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3556,44 +3556,21 @@
       }
     },
     "@guardian/image-rendering": {
-      "version": "github:guardian/image-rendering#2b58d85b5f9131e2afde31d6fc9dbc0b2585ac27",
-      "from": "github:guardian/image-rendering#semver:^3.0.0",
+      "version": "github:guardian/image-rendering#6dd318d29864173456dbd313ebf83d34f6d6b287",
+      "from": "github:guardian/image-rendering#semver:^3.0.2",
       "requires": {
         "@emotion/core": "^10.0.35",
         "@guardian/src-foundations": "^2.5.0",
-        "@guardian/types": "github:guardian/types#da18ca13c822c9eed91ec9b6722c344c6f8088b4",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "typescript": "^4.0.3"
+        "@guardian/types": "github:guardian/types#semver:^0.5.2",
+        "react": "^16.14.0",
+        "react-dom": "^16.14.0",
+        "typescript": "^4.0.5"
       },
       "dependencies": {
-        "react": {
-          "version": "17.0.1",
-          "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-          "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-dom": {
-          "version": "17.0.1",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-          "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "scheduler": "^0.20.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.20.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-          "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
+        "typescript": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+          "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@guardian/bridget": "^1.1.0",
     "@guardian/content-api-models": "^15.9.2",
     "@guardian/content-atom-model": "^3.2.4",
-    "@guardian/image-rendering": "github:guardian/image-rendering#semver:^3.0.0",
+    "@guardian/image-rendering": "github:guardian/image-rendering#semver:^3.0.2",
     "@guardian/node-riffraff-artifact": "^0.1.9",
     "@guardian/src-brand": "^2.5.0",
     "@guardian/src-button": "^2.4.0",


### PR DESCRIPTION
## Why are you doing this?

The apps-rendering team city job is failing frequently due to a preinstall script in the image-rendering project.

This should hopefully enable successful builds in team city, which is required for riff-raff and deploying apps-rendering to production.

image-rendering fix: https://github.com/guardian/image-rendering/pull/107