### PR TITLE
render match reports as standard articles

### DIFF
--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -220,7 +220,7 @@ describe('fromCapi returns correct Item', () => {
 
     test('matchreport', () => {
         const item = f(contentWithTag('tone/matchreports'));
-        expect(item.design).toBe(Design.MatchReport);
+        expect(item.design).toBe(Design.Article);
     })
 
     test('interview', () => {

--- a/src/item.ts
+++ b/src/item.ts
@@ -210,9 +210,6 @@ const isLive =
 const isRecipe =
     hasTag('tone/recipes');
 
-const isMatchReport =
-    hasTag('tone/matchreports');
-
 const isInterview =
     hasTag('tone/interview');
 
@@ -281,11 +278,6 @@ const fromCapi = (context: Context) => (request: RenderingRequest): Item => {
     } else if (isRecipe(tags)) {
         return {
             design: Design.Recipe,
-            ...itemFieldsWithBody(context, request),
-        };
-    } else if (isMatchReport(tags)) {
-        return {
-            design: Design.MatchReport,
             ...itemFieldsWithBody(context, request),
         };
     } else if (isInterview(tags)) {


### PR DESCRIPTION
## Why are you doing this?
Match reports should look like standard articles, render them in the same way as other articles.
Article: `football/2020/nov/03/atalanta-liverpool-champions-league-group-d-match-report`
## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/98258544-e5fc8400-1f78-11eb-8fb7-64ed7531eeab.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/98258568-ed239200-1f78-11eb-9938-a51d38a2c9ca.png" width="300px" /> |
