### PR TITLE
updated footer for dark mode and privacy links

### DIFF
--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -20,7 +20,7 @@ const container = css`
 	}
 	${darkModeCss`
             color: ${neutral[60]};
-        `}
+    `}
 `;
 
 const anchor = css`
@@ -29,7 +29,7 @@ const anchor = css`
 	text-decoration: underline;
 	${darkModeCss`
             color: ${neutral[60]};
-        `}
+    `}
 `;
 
 interface FooterCcpaProps {

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/core';
-import { neutral, remSpace } from '@guardian/src-foundations';
+import { breakpoints, neutral, remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
 import type { FC } from 'react';
 import React from 'react';
+import { darkModeCss } from 'styles';
 
 // Footer content styles
 const container = css`
@@ -12,37 +14,43 @@ const container = css`
 	margin-right: ${remSpace[2]};
 	padding-top: ${remSpace[4]};
 	padding-bottom: ${remSpace[6]};
+	${from.wide} {
+		width: ${breakpoints.wide}px;
+		margin: 0 auto;
+	}
+	${darkModeCss`
+            color: ${neutral[60]};
+        `}
 `;
 
 const anchor = css`
 	${textSans.small({ lineHeight: 'regular' })};
 	color: ${neutral[7]};
 	text-decoration: underline;
+	${darkModeCss`
+            color: ${neutral[60]};
+        `}
 `;
 
 interface FooterCcpaProps {
 	isCcpa: boolean;
 }
 
-const renderContent = (ccpaStatus: boolean): JSX.Element => {
-	if (!ccpaStatus) {
+const renderContent = (ccpaStatus: boolean): JSX.Element | null => {
+	if (ccpaStatus) {
 		return (
-			<a
-				css={anchor}
-				href="https://www.theguardian.com/help/privacy-policy"
-			>
-				Privacy Settings
-			</a>
+			<>
+				<a
+					css={anchor}
+					href="https://www.theguardian.com/help/privacy-policy"
+				>
+					California Residents - Do Not Sell
+				</a>
+				&nbsp;&#183;&nbsp;
+			</>
 		);
 	} else {
-		return (
-			<a
-				css={anchor}
-				href="https://www.theguardian.com/help/privacy-policy"
-			>
-				California Residents - Do Not Sell
-			</a>
-		);
+		return null;
 	}
 };
 
@@ -53,8 +61,7 @@ const FooterCcpa: FC<FooterCcpaProps> = ({ isCcpa }) => {
 			&#169; {currentYear} Guardian News and Media Limited or its
 			affiliated companies. All rights reserved.
 			<br />
-			{renderContent(isCcpa)}
-			&nbsp;&#183;&nbsp;
+			{renderContent(true)}
 			<a
 				css={anchor}
 				href="https://www.theguardian.com/help/privacy-policy"


### PR DESCRIPTION
## Why are you doing this?

The footer is not supported in dark mode. also the width of the text is not contained within the border of the article.
Additional Privacy settings link not needed

## Changes
- Removed the privacy settings link
- Included Border `width: ${breakpoints.wide}px;` to container css
- Added dark mode to css for container css as well as anchor css

## Screenshots

| Dark Default | Dark with Ccpa |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/98833004-6cabd800-2435-11eb-8eab-9482502620cd.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/98832791-2787a600-2435-11eb-8e7b-85ec83928563.png" width="300px" /> |
