### PR TITLE
Editions CSP

### DIFF
--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -1,13 +1,20 @@
 // ----- Imports ----- //
 
+import { CacheProvider } from '@emotion/core';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import type { Option } from '@guardian/types/option';
 import { none } from '@guardian/types/option';
 import Article from 'components/editions/article';
+import type { EmotionCritical } from 'create-emotion-server';
+import { cache } from 'emotion';
+import { extractCritical } from 'emotion-server';
+import type { Item } from 'item';
 import { fromCapi } from 'item';
 import { JSDOM } from 'jsdom';
+import { compose } from 'lib';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+import { assetHashes } from 'server/csp';
 import { pageFonts } from 'styles';
 
 // ----- Types ----- //
@@ -23,14 +30,12 @@ const docParser = JSDOM.fragment.bind(null);
 
 // ----- Functions ----- //
 
-const renderHead = (request: RenderingRequest): string =>
-	renderToString(
-		<>
-			<meta charSet="utf-8" />
-			<title>{request.content.webTitle}</title>
-			<meta name="viewport" content="initial-scale=1" />
-		</>,
-	);
+const csp = (styles: string[]): string =>
+	`
+	default-src 'self';
+	style-src ${assetHashes(styles)};
+	img-src 'self' https://i.guim.co.uk;
+	`.trim();
 
 const styles = `
     ${pageFonts}
@@ -39,6 +44,35 @@ const styles = `
         margin: 0;
     }
 `;
+
+const renderHead = (
+	request: RenderingRequest,
+	emotionCritical: EmotionCritical,
+): string =>
+	renderToString(
+		<>
+			<meta charSet="utf-8" />
+			<title>{request.content.webTitle}</title>
+			<meta name="viewport" content="initial-scale=1" />
+			<meta
+				httpEquiv="Content-Security-Policy"
+				content={csp([styles, emotionCritical.css])}
+			/>
+			<style data-emotion-css={emotionCritical.ids.join(' ')}>
+				{emotionCritical.css}
+			</style>
+		</>,
+	);
+
+const renderBody = (item: Item): EmotionCritical =>
+	compose(
+		extractCritical,
+		renderToString,
+	)(
+		<CacheProvider value={cache}>
+			<Article item={item} />
+		</CacheProvider>,
+	);
 
 const buildHtml = (head: string, body: string): string => `
     <!DOCTYPE html>
@@ -55,12 +89,10 @@ const buildHtml = (head: string, body: string): string => `
 
 function render(imageSalt: string, request: RenderingRequest): Page {
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
+	const body = renderBody(item);
 
 	return {
-		html: buildHtml(
-			renderHead(request),
-			renderToString(<Article item={item} />),
-		),
+		html: buildHtml(renderHead(request, body), body.html),
 		clientScript: none,
 	};
 }


### PR DESCRIPTION
## Why are you doing this?

Added a Content Security Policy for the Editions page. This will restrict the resources, such as styles, images and scripts, that we allow on pages used by the Editions project. For more information on CSPs see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). Go [here](https://emotion.sh/docs/ssr#advanced-approach) for more information about the Emotion APIs.

## Changes

- Used Emotion critical to extract styles into single tag
- Hashed style tags in CSP
- Allowed some image domains
