### PR TITLE
update screenshot action to avoid using set env

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -34,7 +34,7 @@ jobs:
                   APIS_IMG_SALT: ${{ secrets.APIS_IMG_SALT }}
                   CAPI_KEY: ${{ secrets.CAPI_KEY }}
             - name: Take screenshot of apps-rendering
-              uses: 'lannonbr/puppeteer-screenshot-action@1.3.0'
+              uses: 'lannonbr/puppeteer-screenshot-action@1.3.1'
               with:
                   url: http://localhost:8080/
             - name: Upload screenshot


### PR DESCRIPTION
## Why are you doing this?
All the open pull requests are failing builds because of the screenshot action.
I saw a warning message on Friday saying `set-env` would be removed and actions wouldn't run if they used it after the 16th November.

Luckily it appears the action we're using to take screenshots has been updated to use the suggested environment files.
https://github.com/lannonbr/puppeteer-screenshot-action/commit/ecc08ce649f3aa4ff689388f903d38d83eccfc22
