### PR TITLE
Apps rendered footer does ccpa apply with time out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1650,7 +1650,7 @@
       "requires": {
         "@emotion/core": "^10.1.1",
         "@guardian/src-foundations": "^2.5.0",
-        "@guardian/types": "github:guardian/types#da18ca13c822c9eed91ec9b6722c344c6f8088b4",
+        "@guardian/types": "github:guardian/types#semver:^0.5.2",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "typescript": "^4.0.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1649,11 +1649,18 @@
       "from": "github:guardian/image-rendering#semver:^3.0.4",
       "requires": {
         "@emotion/core": "^10.1.1",
-        "@guardian/src-foundations": "^2.5.0",
+        "@guardian/src-foundations": "^2.6.0",
         "@guardian/types": "github:guardian/types#semver:^0.5.2",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "typescript": "^4.0.5"
+      },
+      "dependencies": {
+        "@guardian/src-foundations": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-2.6.0.tgz",
+          "integrity": "sha512-r1eUesgetq0jJc0vt1f+b07PtkQ44AzytsW1tGmdirtthF28FBWoVJ5QcFcebL/Ou47xNQi+BhqC8VKbjMFbrg=="
+        }
       }
     },
     "@guardian/node-riffraff-artifact": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/apps-rendering-api-models": "^0.11.0",
     "@guardian/atoms-rendering": "2.0.7",
-    "@guardian/bridget": "^1.1.0",
+    "@guardian/bridget": "^1.6.0",
     "@guardian/content-api-models": "^15.9.2",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/image-rendering": "github:guardian/image-rendering#semver:^3.0.4",

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -143,7 +143,7 @@ function footerInit(): void {
 	if (footer && isAndroid) {
 		footer.innerHTML = '';
 	} else {
-		setTimeout(isCCPA,5000);
+		setTimeout(isCCPA, 5000);
 	}
 }
 

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -143,15 +143,15 @@ function footerInit(): void {
 	if (footer && isAndroid) {
 		footer.innerHTML = '';
 	} else {
-		setTimeout(isCCPA, 5000);
+		isCCPA();
 	}
 }
 
 function isCCPA(): void {
 	userClient
 		.doesCcpaApply()
-		.then((isOptedIn) => {
-			const comp = h(FooterCcpa, { isCcpa: isOptedIn });
+		.then((isCcpa) => {
+			const comp = h(FooterCcpa, { isCcpa });
 			ReactDOM.render(comp, document.getElementById('articleFooter'));
 		})
 		.catch((error) => {
@@ -353,11 +353,11 @@ reportNativeElementPositionChanges();
 topics();
 slideshow();
 formatDates();
+footerInit();
 insertEpic();
 callouts();
 hasSeenCards();
 initAudioAtoms();
 hydrateQuizAtoms();
-footerInit();
 localDates();
 richLinks();

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -143,7 +143,7 @@ function footerInit(): void {
 	if (footer && isAndroid) {
 		footer.innerHTML = '';
 	} else {
-		isCCPA();
+		setTimeout(isCCPA,5000);
 	}
 }
 

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -54,7 +54,7 @@ const renderContent = (ccpaStatus: boolean): JSX.Element | null => {
 			<>
 				<a
 					css={anchor}
-					href="https://www.theguardian.com/help/privacy-policy"
+					href="https://www.theguardian.com/help/privacy-settings"
 				>
 					Privacy Settings
 				</a>

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -50,7 +50,17 @@ const renderContent = (ccpaStatus: boolean): JSX.Element | null => {
 			</>
 		);
 	} else {
-		return null;
+		return (
+			<>
+				<a
+					css={anchor}
+					href="https://www.theguardian.com/help/privacy-policy"
+				>
+					Privacy Settings
+				</a>
+				&nbsp;&#183;&nbsp;
+			</>
+		);
 	}
 };
 


### PR DESCRIPTION
## Why are you doing this?

iOS currently is communicating with SSR articles to implement `doesCcpaApply()` to effectively render CCPA footer content for US residents.

## Changes

- Added a timeOut delay for async - a delay to allow time for the the data to be parsed and processed to bridget before reading the boolean value from `article.ts`

