### PR TITLE
Editions lightbox

### DIFF
--- a/src/client/editions.ts
+++ b/src/client/editions.ts
@@ -27,7 +27,7 @@ Array.from(body?.querySelectorAll('.js-launch-slideshow') ?? []).forEach(
 			window.ReactNativeWebView.postMessage(
 				JSON.stringify({
 					type: 'openLightbox',
-					index: index + 1,
+					index,
 					isMainImage: 'false',
 				}),
 			);

--- a/src/client/editions.ts
+++ b/src/client/editions.ts
@@ -1,0 +1,36 @@
+declare module 'ReactNativeWebView' {
+	global {
+		interface Window {
+			ReactNativeWebView: {
+				postMessage: (data: string) => void;
+			};
+		}
+	}
+}
+
+document
+	.querySelector('.js-header .js-launch-slideshow')
+	?.addEventListener('click', () => {
+		window.ReactNativeWebView.postMessage(
+			JSON.stringify({
+				type: 'openLightbox',
+				index: 0,
+				isMainImage: 'true',
+			}),
+		);
+	});
+
+const body = document.querySelector('.js-body');
+Array.from(body?.querySelectorAll('.js-launch-slideshow') ?? []).forEach(
+	(image, index) => {
+		image.addEventListener('click', () => {
+			window.ReactNativeWebView.postMessage(
+				JSON.stringify({
+					type: 'openLightbox',
+					index: index + 1,
+					isMainImage: 'false',
+				}),
+			);
+		});
+	},
+);

--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -39,7 +39,7 @@ const Article: FC<Props> = ({ item }) => {
 	return (
 		<main>
 			<article>
-				<header css={headerStyles}>
+				<header css={headerStyles} className="js-header">
 					<HeaderImage item={item} />
 					<Series item={item} />
 					<Headline item={item} />
@@ -47,7 +47,7 @@ const Article: FC<Props> = ({ item }) => {
 					<Lines />
 					<Byline item={item} />
 				</header>
-				<section css={bodyStyles}>
+				<section css={bodyStyles} className="js-body">
 					{renderAll(item, partition(item.body).oks)}
 				</section>
 			</article>

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -57,19 +57,19 @@ export async function getInlineScript(
 	getAssetLocation: (assetName: string) => string,
 ): Promise<Option<string>> {
 	const clientScript = map(getAssetLocation)(some('editions.js'));
-	let inlineScript: Option<string> = none;
 
 	if (clientScript.kind === OptionKind.Some) {
 		const readFilePromise = util.promisify(fs.readFile);
+		const file = `${__dirname}${clientScript.value}`;
 		try {
-			const inlineScriptBuffer = await readFilePromise(
-				`${__dirname}${clientScript.value}`,
-			);
-			inlineScript = some(inlineScriptBuffer.toString());
+			const inlineScriptBuffer = await readFilePromise(file);
+			return some(inlineScriptBuffer.toString());
 		} catch (e) {
-			console.error(e);
+			console.error(
+				`Unable to find the file: ${file}. Falling back to fetching editions.js file`,
+			);
 		}
 	}
 
-	return inlineScript;
+	return none;
 }

--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -1,9 +1,9 @@
-import { isObject } from 'lib';
-import { logger } from 'logger';
-import { map, OptionKind, some, none } from '@guardian/types/option';
-import type { Option } from '@guardian/types/option';
 import fs from 'fs';
 import util from 'util';
+import { map, none, OptionKind, some } from '@guardian/types/option';
+import type { Option } from '@guardian/types/option';
+import { isObject } from 'lib';
+import { logger } from 'logger';
 
 type AssetMapping = Record<string, string | undefined> | null;
 

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -89,7 +89,11 @@ const buildHtml = (
         </head>
         <body>
 			${body}
-			${map((inline) => `<script>${inline}</script>`)(inlineScript)}
+			${
+				inlineScript.kind === OptionKind.Some
+					? `<script>${inlineScript.value}</script>`
+					: ''
+			}
         </body>
     </html>
 `;

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -2,9 +2,10 @@
 
 import { CacheProvider } from '@emotion/core';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
-import type { Option } from '@guardian/types/option';
-import { none } from '@guardian/types/option';
+import { map, Option, some } from '@guardian/types/option';
+import { getThirdPartyEmbeds } from 'capi';
 import Article from 'components/editions/article';
+import Scripts from 'components/scripts';
 import type { EmotionCritical } from 'create-emotion-server';
 import { cache } from 'emotion';
 import { extractCritical } from 'emotion-server';
@@ -12,7 +13,7 @@ import type { Item } from 'item';
 import { fromCapi } from 'item';
 import { JSDOM } from 'jsdom';
 import { compose } from 'lib';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { renderToString } from 'react-dom/server';
 import { assetHashes } from 'server/csp';
 import { pageFonts } from 'styles';
@@ -74,7 +75,11 @@ const renderBody = (item: Item): EmotionCritical =>
 		</CacheProvider>,
 	);
 
-const buildHtml = (head: string, body: string): string => `
+const buildHtml = (
+	head: string,
+	body: string,
+	scripts: ReactElement,
+): string => `
     <!DOCTYPE html>
     <html lang="en">
         <head>
@@ -82,18 +87,32 @@ const buildHtml = (head: string, body: string): string => `
             <style>${styles}</style>
         </head>
         <body>
-            ${body}
+			${body}
+			${renderToString(scripts)}
         </body>
     </html>
 `;
 
-function render(imageSalt: string, request: RenderingRequest): Page {
+function render(
+	imageSalt: string,
+	request: RenderingRequest,
+	getAssetLocation: (assetName: string) => string,
+): Page {
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
 	const body = renderBody(item);
+	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
+	const clientScript = map(getAssetLocation)(some('editions.js'));
+
+	const scripts = (
+		<Scripts
+			clientScript={clientScript}
+			twitter={thirdPartyEmbeds.twitter}
+		/>
+	);
 
 	return {
-		html: buildHtml(renderHead(request, body), body.html),
-		clientScript: none,
+		html: buildHtml(renderHead(request, body), body.html, scripts),
+		clientScript,
 	};
 }
 

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -2,7 +2,8 @@
 
 import { CacheProvider } from '@emotion/core';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
-import { map, Option, some } from '@guardian/types/option';
+import { map, some } from '@guardian/types/option';
+import type { Option } from '@guardian/types/option';
 import { getThirdPartyEmbeds } from 'capi';
 import Article from 'components/editions/article';
 import Scripts from 'components/scripts';
@@ -13,7 +14,8 @@ import type { Item } from 'item';
 import { fromCapi } from 'item';
 import { JSDOM } from 'jsdom';
 import { compose } from 'lib';
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { renderToString } from 'react-dom/server';
 import { assetHashes } from 'server/csp';
 import { pageFonts } from 'styles';

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -2,9 +2,11 @@
 
 import { CacheProvider } from '@emotion/core';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
-import { OptionKind, none, map, some } from '@guardian/types/option';
+import { map, none, OptionKind, some } from '@guardian/types/option';
 import type { Option } from '@guardian/types/option';
+import { getThirdPartyEmbeds } from 'capi';
 import Article from 'components/editions/article';
+import Scripts from 'components/scripts';
 import type { EmotionCritical } from 'create-emotion-server';
 import { cache } from 'emotion';
 import { extractCritical } from 'emotion-server';
@@ -13,12 +15,10 @@ import { fromCapi } from 'item';
 import { JSDOM } from 'jsdom';
 import { compose } from 'lib';
 import React from 'react';
+import type { ReactElement } from 'react';
 import { renderToString } from 'react-dom/server';
 import { assetHashes } from 'server/csp';
 import { pageFonts } from 'styles';
-import { getThirdPartyEmbeds } from 'capi';
-import Scripts from 'components/scripts';
-import { ReactElement } from 'react';
 
 // ----- Types ----- //
 
@@ -100,12 +100,12 @@ const buildHtml = (
     </html>
 `;
 
-async function render(
+function render(
 	imageSalt: string,
 	request: RenderingRequest,
 	getAssetLocation: (assetName: string) => string,
 	editionsInlineScript: Option<string>,
-): Promise<Page> {
+): Page {
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
 	const clientScript = map(getAssetLocation)(some('editions.js'));
 	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -128,7 +128,7 @@ async function serveArticle(
 	}
 
 	const renderer = isEditions ? renderEditions : render;
-	const { html, clientScript } = renderer(
+	const { html, clientScript } = await renderer(
 		imageSalt,
 		request,
 		getAssetLocation,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -133,6 +133,7 @@ async function serveArticle(
 		renderedContent = await renderEditions(
 			imageSalt,
 			request,
+			getAssetLocation,
 			await editionsInlineScript,
 		);
 	} else {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -130,14 +130,14 @@ async function serveArticle(
 	}
 
 	if (isEditions) {
-		renderedContent = await renderEditions(
+		renderedContent = renderEditions(
 			imageSalt,
 			request,
 			getAssetLocation,
 			await editionsInlineScript,
 		);
 	} else {
-		renderedContent = await render(imageSalt, request, getAssetLocation);
+		renderedContent = render(imageSalt, request, getAssetLocation);
 	}
 	const { html, clientScript } = renderedContent;
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -120,6 +120,7 @@ export const clientConfig: Configuration = {
 	entry: {
 		article: 'client/article.ts',
 		media: 'client/media.ts',
+		editions: 'client/editions.ts',
 	},
 	target: 'web',
 	devtool: 'inline-cheap-source-map',


### PR DESCRIPTION
## Why are you doing this?

Post messages to react native when the header image or body images are clicked.

Tested on apps-rendering branch in the editions project, opens header and body images in the lightbox component

## Changes
- Inline client side JavaScript on editions articles - articles with the `?editions` query param
- Adds click event listeners to inform React native layer to open lightbox


This extends a previous PR that generated an editions.js file used clientside https://github.com/guardian/apps-rendering/pull/968