### PR TITLE
Image-Rendering Top-Level Exports

### DIFF
--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -2,7 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/core';
 import { css, jsx as styledH } from '@emotion/core';
-import { Role } from '@guardian/image-rendering/src/image';
+import { Role } from '@guardian/image-rendering';
 import { neutral } from '@guardian/src-foundations/palette';
 import type { Format } from '@guardian/types/Format';
 import { Design } from '@guardian/types/Format';

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import type { Content } from '@guardian/content-api-models/v1/content';
-import { Role } from '@guardian/image-rendering/src/image';
+import { Role } from '@guardian/image-rendering';
 import type { Option } from '@guardian/types/option';
 import { fromNullable, map, none } from '@guardian/types/option';
 import { articleContributors } from 'capi';

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -8,7 +8,7 @@ import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import { AssetType } from '@guardian/content-api-models/v1/assetType';
 import { none, withDefault } from '@guardian/types/option';
 import { pipe3 } from 'lib';
-import { Role } from '@guardian/image-rendering/src/image';
+import { Role } from '@guardian/image-rendering';
 
 // ----- Mocks ----- //
 

--- a/src/image.ts
+++ b/src/image.ts
@@ -3,8 +3,8 @@
 import { createHash } from 'crypto';
 import type { Image as CardImage } from '@guardian/apps-rendering-api-models/image';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
-import type { Image as ImageData } from '@guardian/image-rendering/src/image';
-import { Role } from '@guardian/image-rendering/src/image';
+import type { Image as ImageData } from '@guardian/image-rendering';
+import { Role } from '@guardian/image-rendering';
 import type { Format } from '@guardian/types/Format';
 import { andThen, fromNullable, map, none, some } from '@guardian/types/option';
 import type { Option } from '@guardian/types/option';

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -10,7 +10,7 @@ import { Pillar } from '@guardian/types/Format';
 import { isValidElement, ReactNode } from 'react';
 import { compose } from 'lib';
 import { BodyElement, ElementKind } from 'bodyElement';
-import { Role } from '@guardian/image-rendering/src/image';
+import { Role } from '@guardian/image-rendering';
 import { none, some } from '@guardian/types/option';
 import { Design, Display, Format } from '@guardian/types/Format';
 import { renderToStaticMarkup } from 'react-dom/server';

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -12,7 +12,7 @@ import {
 	QuizAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import { BodyImage, FigCaption }  from '@guardian/image-rendering';
+import { BodyImage, FigCaption } from '@guardian/image-rendering';
 import { palette, remSpace } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
 import type { Breakpoint } from '@guardian/src-foundations/mq';

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -12,8 +12,7 @@ import {
 	QuizAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import BodyImage from '@guardian/image-rendering/src/components/bodyImage';
-import FigCaption from '@guardian/image-rendering/src/components/figCaption';
+import { BodyImage, FigCaption }  from '@guardian/image-rendering';
 import { palette, remSpace } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
 import type { Breakpoint } from '@guardian/src-foundations/mq';


### PR DESCRIPTION
## Why are you doing this?

Image-rendering has provided nicer exports via an `index.ts` file for [a while](https://github.com/guardian/image-rendering/pull/74). This PR stops reaching into the `src` directory and switches to using these exports directly.

## Changes

- Used top-level exports from image-rendering index file
