### PR TITLE
Twitter DNT

### DIFF
--- a/src/components/meta.tsx
+++ b/src/components/meta.tsx
@@ -15,6 +15,7 @@ const Meta: FC<Props> = ({ title, cspString }) => (
 		<meta charSet="utf-8" />
 		<title>{title}</title>
 		<meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
+		<meta name="twitter:dnt" content="on" />
 		<meta name="viewport" content="initial-scale=1, maximum-scale=1" />
 		<meta name="description" content={title} />
 		<meta httpEquiv="Content-Security-Policy" content={cspString} />


### PR DESCRIPTION
## Why are you doing this?

To ask Twitter widgets not to track users, as documented by Twitter [here](https://developer.twitter.com/en/docs/twitter-for-websites/privacy).

## Changes

- Add DNT `<meta>` tag for Twitter
