### PR TITLE
Migrated To Image-Rendering For Image Sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1702,15 +1702,15 @@
       }
     },
     "@guardian/image-rendering": {
-      "version": "github:guardian/image-rendering#18212e5bb2059f278f99254996a5698446a44b30",
-      "from": "github:guardian/image-rendering#semver:^4.0.1",
+      "version": "github:guardian/image-rendering#d704d4aaeeeed22b6d85f64f658eeff7f35b7cc6",
+      "from": "github:guardian/image-rendering#semver:^4.1.0",
       "requires": {
         "@emotion/core": "^10.1.1",
-        "@guardian/src-foundations": "^2.6.0",
-        "@guardian/types": "github:guardian/types#7c57081d48d517392e4eb7492ece393076fbeaf1",
+        "@guardian/src-foundations": "^2.7.1",
+        "@guardian/types": "github:guardian/types#semver:^1.0.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "typescript": "^4.0.5"
+        "typescript": "^4.1.2"
       },
       "dependencies": {
         "@guardian/src-foundations": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@guardian/content-api-models": "^15.9.6",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^3.2.1",
-    "@guardian/image-rendering": "github:guardian/image-rendering#semver:^4.0.1",
+    "@guardian/image-rendering": "github:guardian/image-rendering#semver:^4.1.0",
     "@guardian/node-riffraff-artifact": "^0.1.9",
     "@guardian/src-brand": "^2.6.0",
     "@guardian/src-button": "^2.5.0",

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -1,12 +1,11 @@
 // ----- Imports ----- //
 
 import type { Content } from '@guardian/content-api-models/v1/content';
-import { Role } from '@guardian/image-rendering';
+import { Dpr, Role, src, srcsetWithWidths } from '@guardian/image-rendering';
 import type { Option } from '@guardian/types';
 import { fromNullable, map, none } from '@guardian/types';
 import { articleContributors } from 'capi';
 import type { Image } from 'image';
-import { Dpr, src, srcsetWithWidths } from 'image';
 import { pipe2 } from 'lib';
 
 // ------ Types ----- //

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -2,7 +2,7 @@
 
 import { JSDOM } from 'jsdom';
 
-import { Dpr, parseImage, Image, srcset } from 'image';
+import { parseImage, Image } from 'image';
 import { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import { AssetType } from '@guardian/content-api-models/v1/assetType';
@@ -86,23 +86,5 @@ describe('image', () => {
 				withDefault(''),
 			),
 		).toBe('');
-	});
-
-	test('show lower quality when DPR is 2', () => {
-		const src = srcset(
-			'https://media.guim.co.uk/img/media/948ad0a2ebe6d931d8827ea89ac184986af76c1b/0_22_1313_788/master/1313.jpg',
-			'',
-			Dpr.Two,
-		);
-		expect(src).toContain('quality=45');
-	});
-
-	test('show higher quality when DPR is 1', () => {
-		const src = srcset(
-			'https://media.guim.co.uk/img/media/948ad0a2ebe6d931d8827ea89ac184986af76c1b/0_22_1313_788/master/1313.jpg',
-			'',
-			Dpr.One,
-		);
-		expect(src).toContain('quality=85');
 	});
 });

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,45 +1,16 @@
 // ----- Imports ----- //
 
-import { createHash } from 'crypto';
 import type { Image as CardImage } from '@guardian/apps-rendering-api-models/image';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import type { Image as ImageData } from '@guardian/image-rendering';
-import { Role } from '@guardian/image-rendering';
-import type { Format, Option, Result } from '@guardian/types';
-import {
-	andThen,
-	fromNullable,
-	fromUnsafe,
-	map,
-	none,
-	ResultKind,
-	some,
-} from '@guardian/types';
+import { Dpr, Role, src, srcsets } from '@guardian/image-rendering';
+import type { Format, Option } from '@guardian/types';
+import { andThen, fromNullable, map, none, some } from '@guardian/types';
 import { pipe2 } from 'lib';
 import type { ReactNode } from 'react';
 import type { Context } from 'types/parserContext';
 
-// ----- Setup ----- //
-
-const imageResizer = 'https://i.guim.co.uk/img';
-
-const defaultWidths = [140, 500, 1000, 1500, 2000];
-
-// Percentage.
-const defaultQuality = 85;
-const lowerQuality = 45;
-
 // ----- Types ----- //
-
-const enum Dpr {
-	One,
-	Two,
-}
-
-interface Srcsets {
-	srcset: string;
-	dpr2Srcset: string;
-}
 
 interface Image extends ImageData {
 	caption: Option<DocumentFragment>;
@@ -54,63 +25,6 @@ interface BodyImageProps {
 }
 
 // ----- Functions ----- //
-
-const getSubdomain = (domain: string): string => domain.split('.')[0];
-
-const sign = (salt: string, path: string): string =>
-	createHash('md5')
-		.update(salt + path)
-		.digest('hex');
-
-function src(salt: string, input: string, width: number, dpr: Dpr): string {
-	const maybeUrl: Result<string, URL> = fromUnsafe(
-		() => new URL(input),
-		'invalid url',
-	);
-
-	switch (maybeUrl.kind) {
-		case ResultKind.Ok: {
-			const url = maybeUrl.value;
-			const service = getSubdomain(url.hostname);
-
-			const params = new URLSearchParams({
-				width: width.toString(),
-				quality:
-					dpr === Dpr.Two
-						? lowerQuality.toString()
-						: defaultQuality.toString(),
-				fit: 'bounds',
-			});
-
-			const path = `${url.pathname}?${params.toString()}`;
-			const sig = sign(salt, path);
-
-			return `${imageResizer}/${service}${path}&s=${sig}`;
-		}
-		case ResultKind.Err:
-		default: {
-			return input;
-		}
-	}
-}
-
-const srcsetWithWidths = (widths: number[]) => (
-	url: string,
-	salt: string,
-	dpr: Dpr,
-): string =>
-	widths.map((width) => `${src(salt, url, width, dpr)} ${width}w`).join(', ');
-
-const srcset: (
-	url: string,
-	salt: string,
-	dpr: Dpr,
-) => string = srcsetWithWidths(defaultWidths);
-
-const srcsets = (url: string, salt: string): Srcsets => ({
-	srcset: srcset(url, salt, Dpr.One),
-	dpr2Srcset: srcset(url, salt, Dpr.Two),
-});
 
 const parseCredit = (
 	displayCredit: boolean | undefined,
@@ -192,14 +106,4 @@ const parseCardImage = (
 
 // ----- Exports ----- //
 
-export {
-	Image,
-	Dpr,
-	src,
-	srcset,
-	srcsetWithWidths,
-	sign,
-	parseImage,
-	parseCardImage,
-	BodyImageProps,
-};
+export { Image, parseImage, parseCardImage, BodyImageProps };


### PR DESCRIPTION
## Why are you doing this?

We've moved the code to generate image sources upstream to Image-Rendering. See https://github.com/guardian/image-rendering/pull/152 for more details.

FYI @paperboyo

## Changes

- Updated image-rendering to `v4.1.0`
- Removed code to generate image sources from `image.ts`
- Updated imports to use new types and functions for image sources
