### PR TITLE
LIVE-1250: Split out AR and ER renderers

### DIFF
--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -49,6 +49,11 @@ const enum ElementKind {
 	QuizAtom,
 }
 
+type Text = {
+	kind: ElementKind.Text;
+	doc: DocumentFragment;
+};
+
 type Image = ImageData & {
 	kind: ElementKind.Image;
 };
@@ -65,6 +70,17 @@ type Video = {
 	src: string;
 	height: string;
 	width: string;
+};
+
+type Embed = {
+	kind: ElementKind.Embed;
+	html: string;
+	alt: Option<string>;
+};
+
+type Instagram = {
+	kind: ElementKind.Instagram;
+	html: string;
 };
 
 type MediaKind = ElementKind.Audio | ElementKind.Video;
@@ -143,10 +159,7 @@ interface QuizAtom {
 }
 
 type BodyElement =
-	| {
-			kind: ElementKind.Text;
-			doc: DocumentFragment;
-	  }
+	| Text
 	| Image
 	| {
 			kind: ElementKind.Pullquote;
@@ -167,16 +180,9 @@ type BodyElement =
 			kind: ElementKind.Tweet;
 			content: NodeList;
 	  }
-	| {
-			kind: ElementKind.Instagram;
-			html: string;
-	  }
+	| Instagram
 	| Audio
-	| {
-			kind: ElementKind.Embed;
-			html: string;
-			alt: Option<string>;
-	  }
+	| Embed
 	| {
 			kind: ElementKind.Callout;
 			id: string;
@@ -445,4 +451,23 @@ const parseElements = (
 
 // ----- Exports ----- //
 
-export { ElementKind, BodyElement, Audio, Video, Body, parseElements };
+export {
+	ElementKind,
+	BodyElement,
+	Audio,
+	Video,
+	Body,
+	Image,
+	Text,
+	Embed,
+	Instagram,
+	GuideAtom,
+	InteractiveAtom,
+	MediaAtom,
+	QandaAtom,
+	ProfileAtom,
+	TimelineAtom,
+	AudioAtom,
+	QuizAtom,
+	parseElements,
+};

--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -12,7 +12,7 @@ import Series from 'components/editions/series';
 import Standfirst from 'components/editions/standfirst';
 import type { Item } from 'item';
 import type { FC } from 'react';
-import { renderAll } from 'renderer';
+import { renderEditionsAll } from 'renderer';
 
 // ----- Component ----- //
 
@@ -46,7 +46,7 @@ const Article: FC<Props> = ({ item }) => {
 					<Byline item={item} />
 				</header>
 				<section css={bodyStyles}>
-					{renderAll(item, partition(item.body).oks)}
+					{renderEditionsAll(item, partition(item.body).oks)}
 				</section>
 			</article>
 		</main>

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -1,5 +1,6 @@
 import {
 	renderAll,
+	renderEditionsAll,
 	renderAllWithoutStyles,
 	renderStandfirstText,
 	renderText,
@@ -191,6 +192,9 @@ const audioAtom = (): BodyElement => ({
 
 const render = (element: BodyElement): ReactNode[] =>
 	renderAll(mockFormat, [element]);
+
+const renderEditions = (element: BodyElement): ReactNode[] =>
+	renderEditionsAll(mockFormat, [element]);
 
 const renderWithoutStyles = (element: BodyElement): ReactNode[] =>
 	renderAllWithoutStyles(mockFormat, [element]);
@@ -420,6 +424,203 @@ describe('Renders different types of elements', () => {
 
 	test('ElementKind.AudioAtom', () => {
 		const nodes = render(audioAtom());
+		const audio = nodes.flat()[0];
+		const html = getHtml(audio);
+		expect(html).toContain(
+			'<div kind="20" title="title" id="" trackUrl="trackUrl" kicker="kicker" pillar="0"',
+		);
+	});
+
+	function testHandlers(node: ReactNode): void {
+		if (isValidElement(node)) {
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			act(() => {
+				renderDom(node, container);
+			});
+
+			const likeButton = container.querySelector('[data-testid="like"]');
+			const dislikeButton = container.querySelector(
+				'[data-testid="dislike"]',
+			);
+			const feedback = container.querySelector(
+				'[data-testid="feedback"]',
+			);
+			expect(feedback?.getAttribute('hidden')).toBe('');
+
+			act(() => {
+				dislikeButton!.dispatchEvent(
+					new MouseEvent('click', { bubbles: true }),
+				);
+			});
+			act(() => {
+				likeButton!.dispatchEvent(
+					new MouseEvent('click', { bubbles: true }),
+				);
+			});
+
+			expect(feedback?.getAttribute('hidden')).toBeNull();
+			unmountComponentAtNode(container);
+			container.remove();
+		}
+	}
+});
+
+describe('Renders different types of Editions elements', () => {
+	test('ElementKind.Image', () => {
+		const nodes = renderEditions(imageElement());
+		const bodyImage = nodes.flat()[0];
+		expect(getHtml(bodyImage)).toContain('img');
+		expect(getHtml(bodyImage)).toContain('figcaption');
+		expect(getHtml(bodyImage)).toContain('caption="caption"');
+		expect(getHtml(bodyImage)).toContain('credit="credit"');
+	});
+
+	test('ElementKind.Image with thumbnail role', () => {
+		const nodes = renderEditions(imageElementWithRole());
+		const bodyImage = nodes.flat()[0];
+		expect(getHtml(bodyImage)).toContain('img');
+	});
+
+	test('ElementKind.Pullquote', () => {
+		const nodes = renderEditions(pullquoteElement());
+		const pullquote = nodes.flat()[0];
+		expect(getHtml(pullquote)).toContain('quote');
+		expect(getHtml(pullquote)).not.toContain('attribution');
+	});
+
+	test('ElementKind.Pullquote with attribution', () => {
+		const nodes = renderEditions(pullquoteWithAttributionElement());
+		const pullquote = nodes.flat()[0];
+		expect(getHtml(pullquote)).toContain('attribution');
+		expect(getHtml(pullquote)).toContain('quote');
+	});
+
+	test('ElementKind.RichLink', () => {
+		const nodes = renderEditions(richLinkElement());
+		const richLink = nodes.flat()[0];
+		expect(getHtml(richLink)).toContain(
+			'<h1>this links to a related article</h1>',
+		);
+		expect(getHtml(richLink)).toContain('href="https://theguardian.com"');
+	});
+
+	test('ElementKind.Interactive', () => {
+		const nodes = renderEditions(interactiveElement());
+		const interactive = nodes.flat()[0];
+		expect(getHtml(interactive)).toContain(
+			'<iframe src="https://theguardian.com" height="500" title=""></iframe>',
+		);
+	});
+
+	test('ElementKind.Tweet', () => {
+		const nodes = renderEditions(tweetElement());
+		const tweet = nodes.flat()[0];
+		expect(getHtml(tweet)).toContain('twitter-tweet');
+	});
+
+	test('ElementKind.Instagram', () => {
+		const nodes = renderEditions(instagramElement());
+		const instagram = nodes.flat()[0];
+		expect(getHtml(instagram)).toBe(
+			'<div><blockquote>Instagram</blockquote></div>',
+		);
+	});
+
+	test('ElementKind.Embed', () => {
+		const nodes = renderEditions(embedElement());
+		const embed = nodes.flat()[0];
+		expect(getHtml(embed)).toContain('<div><section>Embed</section></div>');
+	});
+
+	test('ElementKind.Audio', () => {
+		const nodes = renderEditions(audioElement());
+		const audio = nodes.flat()[0];
+		expect(getHtml(audio)).toContain(
+			'src="https://www.spotify.com/" sandbox="allow-scripts" height="300" width="500" title="Audio element"',
+		);
+	});
+
+	test('ElementKind.Video', () => {
+		const nodes = renderEditions(videoElement());
+		const video = nodes.flat()[0];
+		expect(getHtml(video)).toContain(
+			'src="https://www.youtube.com/" height="300" width="500" allowfullscreen="" title="Video element"',
+		);
+	});
+
+	test('ElementKind.LiveEvent', () => {
+		const nodes = renderEditions(liveEventElement());
+		const liveEvent = nodes.flat()[0];
+		expect(getHtml(liveEvent)).toContain(
+			'<h1>this links to a live event</h1>',
+		);
+	});
+
+	test('ElementKind.InteractiveAtom', () => {
+		const nodes = renderEditions(atomElement());
+		const atom = nodes.flat()[0];
+		expect(getHtml(atom)).toContain('main { background: yellow; }');
+		expect(getHtml(atom)).toContain('console.log(&#x27;init&#x27;)');
+		expect(getHtml(atom)).toContain('Some content');
+	});
+
+	test('ElementKind.ExplainerAtom', () => {
+		const nodes = renderEditions(explainerElement());
+		const explainer = nodes.flat()[0];
+		expect(getHtml(explainer)).toContain('<main>Explainer content</main>');
+	});
+
+	test('ElementKind.GuideAtom', () => {
+		const nodes = renderEditions(guideElement());
+		const guide = nodes.flat()[0];
+		expect(getHtml(guide)).toContain('<main>Guide content</main>');
+		testHandlers(guide);
+	});
+
+	test('ElementKind.QandaAtom', () => {
+		const nodes = renderEditions(qandaElement());
+		const qanda = nodes.flat()[0];
+		expect(getHtml(qanda)).toContain('<main>QandA content</main>');
+		testHandlers(qanda);
+	});
+
+	test('ElementKind.ProfileAtom', () => {
+		const nodes = renderEditions(profileElement());
+		const profile = nodes.flat()[0];
+		expect(getHtml(profile)).toContain('<main>Profile content</main>');
+		testHandlers(profile);
+	});
+
+	test('ElementKind.TimelineAtom', () => {
+		const nodes = renderEditions(timelineElement());
+		const timeline = nodes.flat()[0];
+		expect(getHtml(timeline)).toContain(
+			'<p>Swedish prosecutors announce they are <a href="https://www.theguardian.com/media/2019/may/13/sweden-reopens-case-against-julian-assange">reopening an investigation into a rape allegation</a> against Julian Assange.</p><p><br></p>',
+		);
+		testHandlers(timeline);
+	});
+
+	test('ElementKind.ChartAtom', () => {
+		const nodes = renderEditions(chartElement());
+		const chart = nodes.flat()[0];
+		expect(getHtml(chart)).toContain(
+			'srcDoc="&lt;main&gt;Chart content&lt;/main&gt;"',
+		);
+	});
+
+	test('ElementKind.QuizAtom', () => {
+		const nodes = renderEditions(quizAtom());
+		const quiz = nodes.flat()[0];
+		const html = getHtml(quiz);
+		expect(html).toContain('<div class="js-quiz">');
+		expect(html).toContain(
+			'<script class="js-quiz-params" type="application/json">',
+		);
+	});
+
+	test('ElementKind.AudioAtom', () => {
+		const nodes = renderEditions(audioAtom());
 		const audio = nodes.flat()[0];
 		const html = getHtml(audio);
 		expect(html).toContain(

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -792,8 +792,105 @@ const render = (format: Format, excludeStyles = false) => (
 	}
 };
 
+const renderEditions = (format: Format, excludeStyles = false) => (
+	element: BodyElement,
+	key: number,
+): ReactNode => {
+	switch (element.kind) {
+		case ElementKind.Text:
+			return textRenderer(format, excludeStyles, element);
+
+		case ElementKind.Image:
+			return imageRenderer(format, element, key);
+
+		case ElementKind.Pullquote: {
+			const { quote, attribution } = element;
+			return h(Pullquote, { quote, attribution, format, key });
+		}
+
+		case ElementKind.RichLink: {
+			const { url, linkText } = element;
+			return h(RichLink, { url, linkText, key, format });
+		}
+
+		case ElementKind.LiveEvent: {
+			return h(LiveEventLink, { ...element, key });
+		}
+
+		case ElementKind.Interactive:
+			return h(Interactive, {
+				url: element.url,
+				key,
+				title: element.alt,
+			});
+
+		case ElementKind.Tweet:
+			return h(Tweet, { content: element.content, format, key });
+
+		case ElementKind.Audio:
+			return h(Audio, {
+				src: element.src,
+				width: element.width,
+				height: element.height,
+			});
+
+		case ElementKind.Video:
+			return h(Video, {
+				src: element.src,
+				width: element.width,
+				height: element.height,
+			});
+
+		case ElementKind.Callout: {
+			const { campaign, description } = element;
+			return h(CalloutForm, { campaign, format, description });
+		}
+
+		case ElementKind.Embed:
+			return embedRenderer(element);
+
+		case ElementKind.Instagram:
+			return instagramRenderer(element);
+
+		case ElementKind.ExplainerAtom: {
+			return h(ExplainerAtom, { ...element });
+		}
+
+		case ElementKind.GuideAtom:
+			return guideAtomRenderer(format, element);
+
+		case ElementKind.QandaAtom:
+			return qandaAtomRenderer(format, element);
+
+		case ElementKind.ProfileAtom:
+			return profileAtomRenderer(format, element);
+
+		case ElementKind.TimelineAtom:
+			return timelineAtomRenderer(format, element);
+
+		case ElementKind.ChartAtom: {
+			return h(ChartAtom, { ...element });
+		}
+
+		case ElementKind.InteractiveAtom:
+			return interactiveAtomRenderer(format, element);
+
+		case ElementKind.MediaAtom:
+			return mediaAtomRenderer(format, element);
+
+		case ElementKind.AudioAtom:
+			return audioAtomRenderer(format, element);
+
+		case ElementKind.QuizAtom:
+			return quizAtomRenderer(format, element);
+	}
+};
+
 const renderAll = (format: Format, elements: BodyElement[]): ReactNode[] =>
 	elements.map(render(format));
+
+const renderEditionsAll = (format: Format, elements: BodyElement[]): ReactNode[] =>
+	elements.map(renderEditions(format));
 
 const renderAllWithoutStyles = (
 	format: Format,
@@ -804,6 +901,7 @@ const renderAllWithoutStyles = (
 
 export {
 	renderAll,
+	renderEditionsAll,
 	renderAllWithoutStyles,
 	text as renderText,
 	textElement as renderTextElement,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -813,9 +813,8 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 			return h(RichLink, { url, linkText, key, format });
 		}
 
-		case ElementKind.LiveEvent: {
+		case ElementKind.LiveEvent:
 			return h(LiveEventLink, { ...element, key });
-		}
 
 		case ElementKind.Interactive:
 			return h(Interactive, {
@@ -852,9 +851,8 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 		case ElementKind.Instagram:
 			return instagramRenderer(element);
 
-		case ElementKind.ExplainerAtom: {
+		case ElementKind.ExplainerAtom:
 			return h(ExplainerAtom, { ...element });
-		}
 
 		case ElementKind.GuideAtom:
 			return guideAtomRenderer(format, element);
@@ -868,9 +866,8 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 		case ElementKind.TimelineAtom:
 			return timelineAtomRenderer(format, element);
 
-		case ElementKind.ChartAtom: {
+		case ElementKind.ChartAtom:
 			return h(ChartAtom, { ...element });
-		}
 
 		case ElementKind.InteractiveAtom:
 			return interactiveAtomRenderer(format, element);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -32,19 +32,19 @@ import {
 import type { Format, Option, Result } from '@guardian/types';
 import { ElementKind } from 'bodyElement';
 import type {
+	AudioAtom as AudioAtomElement,
 	BodyElement,
-	Image,
-	Text,
 	Embed,
-	Instagram,
 	GuideAtom as GuideAtomElement,
+	Image,
+	Instagram,
 	InteractiveAtom as InteractiveAtomElement,
 	MediaAtom as MediaAtomElement,
-	QandaAtom as QandaAtomElement,
 	ProfileAtom as ProfileAtomElement,
-	TimelineAtom as TimelineAtomElement,
-	AudioAtom as AudioAtomElement,
+	QandaAtom as QandaAtomElement,
 	QuizAtom as QuizAtomElement,
+	Text,
+	TimelineAtom as TimelineAtomElement,
 } from 'bodyElement';
 import Anchor from 'components/anchor';
 import InteractiveAtom, {
@@ -889,8 +889,10 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 const renderAll = (format: Format, elements: BodyElement[]): ReactNode[] =>
 	elements.map(render(format));
 
-const renderEditionsAll = (format: Format, elements: BodyElement[]): ReactNode[] =>
-	elements.map(renderEditions(format));
+const renderEditionsAll = (
+	format: Format,
+	elements: BodyElement[],
+): ReactNode[] => elements.map(renderEditions(format));
 
 const renderAllWithoutStyles = (
 	format: Format,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -67,7 +67,6 @@ import { createElement as h } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles, themeFromString, themeToPillar } from 'themeStyles';
-import { Bool } from 'aws-sdk/clients/clouddirectory';
 
 // ----- Renderer ----- //
 


### PR DESCRIPTION
## Why are you doing this?

We use a `render` function to render blocks, now that some designs will diverge for ER (pullquote for example). We need two separate renderers, however a lot of the element renderers have been refactored out so we don't have to duplicate their code if the element is the same.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- Refactor out element renderers that are > 1 line
- Created `renderEditions` and `renderEditionsAll`
- typed three elements: `Text`, `Embed` and `Instagram`

