### PR TITLE
LIVE-1282: Editions-Rendering CSP

### DIFF
--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -138,4 +138,4 @@ function csp(
 
 // ----- Exports ----- //
 
-export { csp, assetHashes };
+export { csp, assetHashes, buildCsp };

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -134,19 +134,13 @@ function cspEditions(
 			: ''
 	};
     script-src 'self' ${
-		thirdPartyEmbed.instagram ? 'http://www.instagram.com/embed.js' : ''
-	} https://interactive.guim.co.uk https://s16.tiktokcdn.com https://www.tiktok.com/embed.js https://sf16-scmcdn-sg.ibytedtos.com/ ${
 		thirdPartyEmbed.twitter
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-    frame-src https://www.theguardian.com https://www.scribd.com ${
-		thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''
-	} https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
-		thirdPartyEmbed.spotify ? 'https://open.spotify.com' : ''
-	} ${
+    frame-src https://www.theguardian.com ${
 		thirdPartyEmbed.youtube ? 'https://www.youtube-nocookie.com' : ''
-	} https://player.vimeo.com/ ${
+	} ${
 		thirdPartyEmbed.twitter
 			? 'https://platform.twitter.com https://syndication.twitter.com https://twitter.com'
 			: ''

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -121,6 +121,39 @@ const buildCsp = (
     media-src 'self' https://audio.guim.co.uk/
 `.trim();
 
+function cspEditions(
+	{ styles }: Assets,
+	thirdPartyEmbed: ThirdPartyEmbeds,
+): string {
+	return `
+	default-src 'self';
+	style-src 'self' ${assetHashes(styles)};
+	img-src 'self' https://static.theguardian.com https://*.guim.co.uk ${
+		thirdPartyEmbed.twitter
+			? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:'
+			: ''
+	};
+    script-src 'self' ${
+		thirdPartyEmbed.instagram ? 'http://www.instagram.com/embed.js' : ''
+	} https://interactive.guim.co.uk https://s16.tiktokcdn.com https://www.tiktok.com/embed.js https://sf16-scmcdn-sg.ibytedtos.com/ ${
+		thirdPartyEmbed.twitter
+			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
+			: ''
+	};
+    frame-src https://www.theguardian.com https://www.scribd.com ${
+		thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''
+	} https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
+		thirdPartyEmbed.spotify ? 'https://open.spotify.com' : ''
+	} ${
+		thirdPartyEmbed.youtube ? 'https://www.youtube-nocookie.com' : ''
+	} https://player.vimeo.com/ ${
+		thirdPartyEmbed.twitter
+			? 'https://platform.twitter.com https://syndication.twitter.com https://twitter.com'
+			: ''
+	};
+	`;
+}
+
 function csp(
 	item: Item,
 	additionalAssets: Assets,
@@ -138,4 +171,4 @@ function csp(
 
 // ----- Exports ----- //
 
-export { csp, assetHashes, buildCsp };
+export { assetHashes, csp, cspEditions };

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -45,7 +45,6 @@ const renderHead = (
 	itemStyles: string,
 	emotionIds: string[],
 ): string => {
-
 	const cspString = cspEditions(
 		{ scripts: [], styles: [styles, itemStyles] },
 		thirdPartyEmbeds,

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -60,7 +60,7 @@ const renderHead = (
 		<meta charSet="utf-8" />
 		<title>${request.content.webTitle}</title>
 		<meta name="viewport" content="initial-scale=1" />
-		<meta httpEquiv="Content-Security-Policy" content="${cspString}" />
+		<meta http-equiv="Content-Security-Policy" content="${cspString}" />
         <style>${generalStyles}</style>
         <style data-emotion-css="${emotionIds.join(' ')}">${itemStyles}</style>
     `;

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -4,6 +4,8 @@ import { CacheProvider } from '@emotion/core';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import type { Option } from '@guardian/types';
 import { none } from '@guardian/types';
+import { getThirdPartyEmbeds, requiresInlineStyles } from 'capi';
+import type { ThirdPartyEmbeds } from 'capi';
 import Article from 'components/editions/article';
 import type { EmotionCritical } from 'create-emotion-server';
 import { cache } from 'emotion';
@@ -15,8 +17,6 @@ import { compose } from 'lib';
 import { renderToString } from 'react-dom/server';
 import { buildCsp } from 'server/csp';
 import { pageFonts } from 'styles';
-import { getThirdPartyEmbeds, requiresInlineStyles } from 'capi';
-import type { ThirdPartyEmbeds } from 'capi';
 
 // ----- Types ----- //
 
@@ -64,7 +64,7 @@ const renderHead = (
         <style>${generalStyles}</style>
         <style data-emotion-css="${emotionIds.join(' ')}">${itemStyles}</style>
     `;
-}
+};
 
 const renderBody = (item: Item): EmotionCritical =>
 	compose(
@@ -92,7 +92,13 @@ const buildHtml = (head: string, body: string): string => `
 function render(imageSalt: string, request: RenderingRequest): Page {
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
 	const body = renderBody(item);
-	const head = renderHead(request, getThirdPartyEmbeds(request.content), body.css, body.ids, requiresInlineStyles(request.content))
+	const head = renderHead(
+		request,
+		getThirdPartyEmbeds(request.content),
+		body.css,
+		body.ids,
+		requiresInlineStyles(request.content),
+	);
 
 	return {
 		html: buildHtml(head, body.html),


### PR DESCRIPTION
## Why are you doing this?

The CSP is somewhat broken on editions-rendering. The inline styles weren't working and embeds (like YouTube for example) were also broken. I have decided to get inspired by the way it works on AR and use a similar but custom function to render ER's head. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- Change CSP generation
- upgraded `renderHead`

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/12860328/102203022-f715aa80-3ebf-11eb-9fd9-b4f77dbc8af9.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/12860328/102203056-03016c80-3ec0-11eb-8873-d658290ddadf.png" width="300px" /> |
