### PR TITLE
Disable "unsafe-inline"

### DIFF
--- a/src/capi.ts
+++ b/src/capi.ts
@@ -145,12 +145,13 @@ const getThirdPartyEmbeds = (content: Content): ThirdPartyEmbeds => {
 };
 
 const requiresInlineStyles = (content: Content): boolean => {
-	return !!(
-		content.fields?.commentable ??
-		content.atoms?.quizzes ??
-		content.atoms?.audios ??
-		content.atoms?.charts
-	);
+	// return !!(
+	//	   content.fields?.commentable ??
+	//	   content.atoms?.quizzes ??
+	//	   content.atoms?.audios ??
+	//	   content.atoms?.charts
+	// );
+	return false;
 };
 
 const paidContentLogo = (tags: Tag[]): Option<Logo> => {


### PR DESCRIPTION
## Why are you doing this?

We would like to avoid `unsafe-inline`, it [sidesteps most of](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#Unsafe_inline_styles) the security benefits provided by the CSP.

## Changes

- Disable `unsafe-inline` by hardcoding `requiresInlineStyles` to `false`
