### PR TITLE
LIVE: 1249-Header Image Football Scores component 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1828,7 +1828,7 @@
       "requires": {
         "@emotion/core": "^10.1.1",
         "@guardian/src-foundations": "^2.7.1",
-        "@guardian/types": "github:guardian/types#7c57081d48d517392e4eb7492ece393076fbeaf1",
+        "@guardian/types": "github:guardian/types#semver:^1.0.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "typescript": "^4.1.2"

--- a/src/components/editions/headerImage.tsx
+++ b/src/components/editions/headerImage.tsx
@@ -20,7 +20,7 @@ const styles = css`
 		bottom: 0;
 		left: 0;
 		${body.medium({ fontWeight: 'regular' })};
-		padding: 0px 5px 3px 5px;
+		padding: 0px ${remSpace[1]} ${remSpace[1]} ${remSpace[1]};
 	}
 `;
 

--- a/src/components/editions/headerImage.tsx
+++ b/src/components/editions/headerImage.tsx
@@ -1,7 +1,8 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/core';
-import { remSpace } from '@guardian/src-foundations';
+import { brandAltBackground, remSpace } from '@guardian/src-foundations';
+import { body } from '@guardian/src-foundations/typography';
 import Img from 'components/img';
 import { MainMediaKind } from 'headerMedia';
 import type { Item } from 'item';
@@ -12,6 +13,15 @@ import type { FC } from 'react';
 
 const styles = css`
 	margin: 0;
+	position: relative;
+	div {
+		background-color: ${brandAltBackground.primary};
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		${body.medium({ fontWeight: 'regular' })};
+		padding: 0px 5px 3px 5px;
+	}
 `;
 
 const imgStyles = css`
@@ -34,6 +44,7 @@ const HeaderImage: FC<Props> = ({ item }) =>
 						format={item}
 						className={imgStyles}
 					/>
+					<div>Man Utd 1 Arsenal 2</div>
 				</figure>
 			);
 		}


### PR DESCRIPTION
## Why are you doing this?

I have  opened this PR to get the ball rolling and provide platform for feedback.
I have begun by implementing the design.

Header Image Football Scores component - we need to display the match report scores and teams in the HeaderImage component. (https://theguardian.atlassian.net/browse/LIVE-1249)

- [x] Added a yellow background div to house score and teams
- [x] Used `${brandAltBackground.primary}` and `${body.medium({ fontWeight: 'regular' })};` for consistent styling
- [ ] Use the `maybeRender` function so the <div> and scores only show up on match reports
- [ ] Gets scores and teams from `mobile-sport`

**note** * I have temporarily added dummy scores and teams to test design
## Changes

Added a yellow background div to house score and teams
Used `${brandAltBackground.primary}` and `${body.medium({ fontWeight: 'regular' })};` for consistent styling

## Screenshots

| Target | Before | After |
| --- | --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/103642436-07fb8e00-4f4b-11eb-984e-9a8ef1e4b298.png" width="300px" /> | <img src="" width="300px" /> | <img src="" width="300px" /> |
