### PR TITLE
Disable user-scalable

### DIFF
--- a/src/components/meta.tsx
+++ b/src/components/meta.tsx
@@ -15,7 +15,7 @@ const Meta: FC<Props> = ({ title, cspString }) => (
 		<title>{title}</title>
 		<meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
 		<meta name="twitter:dnt" content="on" />
-		<meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+		<meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no"/>
 		<meta name="description" content={title} />
 		<meta httpEquiv="Content-Security-Policy" content={cspString} />
 	</>

--- a/src/components/meta.tsx
+++ b/src/components/meta.tsx
@@ -15,7 +15,10 @@ const Meta: FC<Props> = ({ title, cspString }) => (
 		<title>{title}</title>
 		<meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
 		<meta name="twitter:dnt" content="on" />
-		<meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no"/>
+		<meta
+			name="viewport"
+			content="initial-scale=1, maximum-scale=1, user-scalable=no"
+		/>
 		<meta name="description" content={title} />
 		<meta httpEquiv="Content-Security-Policy" content={cspString} />
 	</>

--- a/src/components/meta.tsx
+++ b/src/components/meta.tsx
@@ -15,7 +15,10 @@ const Meta: FC<Props> = ({ title, cspString }) => (
 		<title>{title}</title>
 		<meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
 		<meta name="twitter:dnt" content="on" />
-		<meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+		<meta
+			name="viewport"
+			content="initial-scale=1, maximum-scale=1, user-scalable=no"
+		/>
 		<meta name="description" content={title} />
 		<meta httpEquiv="Content-Security-Policy" content={cspString} />
 	</>

--- a/src/components/meta.tsx
+++ b/src/components/meta.tsx
@@ -15,10 +15,7 @@ const Meta: FC<Props> = ({ title, cspString }) => (
 		<title>{title}</title>
 		<meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
 		<meta name="twitter:dnt" content="on" />
-		<meta
-			name="viewport"
-			content="initial-scale=1, maximum-scale=1, user-scalable=no"
-		/>
+		<meta name="viewport" content="initial-scale=1, maximum-scale=1" />
 		<meta name="description" content={title} />
 		<meta httpEquiv="Content-Security-Policy" content={cspString} />
 	</>


### PR DESCRIPTION
Duplicate PR of [this PR](https://github.com/guardian/apps-rendering/pull/1066) because CI was unreasonable failing.

# Why are you doing this

There is bug in iOS with swiping the articles. It is not yet fully known if the behaviour is caused by the iOS app, apps-rendering or both. This change doesn't hurt our UX however as our apps default behaviour is not to allow users to zoom/pinch. As far as I understand, iOS doesn't allow this on iOS safari however it does allow it on WKWebView.

### Conversation from previous PR:
@JamieB-gu : Are there any a11y concerns with preventing users zooming in? Or are we already preventing zooming in by setting maximum-scale=1?
@faresite : The reason user-scalable=no causes accessibility issues is because the user can no longer help themselves to zoom and read for example, our app has its own mechanism to do this with the font-resizing with conjunction of Dynamic Type (iOS thingie). We don't let users zoom on our articles this way anyway.
The PR changes nothing user-facing experience. it's just a potential fix for the apps-rendering swiping bug (or part of the fix).