### PR TITLE
Test CI fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1839,6 +1839,20 @@
           "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-2.8.1.tgz",
           "integrity": "sha512-CFpmL8ZGYfBp0YdFR9MaZRL+PfbbZFTwV2k4r/0+9KXh4U/mhmQWjJ/75GvtuLc5K2HQK42kf0SMnqRnHL/s1A=="
         },
+        "@guardian/types": {
+          "version": "github:guardian/types#7c57081d48d517392e4eb7492ece393076fbeaf1",
+          "from": "github:guardian/types#7c57081d48d517392e4eb7492ece393076fbeaf1",
+          "requires": {
+            "typescript": "^3.8.3"
+          },
+          "dependencies": {
+            "typescript": {
+              "version": "3.9.7",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+              "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+            }
+          }
+        },
         "react": {
           "version": "16.14.0",
           "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
@@ -2076,18 +2090,8 @@
       }
     },
     "@guardian/types": {
-      "version": "github:guardian/types#7c57081d48d517392e4eb7492ece393076fbeaf1",
-      "from": "github:guardian/types#semver:^1.0.0",
-      "requires": {
-        "typescript": "^3.8.3"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.9.7",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
-        }
-      }
+      "version": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
+      "from": "github:guardian/types#semver:^1.0.0"
     },
     "@icons/material": {
       "version": "0.2.4",


### PR DESCRIPTION
## Why are you doing this?

CI is broken because of a peer dependency of image-rendering (@types/guardian). Updated package-lock.json to see if this fixes `npm ci`.
