### PR TITLE
Renamed Deprecated ts-jest Field

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
                 ],
                 plugins: [ '@emotion' ],
             },
-            tsConfig: "config/tsconfig.test.json",
+            tsconfig: "config/tsconfig.test.json",
         },
     },
     coverageThreshold: {


### PR DESCRIPTION
## Why are you doing this?

The `tsConfig` field has been renamed to `tsconfig`.

## Changes

- Renamed deprecated `ts-jest` field