### PR TITLE
Add Cache Action To Chromatic CI

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,7 +18,13 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: 12
-            - run: npm ci
+            - uses: actions/cache@v2
+              with:
+                  path: ~/.npm
+                  key: node-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: node-
+            - name: install
+              run: npm ci
             - uses: chromaui/action@v1
               with:
                   appCode: ${{ secrets.CHROMATIC_APP_CODE }}


### PR DESCRIPTION
## Why are you doing this?

Our other workflows (e.g. [nodejs](https://github.com/guardian/apps-rendering/blob/3ee405708fedbed4ce8bc799d86e6b419edc701c/.github/workflows/nodejs.yml) and [screenshots](https://github.com/guardian/apps-rendering/blob/3ee405708fedbed4ce8bc799d86e6b419edc701c/.github/workflows/screenshots.yml)) are using the [cache action](https://github.com/actions/cache) to cache npm dependencies.

**Note:** The chromatic workflow is currently failing on other PRs on the `npm ci` step. This is the only difference I can see between them so I thought I'd add it (because it's useful in general), but I don't see why it would fix the problem 🤔.

## Changes

- Add cache action to chromatic CI
