### PR TITLE
Bump guardian/types To v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1828,7 +1828,7 @@
       "requires": {
         "@emotion/core": "^10.1.1",
         "@guardian/src-foundations": "^2.7.1",
-        "@guardian/types": "github:guardian/types#7c57081d48d517392e4eb7492ece393076fbeaf1",
+        "@guardian/types": "github:guardian/types#semver:^1.1.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "typescript": "^4.1.3"
@@ -2076,15 +2076,8 @@
       }
     },
     "@guardian/types": {
-      "version": "github:guardian/types#7c57081d48d517392e4eb7492ece393076fbeaf1",
-      "from": "github:guardian/types#semver:^1.0.0",
-      "dependencies": {
-        "typescript": {
-          "version": "3.9.7",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
-        }
-      }
+      "version": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
+      "from": "github:guardian/types#semver:^1.1.0"
     },
     "@icons/material": {
       "version": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@guardian/src-svgs": "^2.8.1",
     "@guardian/src-text-area": "^2.8.1",
     "@guardian/src-text-input": "^2.7.1",
-    "@guardian/types": "github:guardian/types#semver:^1.0.0",
+    "@guardian/types": "github:guardian/types#semver:^1.1.0",
     "@types/jsdom": "^16.2.5",
     "@types/uuid": "^8.3.0",
     "@types/webpack-node-externals": "^2.5.0",


### PR DESCRIPTION
## Why are you doing this?

Keeps the dependency up-to-date and prevents compiler errors now that image-rendering is `v1.1.0`.

## Changes

- Bumped `@guardian/types` to `v1.1.0`
