### PR TITLE
LIVE-1370: camera caption icon fix

### DIFF
--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -17,11 +17,11 @@ const HeaderImageCaptionStyles = css`
 		text-align: center;
 		background-color: ${brandAlt[400]};
 		color: ${neutral[7]};
-		width: ${remSpace[9]};
-		height: ${remSpace[9]};
+		width: 34px;
+		height: 34px;
 		position: absolute;
-		bottom: ${remSpace[2]};
-		right: ${remSpace[2]};
+		bottom: 8px;
+		right: 8px;
 		border-radius: 100%;
 		outline: none;
 
@@ -66,9 +66,9 @@ const svgStyle = css`
 	line-height: 32px;
 	font-size: 0;
 	svg {
-		width: 24px;
-		height: 24px;
-		margin: 4px;
+		width: 75%;
+		height: 75%;
+		margin: 12.5%;
 	}
 `;
 


### PR DESCRIPTION
# The bug
there's currently a bug on prod where the styles of the icon container scale up with rem. The icon should stay the same.

@aoifemcl15 and I believe there's a good chance the icon is the culprit with the iOS swipe bug. Hoping this might shed some light on this too.

| before | after |
| ------ | ----- |
| <img src="https://user-images.githubusercontent.com/12860328/104446065-d2c9ee00-5591-11eb-982b-358473ece4c5.png" width="300" /> | <img src="https://user-images.githubusercontent.com/12860328/104446111-df4e4680-5591-11eb-935a-5f384f799a6a.png" width="300" /> |


