### PR TITLE
feat(editions-article): add article showcase header component

### DIFF
--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -1,19 +1,15 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/core';
-import { Lines } from '@guardian/src-ed-lines';
 import { remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { border } from '@guardian/src-foundations/palette';
 import { Design, partition } from '@guardian/types';
-import Byline from 'components/editions/byline';
-import HeaderImage from 'components/editions/headerImage';
-import Headline from 'components/editions/headline';
-import Series from 'components/editions/series';
-import Standfirst from 'components/editions/standfirst';
 import type { Item } from 'item';
 import type { FC } from 'react';
 import { renderEditionsAll } from 'renderer';
-import { articleWidthStyles } from 'styles';
+import { wideContentWidth } from 'styles';
+import Header from './header';
 
 // ----- Component ----- //
 
@@ -21,13 +17,18 @@ interface Props {
 	item: Item;
 }
 
-const headerStyles = css`
-	margin: 0 ${remSpace[3]} ${remSpace[4]};
-`;
-
 const bodyStyles = css`
 	border-top: 1px solid ${border.secondary};
-	padding: 0 ${remSpace[4]};
+	padding-top: ${remSpace[4]};
+
+	${from.wide} {
+		margin: 0 auto;
+	}
+
+	${from.phablet} {
+		margin-left: ${remSpace[24]};
+		width: ${wideContentWidth}px;
+	}
 `;
 
 const Article: FC<Props> = ({ item }) => {
@@ -38,15 +39,8 @@ const Article: FC<Props> = ({ item }) => {
 	return (
 		<main>
 			<article>
-				<header css={headerStyles}>
-					<HeaderImage item={item} />
-					<Series item={item} />
-					<Headline item={item} />
-					<Standfirst item={item} />
-					<Lines />
-					<Byline item={item} />
-				</header>
-				<section css={[articleWidthStyles, bodyStyles]}>
+				<Header item={item} />
+				<section css={[bodyStyles]}>
 					{renderEditionsAll(item, partition(item.body).oks)}
 				</section>
 			</article>

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/core';
+import { remSpace } from '@guardian/src-foundations';
 import { news } from '@guardian/src-foundations/palette';
 import { body } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
@@ -12,6 +13,7 @@ import type { FC } from 'react';
 const styles = css`
 	${body.medium({ fontStyle: 'normal', fontWeight: 'bold' })}
 	color: ${news[400]};
+	margin-bottom: ${remSpace[4]};
 `;
 
 interface Props {

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -1,0 +1,71 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/core';
+import { remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { Display } from '@guardian/types';
+import Byline from 'components/editions/byline';
+import HeaderImage from 'components/editions/headerImage';
+import Headline from 'components/editions/headline';
+import Lines from 'components/editions/lines';
+import Series from 'components/editions/series';
+import Standfirst from 'components/editions/standfirst';
+import type { Item } from 'item';
+import type { FC, ReactElement } from 'react';
+
+// ----- Component ----- //
+
+interface Props {
+	item: Item;
+}
+
+const headerStyles = css`
+	margin: 0;
+
+	${from.wide} {
+		margin: 0 auto;
+	}
+
+	${from.phablet} {
+		margin-left: ${remSpace[24]};
+	}
+`;
+
+const StandardHeader: FC<Props> = ({ item }) => (
+	<>
+		<HeaderImage item={item} />
+		<Series item={item} />
+		<Headline item={item} />
+		<Standfirst item={item} />
+		<Lines />
+		<Byline item={item} />
+	</>
+);
+
+const ShowcaseHeader: FC<Props> = ({ item }) => (
+	<>
+		<Series item={item} />
+		<Headline item={item} />
+		<HeaderImage item={item} />
+		<Standfirst item={item} />
+		<Lines />
+		<Byline item={item} />
+	</>
+);
+
+const renderArticleHeader = (item: Item): ReactElement<Props> => {
+	switch (item.display) {
+		case Display.Showcase:
+			return <ShowcaseHeader item={item} />;
+		default:
+			return <StandardHeader item={item} />;
+	}
+};
+
+const Header: FC<Props> = ({ item }: Props) => {
+	return <header css={headerStyles}>{renderArticleHeader(item)}</header>;
+};
+
+// ----- Exports ----- //
+
+export default Header;

--- a/src/components/editions/lines.tsx
+++ b/src/components/editions/lines.tsx
@@ -1,0 +1,25 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/core';
+import { Lines } from '@guardian/src-ed-lines';
+import { from } from '@guardian/src-foundations/mq';
+import type { FC } from 'react';
+import { wideContentWidth } from 'styles';
+
+// ----- Component ----- //
+
+const styles = css`
+	${from.phablet} {
+		width: ${wideContentWidth}px;
+	}
+`;
+
+const EditionsLines: FC = () => (
+	<div css={styles}>
+		<Lines />
+	</div>
+);
+
+// ----- Exports ----- //
+
+export default EditionsLines;

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -1,18 +1,38 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/core';
-import { remSpace } from '@guardian/src-foundations';
+import { remSpace, text } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { renderStandfirstText } from 'renderer';
+import { wideContentWidth } from 'styles';
 
 // ----- Component ----- //
 
 const styles = css`
 	${body.medium({ lineHeight: 'tight' })}
-	margin: ${remSpace[4]} 0 0;
+	margin-bottom: ${remSpace[6]};
+	color: ${text.primary};
+
+	${from.wide} {
+		margin: 0 auto;
+	}
+
+	${from.phablet} {
+		width: ${wideContentWidth}px;
+	}
+
+	p,
+	ul {
+		margin: ${remSpace[2]} 0;
+	}
+
+	address {
+		font-style: normal;
+	}
 `;
 
 interface Props {


### PR DESCRIPTION
## Why are you doing this?

Creates new `Header` component to contain switch for different article template options in `Editions/Article` component. 

## Changes

- adds `Header` component
- adds switch and subcomponents for individual layouts
- updates margins and widths to roughly match existing figma designs (aware these may well change after Ben's audit)
- creates editions specific `lines` component to control width

We still need to incorporate Fares` byline` updates and include line / outlines as in Figma.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/104594241-c82e5800-5668-11eb-8ebe-34acc1e2f54d.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/104594333-eac07100-5668-11eb-89a4-c8ff65139741.png" width="300px" /> |
