### PR TITLE
Add index Function

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import type { Option } from '@guardian/types';
-import { map, withDefault } from '@guardian/types';
+import { fromNullable, map, withDefault } from '@guardian/types';
 import type { ReactElement } from 'react';
 
 // ----- Functions ----- //
@@ -62,6 +62,10 @@ function handleErrors(response: Response): Response | never {
 	}
 	return response;
 }
+		
+const index = (i: number) => <A>(arr: A[]): Option<A> =>
+    fromNullable(arr[i]);
+		
 // ----- Exports ----- //
 
 export {
@@ -77,4 +81,5 @@ export {
 	isObject,
 	maybeRender,
 	handleErrors,
+	index,
 };


### PR DESCRIPTION
## Why are you doing this?

Useful for converting array lookups to `Option`s. If there's nothing at a given array index then JS will return `undefined`, but TS doesn't type it as such. See [this discussion](https://github.com/guardian/apps-rendering/pull/1031#discussion_r556731695) for a use in practice.

Opening as a Draft for now to gather feedback on whether people would find this useful.

## Changes

- Added an `index` utility function
