### PR TITLE
Lock @guardian/types to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1828,7 +1828,7 @@
       "requires": {
         "@emotion/core": "^10.1.1",
         "@guardian/src-foundations": "^2.7.1",
-        "@guardian/types": "github:guardian/types#semver:^1.1.0",
+        "@guardian/types": "github:guardian/types#semver:1.1.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "typescript": "^4.1.3"
@@ -2077,7 +2077,7 @@
     },
     "@guardian/types": {
       "version": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
-      "from": "github:guardian/types#semver:^1.1.0"
+      "from": "github:guardian/types#semver:1.1.0"
     },
     "@icons/material": {
       "version": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@guardian/src-svgs": "^2.8.1",
     "@guardian/src-text-area": "^2.8.1",
     "@guardian/src-text-input": "^2.7.1",
-    "@guardian/types": "github:guardian/types#semver:^1.1.0",
+    "@guardian/types": "github:guardian/types#semver:1.1.0",
     "@types/jsdom": "^16.2.5",
     "@types/uuid": "^8.3.0",
     "@types/webpack-node-externals": "^2.5.0",


### PR DESCRIPTION
NPM is ignoring semver ^ and pulling version 1.2.0 which currently has breaking changes for AR, and the version lock in  package-lock is also being ignored. To temporarily sidestep this, we are locking @guardian/types to 1.1.0 in the package.json