### PR TITLE
feat(editions-article): add border to header components

### DIFF
--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -8,14 +8,24 @@ import { Design, partition } from '@guardian/types';
 import type { Item } from 'item';
 import type { FC } from 'react';
 import { renderEditionsAll } from 'renderer';
-import { wideContentWidth } from 'styles';
 import Header from './header';
+import { editionsArticleWidth } from './styles';
 
 // ----- Component ----- //
 
 interface Props {
 	item: Item;
 }
+
+const articleStyles = css`
+	padding-left: ${remSpace[2]};
+	padding-right: ${remSpace[2]};
+
+	${from.phablet} {
+		padding-left: 0;
+		padding-right: 0;
+	}
+`;
 
 const bodyStyles = css`
 	border-top: 1px solid ${border.secondary};
@@ -27,7 +37,7 @@ const bodyStyles = css`
 
 	${from.phablet} {
 		margin-left: ${remSpace[24]};
-		width: ${wideContentWidth}px;
+		width: ${editionsArticleWidth}rem;
 	}
 `;
 
@@ -38,7 +48,7 @@ const Article: FC<Props> = ({ item }) => {
 
 	return (
 		<main>
-			<article>
+			<article css={articleStyles}>
 				<Header item={item} />
 				<section css={[bodyStyles]}>
 					{renderEditionsAll(item, partition(item.body).oks)}

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -2,18 +2,30 @@
 
 import { css } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
-import { news } from '@guardian/src-foundations/palette';
+import { from } from '@guardian/src-foundations/mq';
+import { border, news } from '@guardian/src-foundations/palette';
 import { body } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
+import { editionsArticleWidth } from './styles';
 
 // ----- Component ----- //
 
 const styles = css`
 	${body.medium({ fontStyle: 'normal', fontWeight: 'bold' })}
 	color: ${news[400]};
-	margin-bottom: ${remSpace[4]};
+	padding-bottom: ${remSpace[4]};
+	margin: 0 ${remSpace[1]} 0 0;
+
+	${from.wide} {
+		margin: 0 auto;
+	}
+
+	${from.phablet} {
+		border-right: 1px solid ${border.secondary};
+		width: ${editionsArticleWidth}rem;
+	}
 `;
 
 interface Props {

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -1,10 +1,13 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/core';
+import { remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
 import type { FC } from 'react';
+import { editionsArticleWidth } from './styles';
 
 // ----- Component ----- //
 
@@ -12,6 +15,16 @@ const styles = css`
 	border-top: 1px solid ${border.secondary};
 	${headline.small({ fontWeight: 'medium' })}
 	margin: 0;
+	padding-bottom: ${remSpace[4]};
+
+	${from.wide} {
+		margin: 0 auto;
+	}
+
+	${from.phablet} {
+		border-right: 1px solid ${border.secondary};
+		width: ${editionsArticleWidth}rem;
+	}
 `;
 
 interface Props {

--- a/src/components/editions/lines.tsx
+++ b/src/components/editions/lines.tsx
@@ -2,15 +2,21 @@
 
 import { css } from '@emotion/core';
 import { Lines } from '@guardian/src-ed-lines';
+import { border } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { FC } from 'react';
-import { wideContentWidth } from 'styles';
+import { editionsArticleWidth } from './styles';
 
 // ----- Component ----- //
 
 const styles = css`
 	${from.phablet} {
-		width: ${wideContentWidth}px;
+		width: ${editionsArticleWidth}rem;
+		border-right: 1px solid ${border.secondary};
+	}
+
+	${from.wide} {
+		margin: 0 auto;
 	}
 `;
 

--- a/src/components/editions/series.tsx
+++ b/src/components/editions/series.tsx
@@ -2,7 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
-import { remSpace } from '@guardian/src-foundations';
+import { border, remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { titlepiece } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
 import { getFormat } from 'item';
@@ -10,6 +11,7 @@ import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import { kickerPicker } from './kickerPicker';
+import { editionsArticleWidth } from './styles';
 
 // ----- Component ----- //
 
@@ -22,6 +24,16 @@ const styles = (item: Item): SerializedStyles => {
 		color: ${kicker};
 		font-size: 1.0625rem;
 		padding: ${remSpace[1]} 0 ${remSpace[2]};
+		border-top: 1px solid ${border.secondary};
+
+		${from.wide} {
+			margin: 0 auto;
+		}
+
+		${from.phablet} {
+			border-right: 1px solid ${border.secondary};
+			width: ${editionsArticleWidth}rem;
+		}
 	`;
 };
 

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -1,20 +1,20 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/core';
-import { remSpace, text } from '@guardian/src-foundations';
+import { border, remSpace, text } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { renderStandfirstText } from 'renderer';
-import { wideContentWidth } from 'styles';
+import { editionsArticleWidth } from './styles';
 
 // ----- Component ----- //
 
 const styles = css`
 	${body.medium({ lineHeight: 'tight' })}
-	margin-bottom: ${remSpace[6]};
+	padding-bottom: ${remSpace[6]};
 	color: ${text.primary};
 
 	${from.wide} {
@@ -22,12 +22,14 @@ const styles = css`
 	}
 
 	${from.phablet} {
-		width: ${wideContentWidth}px;
+		border-right: 1px solid ${border.secondary};
+		width: ${editionsArticleWidth}rem;
 	}
 
 	p,
 	ul {
-		margin: ${remSpace[2]} 0;
+		padding: ${remSpace[2]} ${remSpace[1]} 0 0;
+		margin: 0;
 	}
 
 	address {

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -1,0 +1,2 @@
+
+export const editionsArticleWidth = 28;


### PR DESCRIPTION
## Why are you doing this?

Adds borders to Editions Article template headers.

## Changes

- Creates new width variable and applies to all required header components
- Adds borders where needed according to figma designs: https://www.figma.com/file/AgfOrrLI78asahmA3Z9Env/AUS%2FUS-xtra-designs?node-id=1713%3A0

A separate ticket add borders to the Editions Article body components is here:
https://theguardian.atlassian.net/browse/LIVE-1388

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/104727735-c11d4d80-572d-11eb-96a9-6713b7e8ccc1.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/104727797-dd20ef00-572d-11eb-9c68-de82244dc64f.png" width="300px" /> |
