### PR TITLE
Migrate Interactive Component To Own File

### DIFF
--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -169,7 +169,7 @@ type BodyElement =
 	| {
 			kind: ElementKind.Interactive;
 			url: string;
-			alt?: string;
+			alt: Option<string>;
 	  }
 	| {
 			kind: ElementKind.RichLink;
@@ -299,7 +299,11 @@ const parse = (context: Context, atoms?: Atoms, campaigns?: Campaign[]) => (
 				return err('No iframeUrl field on interactiveTypeData');
 			}
 
-			return ok({ kind: ElementKind.Interactive, url: iframeUrl, alt });
+			return ok({
+				kind: ElementKind.Interactive,
+				url: iframeUrl,
+				alt: fromNullable(alt),
+			});
 		}
 
 		case ElementType.RICH_LINK: {

--- a/src/components/interactive.tsx
+++ b/src/components/interactive.tsx
@@ -1,0 +1,35 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/core';
+import { remSpace } from '@guardian/src-foundations';
+import { neutral } from '@guardian/src-foundations/palette';
+import { withDefault } from '@guardian/types';
+import type { Option } from '@guardian/types';
+import type { FC } from 'react';
+import { darkModeCss } from 'styles';
+
+// ----- Component ----- //
+
+interface Props {
+	url: string;
+	title: Option<string>;
+}
+
+const styles = css`
+	margin: ${remSpace[4]} 0;
+
+	${darkModeCss`
+        padding: ${remSpace[4]};
+        background: ${neutral[100]};
+    `}
+`;
+
+const Interactive: FC<Props> = ({ url, title }) => (
+	<figure css={styles} className="interactive">
+		<iframe src={url} height="500" title={withDefault('')(title)} />
+	</figure>
+);
+
+// ----- Exports ----- //
+
+export default Interactive;

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -8,7 +8,7 @@ import { AtomType } from '@guardian/content-atom-model/atomType';
 import { Atoms } from '@guardian/content-api-models/v1/atoms';
 import { fromCapi, Standard, Review, getFormat } from 'item';
 import { ElementKind, Audio, Video, BodyElement } from 'bodyElement';
-import { Design, Display, resultMap, toOption, withDefault } from '@guardian/types';
+import { Design, Display, none, resultMap, toOption, withDefault } from '@guardian/types';
 import { JSDOM } from 'jsdom';
 import { Content } from '@guardian/content-api-models/v1/content';
 import { pipe2 } from 'lib';
@@ -179,7 +179,7 @@ const getFirstBody = (item: Review | Standard) =>
 	pipe2(
 		item.body[0],
 		toOption,
-		withDefault<BodyElement>({ kind: ElementKind.Interactive, url: '' }),
+		withDefault<BodyElement>({ kind: ElementKind.Interactive, url: '', alt: none }),
 	);
 
 describe('fromCapi returns correct Item', () => {

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -71,6 +71,7 @@ const richLinkElement = (): BodyElement => ({
 const interactiveElement = (): BodyElement => ({
 	kind: ElementKind.Interactive,
 	url: 'https://theguardian.com',
+	alt: none,
 });
 
 const tweetElement = (): BodyElement => ({

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -58,6 +58,7 @@ import CalloutForm from 'components/calloutForm';
 import Credit from 'components/credit';
 import EditionsPullquote from 'components/editions/pullquote';
 import HorizontalRule from 'components/horizontalRule';
+import Interactive from 'components/interactive';
 import LiveEventLink from 'components/liveEventLink';
 import Paragraph from 'components/paragraph';
 import Pullquote from 'components/pullquote';
@@ -341,25 +342,6 @@ const text = (doc: DocumentFragment, format: Format): ReactNode[] =>
 
 const standfirstText = (doc: DocumentFragment, format: Format): ReactNode[] =>
 	Array.from(doc.childNodes).map(standfirstTextElement(format));
-
-const Interactive = (props: { url: string; title?: string }): ReactElement => {
-	const styles = css`
-		margin: ${remSpace[4]} 0;
-		${darkModeCss`
-            padding: ${remSpace[4]};
-            background: ${neutral[100]}
-        `}
-	`;
-	return styledH(
-		'figure',
-		{ css: styles, className: 'interactive' },
-		h(
-			'iframe',
-			{ src: props.url, height: 500, title: props.title ?? '' },
-			null,
-		),
-	);
-};
 
 const Tweet = (props: {
 	content: NodeList;


### PR DESCRIPTION
## Why are you doing this?

The `renderer.ts` file is dealing with multiple concerns, which makes it hard to understand. I plan to start breaking it up into more focused modules. This should allow us to reason more clearly about the structure of our code, which will in turn help us with the embeds and Editions work (I hope).

## Changes

- Moved `Interactive` component out of renderer
- Changed an optional field to an `Option` (preferable type in this codebase)
