### PR TITLE
feat(editions-standfirst): render standfirst without links

### DIFF
--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -37,6 +37,8 @@ const styles = (kickerColor: string): SerializedStyles => {
 
 		padding-bottom: ${remSpace[4]};
 		margin: 0 ${remSpace[1]} 0 0;
+		padding-right: ${remSpace[1]};
+		box-sizing: border-box;
 
 		${from.wide} {
 			margin: 0 auto;

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -16,6 +16,8 @@ const styles = css`
 	${headline.small({ fontWeight: 'medium' })}
 	margin: 0;
 	padding-bottom: ${remSpace[4]};
+	padding-right: ${remSpace[1]};
+	box-sizing: border-box;
 
 	${from.wide} {
 		margin: 0 auto;

--- a/src/components/editions/lines.tsx
+++ b/src/components/editions/lines.tsx
@@ -10,6 +10,8 @@ import { editionsArticleWidth } from './styles';
 // ----- Component ----- //
 
 const styles = css`
+	box-sizing: border-box;
+
 	${from.phablet} {
 		width: ${editionsArticleWidth}rem;
 		border-right: 1px solid ${border.secondary};

--- a/src/components/editions/series.tsx
+++ b/src/components/editions/series.tsx
@@ -23,8 +23,9 @@ const styles = (item: Item): SerializedStyles => {
 		${titlepiece.small()}
 		color: ${kicker};
 		font-size: 1.0625rem;
-		padding: ${remSpace[1]} 0 ${remSpace[2]};
+		padding: ${remSpace[1]} ${remSpace[1]} ${remSpace[2]} 0;
 		border-top: 1px solid ${border.secondary};
+		box-sizing: border-box;
 
 		${from.wide} {
 			margin: 0 auto;

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -16,19 +16,20 @@ const styles = css`
 	${body.medium({ lineHeight: 'tight' })}
 	padding-bottom: ${remSpace[6]};
 	color: ${text.primary};
+	padding-right: ${remSpace[1]};
+	box-sizing: border-box;
 
 	${from.wide} {
 		margin: 0 auto;
 	}
 
 	${from.phablet} {
-		border-right: 1px solid ${border.secondary};
 		width: ${editionsArticleWidth}rem;
+		border-right: 1px solid ${border.secondary};
 	}
 
 	p,
 	ul {
-		padding: ${remSpace[2]} ${remSpace[1]} 0 0;
 		margin: 0;
 	}
 
@@ -41,9 +42,13 @@ interface Props {
 	item: Item;
 }
 
+const noLinks = true;
+
 const Standfirst: FC<Props> = ({ item }) =>
 	maybeRender(item.standfirst, (standfirst) => (
-		<div css={styles}>{renderStandfirstText(standfirst, item)}</div>
+		<div css={styles}>
+			{renderStandfirstText(standfirst, item, noLinks)}
+		</div>
 	));
 
 // ----- Exports ----- //

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -336,11 +336,36 @@ const standfirstTextElement = (format: Format) => (
 	}
 };
 
+const noLinksStandfirstTextElement = (format: Format) => (
+	node: Node,
+	key: number,
+): ReactNode => {
+	const children = Array.from(node.childNodes).map(
+		standfirstTextElement(format),
+	);
+	switch (node.nodeName) {
+		case 'P':
+			return h('p', { key }, children);
+		case 'STRONG':
+			return h('strong', { key }, children);
+		default:
+			return null;
+	}
+};
+
 const text = (doc: DocumentFragment, format: Format): ReactNode[] =>
 	Array.from(doc.childNodes).map(textElement(format));
 
-const standfirstText = (doc: DocumentFragment, format: Format): ReactNode[] =>
-	Array.from(doc.childNodes).map(standfirstTextElement(format));
+const standfirstText = (
+	doc: DocumentFragment,
+	format: Format,
+	noLinks?: boolean,
+): ReactNode[] =>
+	Array.from(doc.childNodes).map(
+		noLinks
+			? noLinksStandfirstTextElement(format)
+			: standfirstTextElement(format),
+	);
 
 const Interactive = (props: { url: string; title?: string }): ReactElement => {
 	const styles = css`


### PR DESCRIPTION
## Why are you doing this?

Removes links from Standfirst in Editions

## Changes

- create new render function without links
- replace vertical margins with padding so borders are continuous
- add padding-right so text is padded from borders

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/104936208-1a8eb200-59a4-11eb-8123-c839bbd02d2c.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/104936242-28dcce00-59a4-11eb-8935-13b95e812065.png" width="300px" /> |
