### PR TITLE
feat(editions-article): fix borders and template layout

### DIFF
--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -1,14 +1,17 @@
 // ----- Imports ----- //
 
+import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
-import { border } from '@guardian/src-foundations/palette';
+import { from } from '@guardian/src-foundations/mq';
+import { background, border, culture } from '@guardian/src-foundations/palette';
+import type { Format } from '@guardian/types';
 import { Design, partition } from '@guardian/types';
 import type { Item } from 'item';
 import type { FC } from 'react';
 import { renderEditionsAll } from 'renderer';
 import Header from './header';
-import { articleWidthStyles, sidePadding } from './styles';
+import { articleMarginStyles, articleWidthStyles, sidePadding } from './styles';
 
 // ----- Component ----- //
 
@@ -16,12 +19,54 @@ interface Props {
 	item: Item;
 }
 
+const articleStyles = css`
+	${articleMarginStyles}
+`;
+
+const headerStyles = css`
+	${articleWidthStyles}
+	border-bottom: 1px solid ${border.secondary};
+
+	${from.phablet} {
+		padding-right: ${remSpace[3]};
+		border-right: 1px solid ${border.secondary};
+	}
+`;
+
 const bodyStyles = css`
-	border-top: 1px solid ${border.secondary};
 	padding-top: ${remSpace[4]};
+
+	figcaption {
+		background: ${background.primary};
+		padding-bottom: ${remSpace[2]};
+	}
+
+	${from.phablet} {
+		p {
+			margin: 0;
+			padding-top: ${remSpace[2]};
+			padding-bottom: ${remSpace[2]};
+		}
+	}
+
 	${sidePadding}
+`;
+
+const bodyWrapperStyles = css`
+	padding-right: ${remSpace[3]};
+	border-right: 1px solid ${border.secondary};
 	${articleWidthStyles}
 `;
+
+const headerBackgroundStyles = (item: Format): SerializedStyles | null => {
+	if (item.design === Design.Review) {
+		return css`
+			background-color: ${culture[800]};
+		`;
+	}
+
+	return null;
+};
 
 const Article: FC<Props> = ({ item }) => {
 	if (item.design === Design.Live) {
@@ -31,10 +76,16 @@ const Article: FC<Props> = ({ item }) => {
 	return (
 		<main>
 			<article>
-				<Header item={item} />
-				<section css={bodyStyles}>
-					{renderEditionsAll(item, partition(item.body).oks)}
-				</section>
+				<div css={headerBackgroundStyles(item)}>
+					<section css={[headerStyles, articleStyles]}>
+						<Header item={item} />
+					</section>
+				</div>
+				<div css={[bodyWrapperStyles, articleStyles]}>
+					<section css={bodyStyles}>
+						{renderEditionsAll(item, partition(item.body).oks)}
+					</section>
+				</div>
 			</article>
 		</main>
 	);

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -2,8 +2,6 @@
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
-import { border } from '@guardian/src-foundations/palette';
 import { body } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
 import { getFormat } from 'item';
@@ -21,7 +19,6 @@ const styles = (kickerColor: string): SerializedStyles => {
 		justify-content: space-between;
 		svg {
 			flex: 0 0 1.875rem;
-			padding: 0.25rem;
 			padding-top: 0.375rem;
 			width: 1.875rem;
 			height: 1.875rem;
@@ -36,15 +33,9 @@ const styles = (kickerColor: string): SerializedStyles => {
 		}
 
 		padding-bottom: ${remSpace[4]};
-		padding-right: ${remSpace[1]};
 		margin: 0;
-		box-sizing: border-box;
 
 		${articleWidthStyles}
-
-		${from.phablet} {
-			border-right: 1px solid ${border.secondary};
-		}
 	`;
 };
 

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -2,8 +2,7 @@
 
 import { css } from '@emotion/core';
 import type { SerializedStyles } from '@emotion/core';
-import { culture, remSpace } from '@guardian/src-foundations';
-import { Design, Display } from '@guardian/types';
+import { Display } from '@guardian/types';
 import Byline from 'components/editions/byline';
 import HeaderImage from 'components/editions/headerImage';
 import Headline from 'components/editions/headline';
@@ -12,7 +11,7 @@ import Series from 'components/editions/series';
 import Standfirst from 'components/editions/standfirst';
 import type { Item } from 'item';
 import type { FC, ReactElement } from 'react';
-import { articleWidthStyles, sidePadding } from './styles';
+import { sidePadding } from './styles';
 
 // ----- Component ----- //
 
@@ -29,20 +28,8 @@ const headerStyles = css`
 	${sidePadding}
 `;
 
-const reviewHeaderStyles = css`
-	background-color: ${culture[800]};
-	color: ${culture[300]};
-`;
-
-const showcaseHeaderStyles = css`
-	padding: 0 ${remSpace[2]};
-	margin: 0;
-
-	${articleWidthStyles}
-`;
-
-const StandardHeader: FC<HeaderProps> = ({ item, className }) => (
-	<header css={[headerStyles, className]}>
+const StandardHeader: FC<HeaderProps> = ({ item }) => (
+	<header css={headerStyles}>
 		<HeaderImage item={item} />
 		<Series item={item} />
 		<Headline item={item} />
@@ -53,7 +40,7 @@ const StandardHeader: FC<HeaderProps> = ({ item, className }) => (
 );
 
 const ShowcaseHeader: FC<HeaderProps> = ({ item }) => (
-	<header css={showcaseHeaderStyles}>
+	<header css={headerStyles}>
 		<Series item={item} />
 		<Headline item={item} />
 		<HeaderImage item={item} />
@@ -66,8 +53,6 @@ const ShowcaseHeader: FC<HeaderProps> = ({ item }) => (
 const renderArticleHeader = (item: Item): ReactElement<Props> => {
 	if (item.display === Display.Showcase) {
 		return <ShowcaseHeader item={item} />;
-	} else if (item.design === Design.Review) {
-		return <StandardHeader item={item} className={reviewHeaderStyles} />;
 	} else {
 		return <StandardHeader item={item} />;
 	}

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -7,27 +7,22 @@ import { from } from '@guardian/src-foundations/mq';
 import { border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import type { Format } from '@guardian/types';
-import { Design } from '@guardian/types';
+import { Design, Display } from '@guardian/types';
+import { headlineTextColour } from 'editorialStyles';
 import type { Item } from 'item';
 import type { FC } from 'react';
 import { articleWidthStyles } from './styles';
 
 // ----- Component ----- //
 
-const styles = css`
+const styles = (format: Format): SerializedStyles => css`
+	${headlineTextColour(format)}
 	box-sizing: border-box;
 	border-top: 1px solid ${border.secondary};
-	${headline.small({ fontWeight: 'medium' })}
-	margin: 0;
 	padding-bottom: ${remSpace[4]};
-	padding-right: ${remSpace[1]};
-	box-sizing: border-box;
+	margin: 0;
 
 	${articleWidthStyles}
-
-	${from.phablet} {
-		border-right: 1px solid ${border.secondary};
-	}
 `;
 
 const reviewStyles = css`
@@ -42,9 +37,24 @@ const reviewStyles = css`
 	}
 `;
 
-const getStyles = ({ design }: Format): SerializedStyles => {
-	if (design === Design.Review) return css(styles, reviewStyles);
-	return styles;
+const showcaseStyles = css`
+	${headline.xsmall({ lineHeight: 'tight', fontWeight: 'bold' })}
+
+	${from.mobileMedium} {
+		${headline.small({ lineHeight: 'tight', fontWeight: 'bold' })}
+	}
+
+	${from.tablet} {
+		${headline.medium({ lineHeight: 'tight', fontWeight: 'bold' })}
+	}
+`;
+
+const getStyles = (format: Format): SerializedStyles => {
+	if (format.design === Design.Review)
+		return css(styles(format), reviewStyles);
+	if (format.display === Display.Showcase)
+		return css(styles(format), showcaseStyles);
+	return styles(format);
 };
 
 interface Props {

--- a/src/components/editions/lines.tsx
+++ b/src/components/editions/lines.tsx
@@ -2,22 +2,29 @@
 
 import { css } from '@emotion/core';
 import { Lines } from '@guardian/src-ed-lines';
-import { border } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { FC } from 'react';
-import { articleWidthStyles } from './styles';
+import { tabletContentWidth, wideContentWidth } from './styles';
 
 // ----- Component ----- //
+
+const wide = wideContentWidth + 12;
+const tablet = tabletContentWidth + 12;
 
 const styles = css`
 	box-sizing: border-box;
 
-	${from.phablet} {
-		border-right: 1px solid ${border.secondary};
+	${from.tablet} {
+		margin: 0 auto;
 	}
 
-	${articleWidthStyles}
-	box-sizing: border-box;
+	${from.tablet} {
+		width: ${tablet}px;
+	}
+
+	${from.wide} {
+		width: ${wide}px;
+	}
 `;
 
 const EditionsLines: FC = () => (

--- a/src/components/editions/series.tsx
+++ b/src/components/editions/series.tsx
@@ -3,7 +3,6 @@
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { border, remSpace } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
 import { titlepiece } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
 import { getFormat } from 'item';
@@ -24,15 +23,11 @@ const styles = (item: Item): SerializedStyles => {
 		${titlepiece.small()}
 		color: ${kicker};
 		font-size: 1.0625rem;
-		padding: ${remSpace[1]} ${remSpace[1]} ${remSpace[2]} 0;
+		padding: ${remSpace[1]} 0 ${remSpace[2]};
 		border-top: 1px solid ${border.secondary};
 		box-sizing: border-box;
 
 		${articleWidthStyles}
-
-		${from.phablet} {
-			border-right: 1px solid ${border.secondary};
-		}
 	`;
 };
 

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -1,8 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/core';
-import { border, remSpace, text } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
+import { remSpace, text } from '@guardian/src-foundations';
 import { body } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
 import { maybeRender } from 'lib';
@@ -13,21 +12,15 @@ import { articleWidthStyles } from './styles';
 // ----- Component ----- //
 
 const styles = css`
-	box-sizing: border-box;
-	padding-bottom: ${remSpace[6]};
 	${body.medium({ lineHeight: 'tight' })}
+	padding-bottom: ${remSpace[6]};
 	color: ${text.primary};
-	padding-right: ${remSpace[1]};
 
 	${articleWidthStyles}
 
-	${from.phablet} {
-		border-right: 1px solid ${border.secondary};
-	}
-
 	p,
 	ul {
-		padding: ${remSpace[2]} ${remSpace[1]} 0 0;
+		padding-top: ${remSpace[2]};
 		margin: 0;
 	}
 

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -6,6 +6,9 @@ import { from } from '@guardian/src-foundations/mq';
 export const tabletContentWidth = 526;
 export const wideContentWidth = 545;
 
+export const tabletArticleMargin = 24;
+export const wideArticleMargin = 144;
+
 export const sidePadding = css`
 	padding-left: ${remSpace[2]};
 	padding-right: ${remSpace[2]};
@@ -18,14 +21,20 @@ export const sidePadding = css`
 
 export const articleWidthStyles: SerializedStyles = css`
 	${from.tablet} {
-		margin: 0 auto;
-	}
-
-	${from.tablet} {
 		width: ${tabletContentWidth}px;
 	}
 
 	${from.wide} {
 		width: ${wideContentWidth}px;
+	}
+`;
+
+export const articleMarginStyles: SerializedStyles = css`
+	${from.tablet} {
+		margin-left: ${tabletArticleMargin}px;
+	}
+
+	${from.wide} {
+		margin-left: ${wideArticleMargin}px;
 	}
 `;

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -42,6 +42,10 @@ const textHeadlinePrimary = (format: Format): Colour => {
 		return neutral[100];
 	}
 
+	if (format.design === Design.Review) {
+		return culture[300];
+	}
+
 	if (format.design === Design.Feature) {
 		switch (format.theme) {
 			case Pillar.Opinion:


### PR DESCRIPTION
## Why are you doing this?

Adds border to article body, fixes existing borders on header and fixes margins to match new designs.

Updates title colours styles.

@abeddow91 I ended up moving the Review background colour up a level and getting the headline colour from the palette as I couldn't make it work as it was with the margins, open to suggestions though if I've missed something there :)  Think it makes sense to get the headline colour from the pillar styles for all articles if possible.

Also aware we need to fix the header image size, have created a new ticket for that here:
https://theguardian.atlassian.net/browse/LIVE-1426

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/105161454-4c6d5900-5b09-11eb-89cc-93ed48147966.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/105161495-5a22de80-5b09-11eb-94d8-fe4a24a67647.png" width="300px" /> |

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/105161328-29db4000-5b09-11eb-932d-a2731f8987eb.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/105161384-3cee1000-5b09-11eb-9d62-1557d5d49810.png" /> |


