### PR TITLE
Live 986 headline styles

### DIFF
--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -26,9 +26,8 @@ const styles = (format: Format): SerializedStyles => css`
 `;
 
 const reviewStyles = css`
-	 color: ${culture[300]};
+	color: ${culture[300]};
 `;
-
 
 const heavyStyles = css`
 	${headline.xsmall({ lineHeight: 'tight', fontWeight: 'bold' })}

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/core';
 import type { SerializedStyles } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { border } from '@guardian/src-foundations/palette';
+import { border, culture } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import type { Format } from '@guardian/types';
 import { Design, Display } from '@guardian/types';
@@ -26,18 +26,11 @@ const styles = (format: Format): SerializedStyles => css`
 `;
 
 const reviewStyles = css`
-	${headline.xsmall({ lineHeight: 'tight', fontWeight: 'bold' })}
-
-	${from.mobileMedium} {
-		${headline.small({ lineHeight: 'tight', fontWeight: 'bold' })}
-	}
-
-	${from.tablet} {
-		${headline.medium({ lineHeight: 'tight', fontWeight: 'bold' })}
-	}
+	 color: ${culture[300]};
 `;
 
-const showcaseStyles = css`
+
+const heavyStyles = css`
 	${headline.xsmall({ lineHeight: 'tight', fontWeight: 'bold' })}
 
 	${from.mobileMedium} {
@@ -51,9 +44,9 @@ const showcaseStyles = css`
 
 const getStyles = (format: Format): SerializedStyles => {
 	if (format.design === Design.Review)
-		return css(styles(format), reviewStyles);
+		return css(styles(format), heavyStyles, reviewStyles);
 	if (format.display === Display.Showcase)
-		return css(styles(format), showcaseStyles);
+		return css(styles(format), heavyStyles);
 	return styles(format);
 };
 

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -42,10 +42,6 @@ const textHeadlinePrimary = (format: Format): Colour => {
 		return neutral[100];
 	}
 
-	if (format.design === Design.Review) {
-		return culture[300];
-	}
-
 	if (format.design === Design.Feature) {
 		switch (format.theme) {
 			case Pillar.Opinion:


### PR DESCRIPTION
## Why are you doing this?
As Editions has specific styling, there shouldn't be Editions styles in the Editorial Palette as it may affect AR articles. 
## Changes

- Moves Editions Review style back into Headline component
- Refactor headline styles
