### PR TITLE
feat(editions-header): create dynamic colour picker for header backgr…

### DIFF
--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -4,14 +4,19 @@ import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { background, border, culture } from '@guardian/src-foundations/palette';
+import { background, border } from '@guardian/src-foundations/palette';
 import type { Format } from '@guardian/types';
 import { Design, partition } from '@guardian/types';
 import type { Item } from 'item';
 import type { FC } from 'react';
 import { renderEditionsAll } from 'renderer';
 import Header from './header';
-import { articleMarginStyles, articleWidthStyles, sidePadding } from './styles';
+import {
+	articleMarginStyles,
+	articleWidthStyles,
+	headerBackgroundColour,
+	sidePadding,
+} from './styles';
 
 // ----- Component ----- //
 
@@ -58,15 +63,9 @@ const bodyWrapperStyles = css`
 	${articleWidthStyles}
 `;
 
-const headerBackgroundStyles = (item: Format): SerializedStyles | null => {
-	if (item.design === Design.Review) {
-		return css`
-			background-color: ${culture[800]};
-		`;
-	}
-
-	return null;
-};
+const headerBackgroundStyles = (item: Format): SerializedStyles => css`
+	background-color: ${headerBackgroundColour(item)};
+`;
 
 const Article: FC<Props> = ({ item }) => {
 	if (item.design === Design.Live) {

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/core';
 import type { SerializedStyles } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { border, culture } from '@guardian/src-foundations/palette';
+import { border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import type { Format } from '@guardian/types';
 import { Design, Display } from '@guardian/types';
@@ -15,6 +15,10 @@ import { articleWidthStyles } from './styles';
 
 // ----- Component ----- //
 
+interface Props {
+	item: Item;
+}
+
 const styles = (format: Format): SerializedStyles => css`
 	${headlineTextColour(format)}
 	box-sizing: border-box;
@@ -23,10 +27,6 @@ const styles = (format: Format): SerializedStyles => css`
 	margin: 0;
 
 	${articleWidthStyles}
-`;
-
-const reviewStyles = css`
-	color: ${culture[300]};
 `;
 
 const heavyStyles = css`
@@ -43,15 +43,11 @@ const heavyStyles = css`
 
 const getStyles = (format: Format): SerializedStyles => {
 	if (format.design === Design.Review)
-		return css(styles(format), heavyStyles, reviewStyles);
+		return css(styles(format), heavyStyles);
 	if (format.display === Display.Showcase)
 		return css(styles(format), heavyStyles);
 	return styles(format);
 };
-
-interface Props {
-	item: Item;
-}
 
 const Headline: FC<Props> = ({ item }) => {
 	return <h1 css={getStyles(item)}>{item.headline}</h1>;

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -2,6 +2,10 @@ import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
+import { culture, neutral } from '@guardian/src-foundations/palette';
+import type { Format } from '@guardian/types';
+import { Design, Pillar } from '@guardian/types';
+import type { Colour } from 'editorialPalette';
 
 export const tabletContentWidth = 526;
 export const wideContentWidth = 545;
@@ -38,3 +42,16 @@ export const articleMarginStyles: SerializedStyles = css`
 		margin-left: ${wideArticleMargin}px;
 	}
 `;
+
+export const headerBackgroundColour = (format: Format): Colour => {
+	if (format.design === Design.Review) {
+		switch (format.theme) {
+			case Pillar.Culture:
+				return culture[800];
+			default:
+				return neutral[100];
+		}
+	}
+
+	return neutral[100];
+};

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -42,7 +42,7 @@ const textHeadlinePrimary = (format: Format): Colour => {
 		return neutral[100];
 	}
 
-	if (format.design === Design.Feature) {
+	if (format.design === Design.Feature || format.design === Design.Review) {
 		switch (format.theme) {
 			case Pillar.Opinion:
 				return opinion[300];
@@ -52,7 +52,6 @@ const textHeadlinePrimary = (format: Format): Colour => {
 				return culture[300];
 			case Pillar.Lifestyle:
 				return lifestyle[300];
-			case Pillar.News:
 			default:
 				return news[300];
 		}


### PR DESCRIPTION
## Why are you doing this?

We need dynamic article header backgrounds across the Editions article templates, and pillar based headline colours for Reviews. 

The background colour picker can be expanded upon as we build out the other article types.

## Changes

- Introduces dynamic background picker.
- Adds Review article type to Editorial Palette headline colour function

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/105180572-a7f81080-5b22-11eb-9d06-13dc8d5a67e3.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/105180649-c100c180-5b22-11eb-9aa8-047a0baf482e.png" width="300px" /> |

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/105180760-dc6bcc80-5b22-11eb-83e8-b2ebf4496cdb.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/105180803-ec83ac00-5b22-11eb-998c-a0cee7c5da40.png" width="300px" /> |


