### PR TITLE
Add default font styles to standfirst

### DIFF
--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -2,6 +2,7 @@
 
 import { css } from '@emotion/core';
 import { remSpace, text } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
 import { maybeRender } from 'lib';
@@ -13,6 +14,12 @@ import { articleWidthStyles } from './styles';
 
 const styles = css`
 	${body.medium({ lineHeight: 'tight' })}
+	font-size: 1.125rem;
+
+	${from.mobileMedium} {
+		font-size: 1.25rem;
+	}
+	
 	padding-bottom: ${remSpace[6]};
 	color: ${text.primary};
 

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -19,7 +19,7 @@ const styles = css`
 	${from.mobileMedium} {
 		font-size: 1.25rem;
 	}
-	
+
 	padding-bottom: ${remSpace[6]};
 	color: ${text.primary};
 


### PR DESCRIPTION
## Why are you doing this?
The editions standfirst has default font styling at mobile and mobile-medium. The font weights are not included in the source standard sizes

## Changes

- add default font styling at mobile and mobile-medium breakpoints 


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/105198495-9f5d0580-5b35-11eb-984c-a666507cc359.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/105198298-6f156700-5b35-11eb-90a4-331509d1bf0c.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/20416599/105198505-a126c900-5b35-11eb-8922-64dd6fc3ac1c.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/105198323-763c7500-5b35-11eb-93d0-a63a0c8a90a9.png" width="300px" /> |



