### PR TITLE
feat(editions-header-image): update widths to match designs

### DIFF
--- a/src/components/editions/headerImage.tsx
+++ b/src/components/editions/headerImage.tsx
@@ -13,7 +13,7 @@ import type { Image } from 'image';
 import type { Item } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
-import { tabletContentWidth, wideContentWidth } from './styles';
+import { tabletImageWidth, wideImageWidth } from './styles';
 
 // ----- Component ----- //
 
@@ -22,13 +22,13 @@ const styles = css`
 	position: relative;
 
 	${from.tablet} {
-		width: ${tabletContentWidth}px;
+		width: ${tabletImageWidth}px;
 		margin-left: auto;
 		margin-right: auto;
 	}
 
 	${from.wide} {
-		width: ${wideContentWidth}px;
+		width: ${wideImageWidth}px;
 		margin-left: auto;
 		margin-right: auto;
 	}
@@ -36,11 +36,11 @@ const styles = css`
 
 const captionStyles = css`
 	${from.tablet} {
-		width: ${tabletContentWidth}px;
+		width: ${tabletImageWidth}px;
 	}
 
 	${from.wide} {
-		width: ${wideContentWidth}px;
+		width: ${wideImageWidth}px;
 	}
 `;
 
@@ -51,13 +51,13 @@ const getImageStyle = ({ width, height }: Image): SerializedStyles => {
 		height: calc(100vw * ${height / width});
 
 		${from.tablet} {
-			width: ${tabletContentWidth}px;
-			height: ${(tabletContentWidth * height) / width}px;
+			width: ${tabletImageWidth}px;
+			height: ${(tabletImageWidth * height) / width}px;
 		}
 
 		${from.wide} {
-			width: ${wideContentWidth}px;
-			height: ${(wideContentWidth * height) / width}px;
+			width: ${wideImageWidth}px;
+			height: ${(wideImageWidth * height) / width}px;
 		}
 	`;
 };

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -10,6 +10,9 @@ import type { Colour } from 'editorialPalette';
 export const tabletContentWidth = 526;
 export const wideContentWidth = 545;
 
+export const tabletImageWidth = 720;
+export const wideImageWidth = 750;
+
 export const tabletArticleMargin = 24;
 export const wideArticleMargin = 144;
 


### PR DESCRIPTION
## Why are you doing this?

Updates Image widths to reflect designs.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/105207608-9ec96c80-5b3f-11eb-851c-edeab3b46bd9.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/105207655-ac7ef200-5b3f-11eb-8c12-ee93fdeaa038.png" width="300px" /> |
