### PR TITLE
FIX: Prioritise Interview tag over Feature

### DIFF
--- a/src/item.ts
+++ b/src/item.ts
@@ -304,6 +304,11 @@ const fromCapi = (context: Context) => (request: RenderingRequest): Item => {
 			...item,
 			theme: item.theme === Pillar.News ? Pillar.Opinion : item.theme,
 		};
+	} else if (isInterview(tags)) {
+		return {
+			design: Design.Interview,
+			...itemFieldsWithBody(context, request),
+		};
 	} else if (isFeature(tags)) {
 		return {
 			design: Design.Feature,
@@ -314,11 +319,6 @@ const fromCapi = (context: Context) => (request: RenderingRequest): Item => {
 	} else if (isRecipe(tags)) {
 		return {
 			design: Design.Recipe,
-			...itemFieldsWithBody(context, request),
-		};
-	} else if (isInterview(tags)) {
-		return {
-			design: Design.Interview,
 			...itemFieldsWithBody(context, request),
 		};
 	} else if (isGuardianView(tags)) {


### PR DESCRIPTION
## Why are you doing this?
Sometimes content has multiple tone tags and this happens frequently with interview and feature. In this circumstance, AR should follow CAPIs lead and prioritise Interview over Feature.

## Changes

- Move Interview above Feature when deriving the Format type.

NB - Most interviews used to fall under the Feature format type. As this is now not the case, interviews will not render on AR as this content format is not built at present.

