### PR TITLE
feat(editions-analysis): add template specific styles

### DIFF
--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/core';
-import type { SerializedStyles } from '@emotion/core';
 import { Design, Display } from '@guardian/types';
 import Byline from 'components/editions/byline';
 import HeaderImage from 'components/editions/headerImage';
@@ -15,13 +14,8 @@ import { sidePadding } from './styles';
 
 // ----- Component ----- //
 
-interface Props {
-	item: Item;
-}
-
 interface HeaderProps {
 	item: Item;
-	className?: SerializedStyles;
 }
 
 const headerStyles = css`
@@ -35,7 +29,7 @@ const StandardHeader: FC<HeaderProps> = ({ item }) => (
 		<Headline item={item} />
 		<Standfirst item={item} />
 		<Lines />
-		<Byline item={item} />
+		<Byline item={item} shareIcon />
 	</header>
 );
 
@@ -46,12 +40,22 @@ const ShowcaseHeader: FC<HeaderProps> = ({ item }) => (
 		<HeaderImage item={item} />
 		<Standfirst item={item} />
 		<Lines />
-		<Byline item={item} />
+		<Byline item={item} shareIcon />
+	</header>
+);
+
+const AnalysisHeader: FC<HeaderProps> = ({ item }) => (
+	<header css={headerStyles}>
+		<HeaderImage item={item} />
+		<Headline item={item} />
+		<Byline item={item} large />
+		<Lines />
+		<Standfirst item={item} shareIcon />
 	</header>
 );
 
 const InterviewHeader: FC<HeaderProps> = ({ item }) => (
-	<header>
+	<header css={headerStyles}>
 		<HeaderImage item={item} />
 		<Headline item={item} />
 		<Standfirst item={item} />
@@ -60,17 +64,19 @@ const InterviewHeader: FC<HeaderProps> = ({ item }) => (
 	</header>
 );
 
-const renderArticleHeader = (item: Item): ReactElement<Props> => {
+const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 	if (item.design === Design.Interview) {
 		return <InterviewHeader item={item} />;
 	} else if (item.display === Display.Showcase) {
 		return <ShowcaseHeader item={item} />;
+	} else if (item.design === Design.Analysis) {
+		return <AnalysisHeader item={item} />;
 	} else {
 		return <StandardHeader item={item} />;
 	}
 };
 
-const Container: FC<Props> = ({ item }: Props) => {
+const Container: FC<HeaderProps> = ({ item }) => {
 	return <>{renderArticleHeader(item)}</>;
 };
 

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -6,11 +6,17 @@ import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { border, neutral } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
+import type {
+	FontWeight,
+	LineHeight,
+} from '@guardian/src-foundations/typography/types';
 import type { Format } from '@guardian/types';
 import { Design, Display } from '@guardian/types';
 import { headlineTextColour } from 'editorialStyles';
 import type { Item } from 'item';
+import { getFormat } from 'item';
 import type { FC } from 'react';
+import { getThemeStyles } from 'themeStyles';
 import { articleWidthStyles } from './styles';
 
 // ----- Component ----- //
@@ -29,29 +35,27 @@ const styles = (format: Format): SerializedStyles => css`
 	${articleWidthStyles}
 `;
 
-const heavyFontStyles = css`
-	${headline.xsmall({ lineHeight: 'tight', fontWeight: 'bold' })}
+const underline = (kickerColor: string): SerializedStyles => css`
+	text-decoration: underline;
+	text-decoration-thickness: from-font;
+	text-decoration-color: ${kickerColor};
+`;
+
+const fontStyles = (
+	lineHeight: LineHeight,
+	fontWeight: FontWeight,
+): SerializedStyles => css`
+	${headline.xsmall({ lineHeight, fontWeight })}
 
 	${from.mobileMedium} {
-		${headline.small({ lineHeight: 'tight', fontWeight: 'bold' })}
+		${headline.small({ lineHeight, fontWeight })}
 	}
 
 	${from.tablet} {
-		${headline.medium({ lineHeight: 'tight', fontWeight: 'bold' })}
+		${headline.medium({ lineHeight, fontWeight })}
 	}
 `;
 
-const standardFontStyles = css`
-	${headline.xsmall({ lineHeight: 'tight' })}
-
-	${from.mobileMedium} {
-		${headline.small({ lineHeight: 'tight' })}
-	}
-
-	${from.tablet} {
-		${headline.medium({ lineHeight: 'tight' })}
-	}
-`;
 const interviewStyles = css`
 	margin-left: ${remSpace[3]};
 	border: 0;
@@ -70,6 +74,7 @@ const interviewFontStyles = css`
 		${headline.medium({ lineHeight: 'regular' })}
 		font-weight: 400;
 	}
+
 	background-color: ${neutral[0]};
 	color: ${neutral[100]};
 	white-space: pre-wrap;
@@ -79,19 +84,27 @@ const interviewFontStyles = css`
 	display: inline;
 `;
 
-const getStyles = (format: Format): SerializedStyles => {
+const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
 	if (format.design === Design.Interview) {
 		return css(styles(format), interviewStyles);
 	}
+
 	if (
 		format.design === Design.Review ||
 		format.display === Display.Showcase ||
 		format.display === Display.Immersive ||
 		format.design === Design.PhotoEssay
 	)
-		return css(styles(format), heavyFontStyles);
+		return css(styles(format), fontStyles('tight', 'bold'));
 
-	return css(styles(format), standardFontStyles);
+	if (format.design === Design.Analysis)
+		return css(
+			styles(format),
+			fontStyles('tight', 'light'),
+			underline(kickerColor),
+		);
+
+	return css(styles(format), fontStyles('tight', 'medium'));
 };
 
 const getHeadlineText = (item: Item): JSX.Element | string => {
@@ -102,7 +115,12 @@ const getHeadlineText = (item: Item): JSX.Element | string => {
 };
 
 const Headline: FC<Props> = ({ item }) => {
-	return <h1 css={getStyles(item)}>{getHeadlineText(item)}</h1>;
+	const format = getFormat(item);
+	const { kicker: kickerColor } = getThemeStyles(format.theme);
+
+	return (
+		<h1 css={getStyles(format, kickerColor)}>{getHeadlineText(item)}</h1>
+	);
 };
 
 // ----- Exports ----- //

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -1,20 +1,26 @@
 // ----- Imports ----- //
 
+import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { remSpace, text } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
+import { getFormat } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { renderStandfirstText } from 'renderer';
+import { getThemeStyles } from 'themeStyles';
+import { ShareIcon } from './shareIcon';
 import { articleWidthStyles } from './styles';
 
 // ----- Component ----- //
 
-const styles = css`
+const styles = (kickerColor: string): SerializedStyles => css`
 	${body.medium({ lineHeight: 'tight' })}
 	font-size: 1.125rem;
+	display: flex;
+	justify-content: space-between;
 
 	${from.mobileMedium} {
 		font-size: 1.25rem;
@@ -27,27 +33,52 @@ const styles = css`
 
 	p,
 	ul {
-		padding-top: ${remSpace[2]};
+		padding-top: ${remSpace[1]};
 		margin: 0;
 	}
 
 	address {
 		font-style: normal;
 	}
+
+	svg {
+		flex: 0 0 1.875rem;
+		margin-top: 0.375rem;
+		width: 1.875rem;
+		height: 1.875rem;
+
+		circle {
+			stroke: ${kickerColor};
+		}
+
+		path {
+			fill: ${kickerColor};
+		}
+	}
 `;
 
 interface Props {
 	item: Item;
+	shareIcon?: boolean;
 }
 
 const noLinks = true;
 
-const Standfirst: FC<Props> = ({ item }) =>
-	maybeRender(item.standfirst, (standfirst) => (
-		<div css={styles}>
+const Standfirst: FC<Props> = ({ item, shareIcon }) => {
+	const format = getFormat(item);
+	const { kicker: kickerColor } = getThemeStyles(format.theme);
+
+	return maybeRender(item.standfirst, (standfirst) => (
+		<div css={styles(kickerColor)}>
 			{renderStandfirstText(standfirst, item, noLinks)}
+			{shareIcon && (
+				<span className="js-share-button" role="button">
+					<ShareIcon />
+				</span>
+			)}
 		</div>
 	));
+};
 
 // ----- Exports ----- //
 

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -47,6 +47,10 @@ export const articleMarginStyles: SerializedStyles = css`
 `;
 
 export const headerBackgroundColour = (format: Format): Colour => {
+	if (format.design === Design.Analysis) {
+		return neutral[97];
+	}
+
 	if (format.design === Design.Review) {
 		switch (format.theme) {
 			case Pillar.Culture:


### PR DESCRIPTION
## Why are you doing this?

Adds Analytics template specific styles to existing Editions article subcomponents.

## Changes

- Add `large` prop to `Byline` component to allow for Analytics font size.
- Add `AnalysisHeader` to `Header` component to change subcomponent ordering
- Add `ShareIcon` to `Standfirst` with optional prop
- Add optional `shareIcon` prop to `Byline` component
- Add `Analysis` to background-colour picker.

Apologies this is a more bloated PR than I'd intended 😞  Still needs the Standfirst text styles but I'll save that rather than adding more noise here.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/105390331-d2c09280-5c10-11eb-9554-f18a6def1842.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/105390374-df44eb00-5c10-11eb-96f3-2895b46fd89c.png" width="300px" /> |
