### PR TITLE
Live 1407: Interview Standfirst Padding

### DIFF
--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -55,7 +55,7 @@ const AnalysisHeader: FC<HeaderProps> = ({ item }) => (
 );
 
 const InterviewHeader: FC<HeaderProps> = ({ item }) => (
-	<header css={headerStyles}>
+	<header>
 		<HeaderImage item={item} />
 		<Headline item={item} />
 		<Standfirst item={item} />

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -5,15 +5,15 @@ import { css } from '@emotion/core';
 import { remSpace, text } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
+import type { Format } from '@guardian/types';
+import { Design } from '@guardian/types';
 import type { Item } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { renderStandfirstText } from 'renderer';
 import { getThemeStyles } from 'themeStyles';
 import { ShareIcon } from './shareIcon';
-import { articleWidthStyles } from './styles';
-import { Design, Format } from '@guardian/types';
-import { sidePadding } from './styles';
+import { articleWidthStyles, sidePadding } from './styles';
 
 // ----- Component ----- //
 

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -6,13 +6,14 @@ import { remSpace, text } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
 import type { Item } from 'item';
-import { getFormat } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { renderStandfirstText } from 'renderer';
 import { getThemeStyles } from 'themeStyles';
 import { ShareIcon } from './shareIcon';
 import { articleWidthStyles } from './styles';
+import { Design, Format } from '@guardian/types';
+import { sidePadding } from './styles';
 
 // ----- Component ----- //
 
@@ -57,6 +58,10 @@ const styles = (kickerColor: string): SerializedStyles => css`
 	}
 `;
 
+const interviewStyles = css`
+	${sidePadding}
+`;
+
 interface Props {
 	item: Item;
 	shareIcon?: boolean;
@@ -64,12 +69,17 @@ interface Props {
 
 const noLinks = true;
 
-const Standfirst: FC<Props> = ({ item, shareIcon }) => {
-	const format = getFormat(item);
+const getStyles = (format: Format): SerializedStyles => {
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
+	if (format.design === Design.Interview) {
+		return css(styles(kickerColor), interviewStyles);
+	}
+	return styles(kickerColor);
+};
 
+const Standfirst: FC<Props> = ({ item, shareIcon }) => {
 	return maybeRender(item.standfirst, (standfirst) => (
-		<div css={styles(kickerColor)}>
+		<div css={getStyles(item)}>
 			{renderStandfirstText(standfirst, item, noLinks)}
 			{shareIcon && (
 				<span className="js-share-button" role="button">


### PR DESCRIPTION
## Why are you doing this?
The Interview template has full width Header Image and Headline on mobile. This PR removes the padding from the header and adds it into Standfirst

## Changes

- Remove padding from header
- Add padding to standfirst
- Add style switch for template type

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/105505217-964c6f80-5cc0-11eb-9f1d-5741a7021da7.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/105504766-12928300-5cc0-11eb-978a-c498889292e0.png" width="300px" /> |
