### PR TITLE
Live 1406: interview series

### DIFF
--- a/src/components/editions/headerImage.tsx
+++ b/src/components/editions/headerImage.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/core';
 import type { Sizes } from '@guardian/image-rendering';
 import { Img } from '@guardian/image-rendering';
 import { from } from '@guardian/src-foundations/mq';
-import { none, some } from '@guardian/types';
+import { Design, none, some } from '@guardian/types';
 import StarRating from 'components/editions/starRating';
 import HeaderImageCaption, { captionId } from 'components/headerImageCaption';
 import { MainMediaKind } from 'headerMedia';
@@ -15,6 +15,7 @@ import { getFormat } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
+import Series from './series';
 import { tabletImageWidth, wideImageWidth } from './styles';
 
 // ----- Component ----- //
@@ -99,6 +100,7 @@ const HeaderImage: FC<Props> = ({ item }) => {
 						supportsDarkMode
 						lightbox={none}
 					/>
+					{item.design === Design.Interview && <Series item={item} />}
 					<HeaderImageCaption
 						caption={nativeCaption}
 						credit={credit}

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -79,6 +79,7 @@ const interviewFontStyles = css`
 	background-color: ${neutral[0]};
 	color: ${neutral[100]};
 	white-space: pre-wrap;
+	padding-top: ${remSpace[1]};
 	padding-bottom: ${remSpace[1]};
 	box-shadow: -${remSpace[3]} 0 0 ${neutral[0]},
 		${remSpace[3]} 0 0 ${neutral[0]};

--- a/src/components/editions/series.tsx
+++ b/src/components/editions/series.tsx
@@ -2,9 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
-import { border, remSpace } from '@guardian/src-foundations';
+import { border, neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { titlepiece } from '@guardian/src-foundations/typography';
+import { Design } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import { maybeRender } from 'lib';
@@ -15,34 +16,54 @@ import { articleWidthStyles } from './styles';
 
 // ----- Component ----- //
 
-const styles = (item: Item): SerializedStyles => {
-	const format = getFormat(item);
-	const { kicker } = getThemeStyles(format.theme);
+const styles = (kicker: string): SerializedStyles => css`
+	box-sizing: border-box;
+	${titlepiece.small()}
+	color: ${kicker};
+	font-size: 1.0625rem;
+	padding: ${remSpace[1]} 0 ${remSpace[2]};
+	border-top: 1px solid ${border.secondary};
+	box-sizing: border-box;
 
-	return css`
-		box-sizing: border-box;
-		${titlepiece.small()}
-		color: ${kicker};
-		font-size: 1.0625rem;
-		padding: ${remSpace[1]} 0 ${remSpace[2]};
-		border-top: 1px solid ${border.secondary};
-		box-sizing: border-box;
+	${articleWidthStyles}
 
-		${articleWidthStyles}
+	${from.tablet} {
+		padding-bottom: ${remSpace[3]};
+	}
+`;
+const interviewStyles = (kicker: string): SerializedStyles => css`
+	position: absolute;
+	left: 0;
+	bottom: 0;
+	border: 0;
+	color: ${neutral[100]};
+	background-color: ${kicker};
+	padding: ${remSpace[2]} ${remSpace[3]};
+	${from.tablet} {
+		width: auto;
+	}
 
-		${from.tablet} {
-			padding-bottom: ${remSpace[3]};
-		}
-	`;
-};
+	${from.wide} {
+		width: auto;
+	}
+`;
 
 interface Props {
 	item: Item;
 }
 
+const getStyles = (item: Item): SerializedStyles => {
+	const format = getFormat(item);
+	const { kicker } = getThemeStyles(format.theme);
+	if (item.design === Design.Interview) {
+		return css(styles(kicker), interviewStyles(kicker));
+	}
+	return styles(kicker);
+};
+
 const Series: FC<Props> = ({ item }) =>
 	maybeRender(kickerPicker(item), (kicker) => (
-		<nav css={styles(item)}>{kicker}</nav>
+		<nav css={getStyles(item)}>{kicker}</nav>
 	));
 
 // ----- Exports ----- //


### PR DESCRIPTION
## Why are you doing this?
The Editions Interview template has the Series component on the Header Image. This PR makes that change
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- Add Series/Kicker to header image if it's type Interview
- Add interview specific styling to series

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/105704868-54f9d100-5f07-11eb-8e62-476352255b3d.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/105704875-56c39480-5f07-11eb-8765-1c671794dde6.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/20416599/105704871-55926780-5f07-11eb-9aee-2d9d631830d4.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/105704872-562afe00-5f07-11eb-9129-7b6543f799cb.png" width="300px" /> |
