### PR TITLE
Live 1408: Interview Header Background Colour

### DIFF
--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -65,14 +65,12 @@ const headerBackgroundStyles = (item: Format): SerializedStyles => css`
 	background-color: ${headerBackgroundColour(item)};
 `;
 
-
-const getSectionStyles = (item: Format) => {
+const getSectionStyles = (item: Format): SerializedStyles[] => {
 	if (item.design === Design.Interview) {
 		return [];
 	}
 	return [headerStyles, articleStyles];
 };
-
 
 const Article: FC<Props> = ({ item }) => {
 	if (item.design === Design.Live) {

--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -65,6 +65,15 @@ const headerBackgroundStyles = (item: Format): SerializedStyles => css`
 	background-color: ${headerBackgroundColour(item)};
 `;
 
+
+const getSectionStyles = (item: Format) => {
+	if (item.design === Design.Interview) {
+		return [];
+	}
+	return [headerStyles, articleStyles];
+};
+
+
 const Article: FC<Props> = ({ item }) => {
 	if (item.design === Design.Live) {
 		return <p>Not implemented</p>;
@@ -74,7 +83,7 @@ const Article: FC<Props> = ({ item }) => {
 		<main>
 			<article>
 				<div css={headerBackgroundStyles(item)}>
-					<section css={[headerStyles, articleStyles]}>
+					<section css={getSectionStyles(item)}>
 						<Header item={item} />
 					</section>
 				</div>

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -1,6 +1,9 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/core';
+import type { SerializedStyles } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import type { Format } from '@guardian/types';
 import { Design, Display } from '@guardian/types';
 import Byline from 'components/editions/byline';
 import HeaderImage from 'components/editions/headerImage';
@@ -10,7 +13,12 @@ import Series from 'components/editions/series';
 import Standfirst from 'components/editions/standfirst';
 import type { Item } from 'item';
 import type { FC, ReactElement } from 'react';
-import { sidePadding } from './styles';
+import {
+	interviewBackgroundColour,
+	sidePadding,
+	tabletArticleMargin,
+	wideArticleMargin,
+} from './styles';
 
 // ----- Component ----- //
 
@@ -20,6 +28,17 @@ interface HeaderProps {
 
 const headerStyles = css`
 	${sidePadding}
+`;
+
+const interviewHeaderStyles = (item: Format): SerializedStyles => css`
+	${from.tablet} {
+		padding-left: ${tabletArticleMargin}px;
+	}
+
+	${from.wide} {
+		padding-left: ${wideArticleMargin}px;
+	}
+	background-color: ${interviewBackgroundColour(item)};
 `;
 
 const StandardHeader: FC<HeaderProps> = ({ item }) => (
@@ -67,8 +86,10 @@ const CommentHeader: FC<HeaderProps> = ({ item }) => (
 const InterviewHeader: FC<HeaderProps> = ({ item }) => (
 	<header>
 		<HeaderImage item={item} />
-		<Headline item={item} />
-		<Standfirst item={item} />
+		<div css={interviewHeaderStyles(item)}>
+			<Headline item={item} />
+			<Standfirst item={item} />
+		</div>
 		<Lines />
 		<Byline item={item} />
 	</header>

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -83,7 +83,7 @@ export const headerBackgroundColour = (format: Format): Colour => {
 export const interviewBackgroundColour = (format: Format): Colour => {
 	switch (format.theme) {
 		case Pillar.Sport:
-			return Palette.brand[400];
+			return Palette.brandAlt[400];
 		case Pillar.Culture:
 			return Palette.culture[600];
 		case Pillar.Lifestyle:

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -79,3 +79,16 @@ export const headerBackgroundColour = (format: Format): Colour => {
 
 	return Palette.neutral[100];
 };
+
+export const interviewBackgroundColour = (format: Format): Colour => {
+	switch (format.theme) {
+		case Pillar.Sport:
+			return Palette.brand[400];
+		case Pillar.Culture:
+			return Palette.culture[600];
+		case Pillar.Lifestyle:
+			return Palette.lifestyle[800];
+		default:
+			return Palette.neutral[100];
+	}
+};


### PR DESCRIPTION
## Why are you doing this?
Adds coloured background for Interview template to headline and standfirst only as per designs. 
NB To reduce the PR size, this PR breaks styling on the image, byline and lines component. These will be resolved in separate pulls.

## Screenshots

| Before | After |
| --- | --- |
| <img src="" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/106125148-b3b38a80-6153-11eb-843a-2023954f5992.png" width="300px" /> |
| <img src="" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/106124840-70591c00-6153-11eb-977a-1c74c358541d.png" width="300px" /> |
