### PR TITLE
Add Instance Type to the cloudformation mappings

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -9,6 +9,7 @@ Mappings:
     ScalingDown:
       Period: 300
       Threshold: 15
+    InstanceType: t3a.micro
   PROD:
     ScalingUp:
       Period: 300
@@ -16,6 +17,7 @@ Mappings:
     ScalingDown:
       Period: 300
       Threshold: 15
+    InstanceType: t3a.micro
   Constants:
     RunbookCopy:
       Value: <<<Runbook|https://docs.google.com/document/d/1VRYMTYtlb0pYt19S7AZoXttLH3N2MJ41hS5oo2vfVhI>>>
@@ -43,9 +45,6 @@ Parameters:
   AutoscalingNotifications:
     Description: The ARN of the SNS topic to send notifications to
     Type: String
-  InstanceType:
-    Type: String
-    Description: The instance type
   ASGMinSize:
     Type: Number
     Description: Minimum size of the autoscaling group
@@ -79,7 +78,6 @@ Metadata:
         Parameters:
           - AMI
           - AutoscalingNotifications
-          - InstanceType
           - ASGMinSize
           - ASGMaxSize
 
@@ -295,7 +293,7 @@ Resources:
       AssociatePublicIpAddress: true
       IamInstanceProfile: !Ref DistributionInstanceProfile
       ImageId: !Ref AMI
-      InstanceType: !Ref InstanceType
+      InstanceType: !FindInMap [InstanceType]
       SecurityGroups:
         - !Ref InstanceSecurityGroup
         - Fn::ImportValue: !Sub SecurityGroups-${Stage}-MapiGuardianLondonSSH

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -9,7 +9,8 @@ Mappings:
     ScalingDown:
       Period: 300
       Threshold: 15
-    InstanceType: "t3a.micro"
+    InstanceType:
+       Value: "t3a.micro"
   PROD:
     ScalingUp:
       Period: 300
@@ -17,7 +18,8 @@ Mappings:
     ScalingDown:
       Period: 300
       Threshold: 15
-    InstanceType: "t3a.micro"
+    InstanceType:
+      Value: "t3a.micro"
   Constants:
     RunbookCopy:
       Value: <<<Runbook|https://docs.google.com/document/d/1VRYMTYtlb0pYt19S7AZoXttLH3N2MJ41hS5oo2vfVhI>>>
@@ -293,7 +295,7 @@ Resources:
       AssociatePublicIpAddress: true
       IamInstanceProfile: !Ref DistributionInstanceProfile
       ImageId: !Ref AMI
-      InstanceType: !FindInMap [!Ref Stage, InstanceType]
+      InstanceType: !FindInMap [!Ref Stage, InstanceType, Value]
       SecurityGroups:
         - !Ref InstanceSecurityGroup
         - Fn::ImportValue: !Sub SecurityGroups-${Stage}-MapiGuardianLondonSSH

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -9,7 +9,7 @@ Mappings:
     ScalingDown:
       Period: 300
       Threshold: 15
-    InstanceType: t3a.micro
+    InstanceType: "t3a.micro"
   PROD:
     ScalingUp:
       Period: 300
@@ -17,7 +17,7 @@ Mappings:
     ScalingDown:
       Period: 300
       Threshold: 15
-    InstanceType: t3a.micro
+    InstanceType: "t3a.micro"
   Constants:
     RunbookCopy:
       Value: <<<Runbook|https://docs.google.com/document/d/1VRYMTYtlb0pYt19S7AZoXttLH3N2MJ41hS5oo2vfVhI>>>

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -293,7 +293,7 @@ Resources:
       AssociatePublicIpAddress: true
       IamInstanceProfile: !Ref DistributionInstanceProfile
       ImageId: !Ref AMI
-      InstanceType: !FindInMap [InstanceType]
+      InstanceType: !FindInMap [!Ref Stage, InstanceType]
       SecurityGroups:
         - !Ref InstanceSecurityGroup
         - Fn::ImportValue: !Sub SecurityGroups-${Stage}-MapiGuardianLondonSSH


### PR DESCRIPTION
## Why are you doing this?
Change the InstanceType from being a parameter to a mapping so we can make sure version control is in place, this is because we want to update apps-rendering to use the new ARM instance type so this first step will make sure we are changing everything in the right place.

This has been tested on CODE