### PR TITLE
Add Graviton 2 ARM instance type

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -19,7 +19,7 @@ Mappings:
       Period: 300
       Threshold: 15
     InstanceType:
-      Value: "t3a.micro"
+      Value: "t4g.micro"
   Constants:
     RunbookCopy:
       Value: <<<Runbook|https://docs.google.com/document/d/1VRYMTYtlb0pYt19S7AZoXttLH3N2MJ41hS5oo2vfVhI>>>

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -10,7 +10,7 @@ Mappings:
       Period: 300
       Threshold: 15
     InstanceType:
-       Value: "t3a.micro"
+       Value: "t4g.micro"
   PROD:
     ScalingUp:
       Period: 300

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       amiEncrypted: true
       amiTags:
-        Recipe: xenial-mobile-node
+        Recipe: xenial-mobile-node-ARM
         AmigoStage: PROD
       templatePath: cloudformation.yaml
   mobile-apps-rendering:


### PR DESCRIPTION
## Why are you doing this?
After Simon's tech time talk about upgrading our instances to ARM-64 we are trying it out for Apps Rendering.

## Changes

- We baked a new recipe in AMIgo, based on a clone of the current Apps Rendering AMI
- We changed the instance type to be `t4g.micro` from `t3a.micro`

We tested on CODE first to make sure everything was fine. This PR updates the same for PROD, and uses the new recipe. We may choose to delete the old recipe after this has been in production, to clear up after ourselves.

Paired with @marjisound and @dskamiotis 
