### PR TITLE
LIVE-1473: Editions Gallery

### DIFF
--- a/src/client/editions.ts
+++ b/src/client/editions.ts
@@ -25,6 +25,36 @@ const initLightbox = (): void => {
 	});
 };
 
+const adjustGalleryImages = (): void => {
+	const figures: NodeListOf<HTMLElement> = document.querySelectorAll(
+		'.editions-gallery-figure',
+	);
+	if (figures.length === 0) return;
+
+	Array.from(figures).forEach((figure) => {
+		const imageEl = figure.querySelector('img');
+		const updateHeight = (): void => {
+			const captionHeight =
+				figure.querySelector('.editions-gallery-caption')
+					?.clientHeight ?? 0;
+			if (captionHeight > figure.clientHeight) {
+				figure.style.minHeight = `${captionHeight}px`;
+			}
+		};
+
+		if (imageEl) {
+			if (imageEl.complete) {
+				updateHeight();
+			} else {
+				imageEl.addEventListener('load', () => {
+					updateHeight();
+				});
+			}
+		}
+	});
+};
+
 initLightbox();
+adjustGalleryImages();
 
 ReactDOM.render(h(ShareIcon), document.querySelector('.js-share-button'));

--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -16,7 +16,12 @@ import {
 	articleWidthStyles,
 	headerBackgroundColour,
 	sidePadding,
+	tabletContentWidth,
+	wideContentWidth,
 } from './styles';
+
+const wide = wideContentWidth + 12;
+const tablet = tabletContentWidth + 12;
 
 // ----- Component ----- //
 
@@ -66,8 +71,20 @@ const bodyWrapperStyles = css`
 `;
 
 const galleryWrapperStyles = css`
+	box-sizing: border-box;
+	padding-top: ${remSpace[3]};
 	padding-right: 0;
 	padding-left: 0;
+	border: none;
+	${from.tablet} {
+		width: ${tablet}px;
+		padding-right: ${remSpace[4]};
+		border-right: 1px solid ${neutral[100]};
+	}
+
+	${from.wide} {
+		width: ${wide}px;
+	}
 `;
 
 const headerBackgroundStyles = (item: Format): SerializedStyles => css`

--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -4,7 +4,7 @@ import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { background, border } from '@guardian/src-foundations/palette';
+import { background, border, neutral } from '@guardian/src-foundations/palette';
 import type { Format } from '@guardian/types';
 import { Design, partition } from '@guardian/types';
 import type { Item } from 'item';
@@ -23,6 +23,10 @@ import {
 interface Props {
 	item: Item;
 }
+
+const articleWrapperStyles = (item: Format): SerializedStyles => css`
+	background-color: ${item.design === Design.Media ? neutral[0] : 'inherit'};
+`;
 
 const articleStyles = css`
 	${articleMarginStyles}
@@ -61,12 +65,17 @@ const bodyWrapperStyles = css`
 	${articleWidthStyles}
 `;
 
+const galleryWrapperStyles = css`
+	padding-right: 0;
+	padding-left: 0;
+`;
+
 const headerBackgroundStyles = (item: Format): SerializedStyles => css`
 	background-color: ${headerBackgroundColour(item)};
 `;
 
 const getSectionStyles = (item: Format): SerializedStyles[] => {
-	if (item.design === Design.Interview) {
+	if (item.design === Design.Interview || item.design === Design.Media) {
 		return [];
 	}
 	return [headerStyles, articleStyles];
@@ -84,13 +93,21 @@ const Article: FC<Props> = ({ item }) => {
 	) {
 		return (
 			<main>
-				<article>
+				<article css={articleWrapperStyles(item)}>
 					<div css={headerBackgroundStyles(item)}>
 						<section css={getSectionStyles(item)}>
 							<Header item={item} />
 						</section>
 					</div>
-					<div css={[bodyWrapperStyles, articleStyles]}>
+					<div
+						css={[
+							bodyWrapperStyles,
+							articleStyles,
+							item.design === Design.Media
+								? galleryWrapperStyles
+								: null,
+						]}
+					>
 						<section css={bodyStyles}>
 							{renderEditionsAll(item, partition(item.body).oks)}
 						</section>

--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -79,7 +79,8 @@ const Article: FC<Props> = ({ item }) => {
 		item.design === Design.Comment ||
 		item.design === Design.Review ||
 		item.design === Design.Interview ||
-		item.design === Design.Feature
+		item.design === Design.Feature ||
+		item.design === Design.Media
 	) {
 		return (
 			<main>

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -40,6 +40,10 @@ const interviewStyles = css`
 	${articleWidthStyles}
 `;
 
+const galleryStyles = css`
+	${articleWidthStyles}
+`;
+
 const showcaseStyles = css`
 	padding-bottom: ${remSpace[6]};
 `;
@@ -140,6 +144,10 @@ const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
 
 	if (format.display === Display.Showcase) {
 		return css(styles(kickerColor), showcaseStyles);
+	}
+
+	if (format.design === Design.Media) {
+		return css(styles(kickerColor), galleryStyles);
 	}
 
 	return styles(kickerColor);

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
-import { remSpace } from '@guardian/src-foundations';
+import { neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { body, headline } from '@guardian/src-foundations/typography';
 import type {
@@ -181,9 +181,12 @@ const Byline: FC<Props> = ({ item, shareIcon, large, avatar }) => {
 	const format = getFormat(item);
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
 
+	const bylineColor =
+		format.design === Design.Media ? neutral[100] : kickerColor;
+
 	return maybeRender(item.bylineHtml, (byline) => (
-		<div css={getStyles(format, kickerColor)}>
-			<address>{renderText(byline, kickerColor, large)}</address>
+		<div css={getStyles(format, bylineColor)}>
+			<address>{renderText(byline, bylineColor, large)}</address>
 			{shareIcon && (
 				<span className="js-share-button" role="button">
 					<ShareIcon />

--- a/src/components/editions/galleryImage.tsx
+++ b/src/components/editions/galleryImage.tsx
@@ -1,18 +1,32 @@
+import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import type { Sizes } from '@guardian/image-rendering';
 import { Img } from '@guardian/image-rendering';
-import { remSpace } from '@guardian/src-foundations';
-import type { Format } from '@guardian/types';
-import { none } from '@guardian/types';
+import { neutral, remSpace } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+import type { Format, Option } from '@guardian/types';
+import { map, none, some, withDefault } from '@guardian/types';
 import type { Image } from 'bodyElement';
+import { maybeRender, pipe2 } from 'lib';
 import type { FC } from 'react';
 import React from 'react';
+import { getThemeStyles } from 'themeStyles';
 
 const width = '100%';
 
 type Props = {
 	image: Image;
 	format: Format;
+};
+
+type CaptionProps = {
+	details: CaptionDetails;
+	format: Format;
+};
+
+type CaptionDetails = {
+	location: Option<string>;
+	description: Option<string>;
 };
 
 const sizes: Sizes = {
@@ -25,6 +39,83 @@ const styles = css`
 	width: ${width};
 `;
 
+const getCaptionDetails = (oDoc: Option<DocumentFragment>): CaptionDetails => {
+	const details: CaptionDetails = {
+		location: none,
+		description: none,
+	};
+
+	const parseCaptionNode = (doc: DocumentFragment): CaptionDetails =>
+		Array.from(doc.childNodes).reduce((details, node) => {
+			if (node.nodeName === 'STRONG') {
+				details.location = node.textContent
+					? some(node.textContent)
+					: none;
+			} else if (node.nodeName === '#text') {
+				details.description = node.textContent
+					? some(node.textContent)
+					: none;
+			}
+			return details;
+		}, details);
+
+	return pipe2(
+		oDoc,
+		map(parseCaptionNode),
+		withDefault<CaptionDetails>(details),
+	);
+};
+
+const triangleStyles = (color: string): SerializedStyles => css`
+	fill: ${color};
+	height: 0.8rem;
+	padding-right: ${remSpace[1]};
+`;
+
+const Triangle: FC<{ color: string }> = ({ color }) => (
+	<svg
+		css={triangleStyles(color)}
+		viewBox="0 0 10 9"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<polygon points="0,9 5,0 10,9" />
+	</svg>
+);
+
+const CaptionLocation: FC<{ location: string; triangleColor: string }> = ({
+	location,
+	triangleColor,
+}) => {
+	const styles = css`
+		${textSans.small({ fontWeight: 'bold' })}
+		color: ${neutral[100]};
+	`;
+	return (
+		<h2 css={styles}>
+			<Triangle color={triangleColor} />
+			{location}
+		</h2>
+	);
+};
+
+const CaptionDescription: FC<{ description: string }> = ({ description }) => (
+	<p>{description}</p>
+);
+
+const GalleryImageCaption: FC<CaptionProps> = ({ details, format }) => {
+	const { kicker } = getThemeStyles(format.theme);
+	return (
+		<div style={{ background: 'red' }}>
+			{maybeRender(details.location, (location) => (
+				<CaptionLocation location={location} triangleColor={kicker} />
+			))}
+			{maybeRender(details.description, (description) => (
+				<CaptionDescription description={description} />
+			))}
+		</div>
+	);
+};
+
 const GalleryImage: FC<Props> = ({ image, format }) => {
 	return (
 		<figure css={styles}>
@@ -35,6 +126,10 @@ const GalleryImage: FC<Props> = ({ image, format }) => {
 				format={format}
 				supportsDarkMode={false}
 				lightbox={none}
+			/>
+			<GalleryImageCaption
+				details={getCaptionDetails(image.caption)}
+				format={format}
 			/>
 		</figure>
 	);

--- a/src/components/editions/galleryImage.tsx
+++ b/src/components/editions/galleryImage.tsx
@@ -21,7 +21,7 @@ const sizes: Sizes = {
 };
 
 const styles = css`
-	margin: ${remSpace[4]} 0;
+	margin: 0 0 ${remSpace[4]};
 	width: ${width};
 `;
 

--- a/src/components/editions/galleryImage.tsx
+++ b/src/components/editions/galleryImage.tsx
@@ -98,9 +98,13 @@ const CaptionLocation: FC<{ location: string; triangleColor: string }> = ({
 	);
 };
 
-const CaptionDescription: FC<{ description: string }> = ({ description }) => (
-	<p>{description}</p>
-);
+const CaptionDescription: FC<{ description: string }> = ({ description }) => {
+	const styles = css`
+		${textSans.small()};
+		color: ${neutral[100]};
+	`;
+	return <p css={styles}>{description}</p>;
+};
 
 const GalleryImageCaption: FC<CaptionProps> = ({ details, format }) => {
 	const { kicker } = getThemeStyles(format.theme);
@@ -125,7 +129,11 @@ const GalleryImage: FC<Props> = ({ image, format }) => {
 				className={none}
 				format={format}
 				supportsDarkMode={false}
-				lightbox={none}
+				lightbox={some({
+					className: 'js-launch-slideshow',
+					caption: none,
+					credit: none,
+				})}
 			/>
 			<GalleryImageCaption
 				details={getCaptionDetails(image.caption)}

--- a/src/components/editions/galleryImage.tsx
+++ b/src/components/editions/galleryImage.tsx
@@ -38,6 +38,7 @@ const sizes: Sizes = {
 const styles = css`
 	margin: 0 0 ${remSpace[6]};
 	width: ${width};
+	position: relative;
 	p {
 		${from.tablet} {
 			margin: 0;
@@ -75,17 +76,18 @@ const getCaptionDetails = (oDoc: Option<DocumentFragment>): CaptionDetails => {
 
 const triangleStyles = (color: string): SerializedStyles => css`
 	fill: ${color};
-	height: 0.8rem;
+	height: 0.6875rem;
+	width: 0.8125rem;
 	padding-right: ${remSpace[1]};
 `;
 
 const Triangle: FC<{ color: string }> = ({ color }) => (
 	<svg
+		viewBox="0 0 13 11"
 		css={triangleStyles(color)}
-		viewBox="0 0 10 9"
 		xmlns="http://www.w3.org/2000/svg"
 	>
-		<polygon points="0,9 5,0 10,9" />
+		<path d="M6.5 0L13 11H0L6.5 0Z" />
 	</svg>
 );
 
@@ -98,6 +100,13 @@ const CaptionLocation: FC<{ location: string; triangleColor: string }> = ({
 		color: ${neutral[100]};
 		margin: 0;
 		padding: ${remSpace[1]} 0 0;
+
+		${from.tablet} {
+			padding: 0;
+			svg {
+				transform: translateX(-10%) translateY(-15%) rotateZ(-90deg);
+			}
+		}
 	`;
 	return (
 		<h2 css={styles}>
@@ -119,8 +128,17 @@ const CaptionDescription: FC<{ description: string }> = ({ description }) => {
 
 const GalleryImageCaption: FC<CaptionProps> = ({ details, format }) => {
 	const { kicker } = getThemeStyles(format.theme);
+	const tabletWidth = '170px';
+	const styles = css`
+		${from.tablet} {
+			position: absolute;
+			top: -${remSpace[1]};
+			width: ${tabletWidth};
+			right: calc(-${tabletWidth} - 2rem);
+		}
+	`;
 	return (
-		<div>
+		<div css={styles} className="editions-gallery-caption">
 			{maybeRender(details.location, (location) => (
 				<CaptionLocation location={location} triangleColor={kicker} />
 			))}
@@ -133,7 +151,7 @@ const GalleryImageCaption: FC<CaptionProps> = ({ details, format }) => {
 
 const GalleryImage: FC<Props> = ({ image, format }) => {
 	return (
-		<figure css={styles}>
+		<figure css={styles} className="editions-gallery-figure">
 			<Img
 				image={image}
 				sizes={sizes}

--- a/src/components/editions/galleryImage.tsx
+++ b/src/components/editions/galleryImage.tsx
@@ -1,0 +1,43 @@
+import { css } from '@emotion/core';
+import type { Sizes } from '@guardian/image-rendering';
+import { Img } from '@guardian/image-rendering';
+import { remSpace } from '@guardian/src-foundations';
+import type { Format } from '@guardian/types';
+import { none } from '@guardian/types';
+import type { Image } from 'bodyElement';
+import type { FC } from 'react';
+import React from 'react';
+
+const width = '100%';
+
+type Props = {
+	image: Image;
+	format: Format;
+};
+
+const sizes: Sizes = {
+	mediaQueries: [],
+	default: width,
+};
+
+const styles = css`
+	margin: ${remSpace[4]} 0;
+	width: ${width};
+`;
+
+const GalleryImage: FC<Props> = ({ image, format }) => {
+	return (
+		<figure css={styles}>
+			<Img
+				image={image}
+				sizes={sizes}
+				className={none}
+				format={format}
+				supportsDarkMode={false}
+				lightbox={none}
+			/>
+		</figure>
+	);
+};
+
+export default GalleryImage;

--- a/src/components/editions/galleryImage.tsx
+++ b/src/components/editions/galleryImage.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/core';
 import type { Sizes } from '@guardian/image-rendering';
 import { Img } from '@guardian/image-rendering';
 import { neutral, remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
 import type { Format, Option } from '@guardian/types';
 import { map, none, some, withDefault } from '@guardian/types';
@@ -35,8 +36,14 @@ const sizes: Sizes = {
 };
 
 const styles = css`
-	margin: 0 0 ${remSpace[4]};
+	margin: 0 0 ${remSpace[6]};
 	width: ${width};
+	p {
+		${from.tablet} {
+			margin: 0;
+			padding: 0;
+		}
+	}
 `;
 
 const getCaptionDetails = (oDoc: Option<DocumentFragment>): CaptionDetails => {
@@ -89,6 +96,8 @@ const CaptionLocation: FC<{ location: string; triangleColor: string }> = ({
 	const styles = css`
 		${textSans.small({ fontWeight: 'bold' })}
 		color: ${neutral[100]};
+		margin: 0;
+		padding: ${remSpace[1]} 0 0;
 	`;
 	return (
 		<h2 css={styles}>
@@ -100,8 +109,10 @@ const CaptionLocation: FC<{ location: string; triangleColor: string }> = ({
 
 const CaptionDescription: FC<{ description: string }> = ({ description }) => {
 	const styles = css`
-		${textSans.small()};
+		${textSans.small({ lineHeight: 'regular' })};
 		color: ${neutral[100]};
+		margin: 0;
+		padding: 0;
 	`;
 	return <p css={styles}>{description}</p>;
 };

--- a/src/components/editions/galleryImage.tsx
+++ b/src/components/editions/galleryImage.tsx
@@ -120,7 +120,7 @@ const CaptionDescription: FC<{ description: string }> = ({ description }) => {
 const GalleryImageCaption: FC<CaptionProps> = ({ details, format }) => {
 	const { kicker } = getThemeStyles(format.theme);
 	return (
-		<div style={{ background: 'red' }}>
+		<div>
 			{maybeRender(details.location, (location) => (
 				<CaptionLocation location={location} triangleColor={kicker} />
 			))}

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -96,6 +96,16 @@ const InterviewHeader: FC<HeaderProps> = ({ item }) => (
 	</header>
 );
 
+const GalleryHeader: FC<HeaderProps> = ({ item }) => (
+	<header css={headerStyles}>
+		<HeaderImage item={item} />
+		<Headline item={item} />
+		<Standfirst item={item} />
+		<Lines />
+		<Byline item={item} shareIcon />
+	</header>
+);
+
 const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 	if (item.design === Design.Interview) {
 		return <InterviewHeader item={item} />;
@@ -105,6 +115,8 @@ const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 		return <AnalysisHeader item={item} />;
 	} else if (item.design === Design.Comment) {
 		return <CommentHeader item={item} />;
+	} else if (item.design === Design.Media) {
+		return <GalleryHeader item={item} />;
 	} else {
 		return <StandardHeader item={item} />;
 	}

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -97,7 +97,7 @@ const InterviewHeader: FC<HeaderProps> = ({ item }) => (
 );
 
 const GalleryHeader: FC<HeaderProps> = ({ item }) => (
-	<header css={headerStyles}>
+	<header>
 		<HeaderImage item={item} />
 		<Headline item={item} />
 		<Standfirst item={item} />

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -37,7 +37,7 @@ const headerStyles = css`
 	${sidePadding}
 `;
 
-const galleryHeaderStyles = css`
+const galleryInnerHeaderStyles = css`
 	${sidePadding}
 	${from.tablet} {
 		padding-left: ${tabletArticleMargin}px;
@@ -45,6 +45,13 @@ const galleryHeaderStyles = css`
 
 	${from.wide} {
 		padding-left: ${wideArticleMargin}px;
+	}
+`;
+
+const galleryHeaderStyles = css`
+	border-bottom: 1px solid ${neutral[100]};
+	${from.tablet} {
+		border: none;
 	}
 `;
 
@@ -60,8 +67,8 @@ const galleryLinesStyles = css`
 
 const galleryHeaderBorderStyles = css`
 	${from.tablet} {
-		border-right: 1px solid ${neutral[100]};
 		border-bottom: 1px solid ${neutral[100]};
+		border-right: 1px solid ${neutral[100]};
 		box-sizing: border-box;
 		width: ${tablet}px;
 		${from.wide} {
@@ -136,9 +143,9 @@ const InterviewHeader: FC<HeaderProps> = ({ item }) => (
 );
 
 const GalleryHeader: FC<HeaderProps> = ({ item }) => (
-	<header>
+	<header css={galleryHeaderStyles}>
 		<HeaderImage item={item} />
-		<div css={galleryHeaderStyles}>
+		<div css={galleryInnerHeaderStyles}>
 			<Headline item={item} />
 			<div css={galleryHeaderBorderStyles}>
 				<Standfirst item={item} />

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -2,6 +2,7 @@
 
 import { css } from '@emotion/core';
 import type { SerializedStyles } from '@emotion/core';
+import { neutral } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';
 import { Design, Display } from '@guardian/types';
@@ -18,8 +19,13 @@ import {
 	interviewBackgroundColour,
 	sidePadding,
 	tabletArticleMargin,
+	tabletContentWidth,
 	wideArticleMargin,
+	wideContentWidth,
 } from './styles';
+
+const wide = wideContentWidth + 12;
+const tablet = tabletContentWidth + 12;
 
 // ----- Component ----- //
 
@@ -29,6 +35,39 @@ interface HeaderProps {
 
 const headerStyles = css`
 	${sidePadding}
+`;
+
+const galleryHeaderStyles = css`
+	${sidePadding}
+	${from.tablet} {
+		padding-left: ${tabletArticleMargin}px;
+	}
+
+	${from.wide} {
+		padding-left: ${wideArticleMargin}px;
+	}
+`;
+
+const galleryLinesStyles = css`
+	${from.tablet} {
+		margin-left: 0;
+	}
+
+	${from.wide} {
+		margin-left: 0;
+	}
+`;
+
+const galleryHeaderBorderStyles = css`
+	${from.tablet} {
+		border-right: 1px solid ${neutral[100]};
+		border-bottom: 1px solid ${neutral[100]};
+		box-sizing: border-box;
+		width: ${tablet}px;
+		${from.wide} {
+			width: ${wide}px;
+		}
+	}
 `;
 
 const interviewHeaderStyles = (item: Format): SerializedStyles => css`
@@ -99,10 +138,14 @@ const InterviewHeader: FC<HeaderProps> = ({ item }) => (
 const GalleryHeader: FC<HeaderProps> = ({ item }) => (
 	<header>
 		<HeaderImage item={item} />
-		<Headline item={item} />
-		<Standfirst item={item} />
-		<Lines />
-		<Byline item={item} shareIcon />
+		<div css={galleryHeaderStyles}>
+			<Headline item={item} />
+			<div css={galleryHeaderBorderStyles}>
+				<Standfirst item={item} />
+				<Lines className={galleryLinesStyles} />
+				<Byline item={item} shareIcon />
+			</div>
+		</div>
 	</header>
 );
 

--- a/src/components/editions/headerImage.tsx
+++ b/src/components/editions/headerImage.tsx
@@ -56,6 +56,10 @@ const captionStyles = css`
 
 const fullWidthCaptionStyles = css`
 	width: 100%;
+
+	${from.tablet} {
+		width: 100%;
+	}
 `;
 
 const getStyles = (format: Format): SerializedStyles => {

--- a/src/components/editions/headerImage.tsx
+++ b/src/components/editions/headerImage.tsx
@@ -41,7 +41,7 @@ const styles = css`
 const fullWidthStyles = css`
 	margin: 0;
 	position: relative;
-	width: 100vw;
+	width: 100%;
 `;
 
 const captionStyles = css`
@@ -55,11 +55,7 @@ const captionStyles = css`
 `;
 
 const fullWidthCaptionStyles = css`
-	width: 100vw;
-
-	${from.wide} {
-		width: 100vw;
-	}
+	width: 100%;
 `;
 
 const getStyles = (format: Format): SerializedStyles => {

--- a/src/components/editions/headerImage.tsx
+++ b/src/components/editions/headerImage.tsx
@@ -63,11 +63,17 @@ const fullWidthCaptionStyles = css`
 `;
 
 const getStyles = (format: Format): SerializedStyles => {
-	return format.design === Design.Interview ? fullWidthStyles : styles;
+	switch (format.design) {
+		case Design.Interview:
+		case Design.Media:
+			return fullWidthStyles;
+		default:
+			return styles;
+	}
 };
 
 const getCaptionStyles = (format: Format): SerializedStyles => {
-	return format.design === Design.Interview
+	return format.design === Design.Interview || format.design === Design.Media
 		? fullWidthCaptionStyles
 		: captionStyles;
 };
@@ -76,7 +82,7 @@ const getImageStyle = (
 	{ width, height }: Image,
 	format: Format,
 ): SerializedStyles => {
-	if (format.design === Design.Interview) {
+	if (format.design === Design.Interview || format.design === Design.Media) {
 		return css`
 			display: block;
 			width: 100%;
@@ -118,7 +124,9 @@ const fullWidthSizes: Sizes = {
 };
 
 const getSizes = (format: Format): Sizes => {
-	return format.design === Design.Interview ? fullWidthSizes : sizes;
+	return format.design === Design.Interview || format.design === Design.Media
+		? fullWidthSizes
+		: sizes;
 };
 
 const HeaderImage: FC<Props> = ({ item }) => {

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -5,7 +5,7 @@ import type { SerializedStyles } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { border, neutral } from '@guardian/src-foundations/palette';
-import { headline } from '@guardian/src-foundations/typography';
+import { headline, titlepiece } from '@guardian/src-foundations/typography';
 import type {
 	FontWeight,
 	LineHeight,
@@ -113,6 +113,13 @@ const interviewFontStyles = css`
 	display: inline;
 `;
 
+const galleryStyles = css`
+	${titlepiece.small()}
+	font-size: 2rem;
+	line-height: 1.2;
+	padding-bottom: ${remSpace[6]};
+`;
+
 const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
 	if (format.design === Design.Interview) {
 		return css(styles(format), interviewStyles);
@@ -138,6 +145,10 @@ const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
 			fontStyles('regular', 'light'),
 			commentStyles,
 		);
+
+	if (format.design === Design.Media) {
+		return css(styles(format), galleryStyles);
+	}
 
 	return css(styles(format), fontStyles('tight', 'medium'));
 };

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -118,6 +118,7 @@ const galleryStyles = css`
 	font-size: 2rem;
 	line-height: 1.2;
 	padding-bottom: ${remSpace[6]};
+	border: 0;
 `;
 
 const getStyles = (format: Format, kickerColor: string): SerializedStyles => {

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -61,6 +61,11 @@ const showcaseStyles = css`
 	color: ${neutral[20]}
 `;
 
+const galleryStyles = css`
+	${headline.xxsmall({ lineHeight: 'tight', fontWeight: 'regular' })}
+	color: ${neutral[100]};
+`;
+
 const greyTextStyles = css`
 	${headline.xxxsmall({ lineHeight: 'tight', fontWeight: 'bold' })}
 	color: ${neutral[46]}
@@ -83,6 +88,9 @@ const getStyles = (format: Format): SerializedStyles => {
 	}
 	if (format.display === Display.Showcase) {
 		return css(styles(kickerColor), showcaseStyles);
+	}
+	if (format.design === Design.Media) {
+		return css(styles(kickerColor), galleryStyles);
 	}
 	return styles(kickerColor);
 };

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -51,6 +51,10 @@ export const headerBackgroundColour = (format: Format): Colour => {
 		return Palette.neutral[97];
 	}
 
+	if (format.design === Design.Media) {
+		return Palette.neutral[0];
+	}
+
 	if (format.design === Design.Comment) {
 		switch (format.theme) {
 			case Pillar.Culture:

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -397,12 +397,12 @@ const captionElement = (format: Format) => (
 	switch (node.nodeName) {
 		case 'STRONG':
 			return format.design === Design.Media
-				? h('h2', { css: captionHeadingStyles, key }, children)
+				? styledH('h2', { css: captionHeadingStyles, key }, children)
 				: children;
 		case 'BR':
 			return null;
 		case 'EM':
-			return h(
+			return styledH(
 				'em',
 				{
 					css: css`
@@ -416,7 +416,7 @@ const captionElement = (format: Format) => (
 				children,
 			);
 		case 'A':
-			return h(
+			return styledH(
 				Anchor,
 				{
 					href: withDefault('')(getHref(node)),

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -56,6 +56,7 @@ import Blockquote from 'components/blockquote';
 import Bullet from 'components/bullet';
 import CalloutForm from 'components/calloutForm';
 import Credit from 'components/credit';
+import GalleryImage from 'components/editions/galleryImage';
 import EditionsPullquote from 'components/editions/pullquote';
 import HorizontalRule from 'components/horizontalRule';
 import Interactive from 'components/interactive';
@@ -809,7 +810,9 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 			return textRenderer(format, excludeStyles, element);
 
 		case ElementKind.Image:
-			return imageRenderer(format, element, key);
+			return format.design === Design.Media
+				? h(GalleryImage, { format, image: element })
+				: imageRenderer(format, element, key);
 
 		case ElementKind.Pullquote: {
 			const { quote, attribution } = element;

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -35,9 +35,12 @@ const docParser = JSDOM.fragment.bind(null);
 
 const styles = `
     ${pageFonts}
-
+	html {
+		height: 100%;
+	}
     body {
-        margin: 0;
+		margin: 0;
+		min-height: 100%;
     }
 `;
 


### PR DESCRIPTION
## Editions Gallery

This PR implements the Editions gallery template ([Figma file](https://www.figma.com/file/7BWzTDoChAGQKCM4iC27aC/Article-Type-Picker?node-id=1%3A9)) and includes a few extras:
- header caption fixes for full width header images
- fix styled jsx in renderer
- full height article body

### Notes:
- When the caption description gets very long on tablet/wide, I've implemented the first figma design where the caption pushes the next image down. Until design can decide how exactly it needs to be implemented.
- The designs don't include credit, will follow up with design about those but shouldn't be a blocker for this PR.


### Screenshots:

| Mobile |
| --- |
| <img src="https://user-images.githubusercontent.com/12860328/106439340-7d398080-646f-11eb-9f51-8c0a716c63f5.png" width="500px" /> |

| Tablet | Wide |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/12860328/106439357-81659e00-646f-11eb-9ff2-3a4e1a900b23.png" width="500px" /> | <img src="https://user-images.githubusercontent.com/12860328/106439381-8591bb80-646f-11eb-804c-bcdab7014759.png" width="500px"/> |

| Unreasonably long captions |
| --- |
| <img src="https://user-images.githubusercontent.com/12860328/106440242-86771d00-6470-11eb-9829-bb8ae3d3473a.png" width="500px" /> |



