### PR TITLE
LIVE-997: immersive basic styles

### DIFF
--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -6,7 +6,7 @@ import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { background, border, neutral } from '@guardian/src-foundations/palette';
 import type { Format } from '@guardian/types';
-import { Design, partition } from '@guardian/types';
+import { Design, Display, partition } from '@guardian/types';
 import type { Item } from 'item';
 import type { FC } from 'react';
 import { renderEditionsAll } from 'renderer';
@@ -87,12 +87,16 @@ const galleryWrapperStyles = css`
 	}
 `;
 
-const headerBackgroundStyles = (item: Format): SerializedStyles => css`
+const headerBackgroundStyles = (item: Item): SerializedStyles => css`
 	background-color: ${headerBackgroundColour(item)};
 `;
 
 const getSectionStyles = (item: Format): SerializedStyles[] => {
-	if (item.design === Design.Interview || item.design === Design.Media) {
+	if (
+		item.design === Design.Interview ||
+		item.design === Design.Media ||
+		item.display === Display.Immersive
+	) {
 		return [];
 	}
 	return [headerStyles, articleStyles];

--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -87,8 +87,8 @@ const galleryWrapperStyles = css`
 	}
 `;
 
-const headerBackgroundStyles = (item: Item): SerializedStyles => css`
-	background-color: ${headerBackgroundColour(item)};
+const headerBackgroundStyles = (format: Format): SerializedStyles => css`
+	background-color: ${headerBackgroundColour(format)};
 `;
 
 const getSectionStyles = (item: Format): SerializedStyles[] => {

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -219,12 +219,9 @@ const Byline: FC<Props> = ({ item, shareIcon, large, avatar }) => {
 	const format = getFormat(item);
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
 
-	const ignoreKickerColour = (format: Format): boolean => {
-		return (
-			format.design === Design.Media ||
-			format.display === Display.Immersive
-		);
-	};
+	const ignoreKickerColour = (format: Format): boolean =>
+		format.design === Design.Media || format.display === Display.Immersive;
+
 	const bylineColor = ignoreKickerColour(format) ? neutral[100] : kickerColor;
 
 	return maybeRender(item.bylineHtml, (byline) => (

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -46,6 +46,21 @@ const interviewStyles = css`
 	border-right: 1px solid ${border.secondary};
 `;
 
+const immersiveStyles = css`
+	padding-left: ${remSpace[2]};
+	padding-right: ${remSpace[2]};
+
+	${from.tablet} {
+		margin-left: ${remSpace[6]};
+	}
+
+	${from.wide} {
+		margin-left: ${wideArticleMargin}px;
+	}
+
+	${articleWidthStyles}
+`;
+
 const galleryStyles = css`
 	${articleWidthStyles}
 `;
@@ -133,15 +148,24 @@ const bylinePrimaryStyles = (
 	`;
 };
 
-const bylineSecondaryStyles = (large?: boolean): SerializedStyles => css`
+const bylineSecondaryStyles = (
+	kickerColor: string,
+	large?: boolean,
+): SerializedStyles => css`
 	${large
 		? largeTextStyles('italic', 'light')
 		: standardTextStyles('italic', 'light')}
+
+	color: ${kickerColor === neutral[100] ? neutral[100] : neutral[7]}
 `;
 
 const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
 	if (format.design === Design.Interview) {
 		return css(styles(kickerColor), interviewStyles);
+	}
+
+	if (format.display === Display.Immersive) {
+		return css(styles(kickerColor), immersiveStyles);
 	}
 
 	if (format.design === Design.Comment) {
@@ -184,7 +208,7 @@ const renderText = (
 			case 'SPAN':
 			case '#text':
 				return (
-					<span css={bylineSecondaryStyles(large)}>
+					<span css={bylineSecondaryStyles(kickerColor, large)}>
 						{node.textContent ?? ''}
 					</span>
 				);
@@ -195,8 +219,13 @@ const Byline: FC<Props> = ({ item, shareIcon, large, avatar }) => {
 	const format = getFormat(item);
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
 
-	const bylineColor =
-		format.design === Design.Media ? neutral[100] : kickerColor;
+	const ignoreKickerColour = (format: Format): boolean => {
+		return (
+			format.design === Design.Media ||
+			format.display === Display.Immersive
+		);
+	};
+	const bylineColor = ignoreKickerColour(format) ? neutral[100] : kickerColor;
 
 	return maybeRender(item.bylineHtml, (byline) => (
 		<div css={getStyles(format, bylineColor)}>

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -77,7 +77,7 @@ const galleryHeaderBorderStyles = css`
 	}
 `;
 
-const interviewHeaderStyles = (item: Item): SerializedStyles => {
+const interviewAndImmersiveStyles = (item: Item): SerializedStyles => {
 	const backgroundColour =
 		item.design === Design.Interview
 			? interviewBackgroundColour(item)
@@ -146,7 +146,7 @@ const CommentHeader: FC<HeaderProps> = ({ item }) => (
 const InterviewHeader: FC<HeaderProps> = ({ item }) => (
 	<header>
 		<HeaderImage item={item} />
-		<div css={interviewHeaderStyles(item)}>
+		<div css={interviewAndImmersiveStyles(item)}>
 			<Headline item={item} />
 			<Standfirst item={item} />
 		</div>
@@ -172,7 +172,7 @@ const GalleryHeader: FC<HeaderProps> = ({ item }) => (
 const ImmersiveHeader: FC<HeaderProps> = ({ item }) => (
 	<header>
 		<HeaderImage item={item} />
-		<div css={interviewHeaderStyles(item)}>
+		<div css={interviewAndImmersiveStyles(item)}>
 			<Headline item={item} />
 			<Standfirst item={item} />
 			<Lines />

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -4,7 +4,6 @@ import { css } from '@emotion/core';
 import type { SerializedStyles } from '@emotion/core';
 import { border, neutral } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import type { Format } from '@guardian/types';
 import { Design, Display } from '@guardian/types';
 import Byline from 'components/editions/byline';
 import HeaderImage from 'components/editions/headerImage';
@@ -16,6 +15,7 @@ import type { Item } from 'item';
 import type { FC, ReactElement } from 'react';
 import {
 	articleMarginStyles,
+	headerBackgroundColour,
 	interviewBackgroundColour,
 	sidePadding,
 	tabletArticleMargin,
@@ -77,16 +77,24 @@ const galleryHeaderBorderStyles = css`
 	}
 `;
 
-const interviewHeaderStyles = (item: Format): SerializedStyles => css`
-	${from.tablet} {
-		padding-left: ${tabletArticleMargin}px;
-	}
+const interviewHeaderStyles = (item: Item): SerializedStyles => {
+	const backgroundColour =
+		item.design === Design.Interview
+			? interviewBackgroundColour(item)
+			: headerBackgroundColour(item);
 
-	${from.wide} {
-		padding-left: ${wideArticleMargin}px;
-	}
-	background-color: ${interviewBackgroundColour(item)};
-`;
+	return css`
+		${from.tablet} {
+			padding-left: ${tabletArticleMargin}px;
+		}
+
+		${from.wide} {
+			padding-left: ${wideArticleMargin}px;
+		}
+
+		background-color: ${backgroundColour};
+	`;
+};
 
 const linesBorderStyles = css`
 	${articleMarginStyles}
@@ -161,9 +169,23 @@ const GalleryHeader: FC<HeaderProps> = ({ item }) => (
 	</header>
 );
 
+const ImmersiveHeader: FC<HeaderProps> = ({ item }) => (
+	<header>
+		<HeaderImage item={item} />
+		<div css={interviewHeaderStyles(item)}>
+			<Headline item={item} />
+			<Standfirst item={item} />
+			<Lines />
+		</div>
+		<Byline item={item} shareIcon />
+	</header>
+);
+
 const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 	if (item.design === Design.Interview) {
 		return <InterviewHeader item={item} />;
+	} else if (item.display === Display.Immersive) {
+		return <ImmersiveHeader item={item} />;
 	} else if (item.display === Display.Showcase) {
 		return <ShowcaseHeader item={item} />;
 	} else if (item.design === Design.Analysis) {

--- a/src/components/editions/headerImage.tsx
+++ b/src/components/editions/headerImage.tsx
@@ -6,7 +6,7 @@ import type { Sizes } from '@guardian/image-rendering';
 import { Img } from '@guardian/image-rendering';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';
-import { Design, none, some } from '@guardian/types';
+import { Design, Display, none, some } from '@guardian/types';
 import StarRating from 'components/editions/starRating';
 import HeaderImageCaption, { captionId } from 'components/headerImageCaption';
 import { MainMediaKind } from 'headerMedia';
@@ -62,27 +62,31 @@ const fullWidthCaptionStyles = css`
 	}
 `;
 
+const isFullWidthImage = (format: Format): boolean =>
+	format.display === Display.Immersive ||
+	format.design === Design.Interview ||
+	format.design === Design.Media;
+
+const hasSeries = (format: Format): boolean =>
+	format.display === Display.Immersive || format.design === Design.Interview;
+
 const getStyles = (format: Format): SerializedStyles => {
-	switch (format.design) {
-		case Design.Interview:
-		case Design.Media:
-			return fullWidthStyles;
-		default:
-			return styles;
-	}
+	return isFullWidthImage(format) ? fullWidthStyles : styles;
 };
 
 const getCaptionStyles = (format: Format): SerializedStyles => {
-	return format.design === Design.Interview || format.design === Design.Media
-		? fullWidthCaptionStyles
-		: captionStyles;
+	return isFullWidthImage(format) ? fullWidthCaptionStyles : captionStyles;
+};
+
+const getImageSizes = (format: Format): Sizes => {
+	return isFullWidthImage(format) ? fullWidthSizes : sizes;
 };
 
 const getImageStyle = (
 	{ width, height }: Image,
 	format: Format,
 ): SerializedStyles => {
-	if (format.design === Design.Interview || format.design === Design.Media) {
+	if (isFullWidthImage(format)) {
 		return css`
 			display: block;
 			width: 100%;
@@ -123,12 +127,6 @@ const fullWidthSizes: Sizes = {
 	default: '100vw',
 };
 
-const getSizes = (format: Format): Sizes => {
-	return format.design === Design.Interview || format.design === Design.Media
-		? fullWidthSizes
-		: sizes;
-};
-
 const HeaderImage: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 	const {
@@ -146,7 +144,7 @@ const HeaderImage: FC<Props> = ({ item }) => {
 				<figure css={getStyles(format)} aria-labelledby={captionId}>
 					<Img
 						image={image}
-						sizes={getSizes(format)}
+						sizes={getImageSizes(format)}
 						format={item}
 						className={some(getImageStyle(image, format))}
 						supportsDarkMode
@@ -156,7 +154,7 @@ const HeaderImage: FC<Props> = ({ item }) => {
 							credit: none,
 						})}
 					/>
-					{item.design === Design.Interview && <Series item={item} />}
+					{hasSeries(format) && <Series item={item} />}
 					<HeaderImageCaption
 						caption={nativeCaption}
 						credit={credit}

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -84,6 +84,17 @@ const interviewStyles = css`
 	border: 0;
 `;
 
+const immersiveStyles = css`
+	border: 0;
+	margin-left: ${remSpace[2]};
+	padding-top: ${remSpace[1]};
+	padding-bottom: ${remSpace[6]};
+
+	${from.tablet} {
+		margin-left: 0;
+	}
+`;
+
 const commentStyles = css`
 	padding-bottom: 0;
 	padding-right: 6rem;
@@ -123,15 +134,27 @@ const galleryStyles = css`
 
 const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
 	if (format.design === Design.Interview) {
-		return css(styles(format), interviewStyles);
+		return css(
+			styles(format),
+			fontStyles('tight', 'bold'),
+			interviewStyles,
+		);
 	}
 
 	if (
 		format.design === Design.Review ||
-		format.display === Display.Showcase ||
-		format.display === Display.Immersive
-	)
+		format.display === Display.Showcase
+	) {
 		return css(styles(format), fontStyles('tight', 'bold'));
+	}
+
+	if (format.display === Display.Immersive) {
+		return css(
+			styles(format),
+			fontStyles('tight', 'bold'),
+			immersiveStyles,
+		);
+	}
 
 	if (format.design === Design.Analysis)
 		return css(

--- a/src/components/editions/lines.tsx
+++ b/src/components/editions/lines.tsx
@@ -2,7 +2,6 @@
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { Lines } from '@guardian/src-ed-lines';
-import { from } from '@guardian/src-foundations/mq';
 import type { FC } from 'react';
 import { borderWidthStyles } from './styles';
 
@@ -10,10 +9,6 @@ import { borderWidthStyles } from './styles';
 
 const styles = css`
 	box-sizing: border-box;
-
-	${from.tablet} {
-		margin: 0 auto;
-	}
 
 	${borderWidthStyles}
 `;

--- a/src/components/editions/series.tsx
+++ b/src/components/editions/series.tsx
@@ -58,8 +58,7 @@ const getStyles = (item: Item): SerializedStyles => {
 	const { kicker } = getThemeStyles(format.theme);
 	if (
 		item.design === Design.Interview ||
-		item.display === Display.Immersive ||
-		item.design === Design.Media
+		item.display === Display.Immersive
 	) {
 		return css(styles(kicker), interviewStyles(kicker));
 	}

--- a/src/components/editions/series.tsx
+++ b/src/components/editions/series.tsx
@@ -2,17 +2,16 @@
 
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
-import { border, neutral, remSpace } from '@guardian/src-foundations';
+import { neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { titlepiece } from '@guardian/src-foundations/typography';
-import { Design } from '@guardian/types';
+import { Design, Display } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import { kickerPicker } from './kickerPicker';
-import { articleWidthStyles } from './styles';
 
 // ----- Component ----- //
 
@@ -22,15 +21,14 @@ const styles = (kicker: string): SerializedStyles => css`
 	color: ${kicker};
 	font-size: 1.0625rem;
 	padding: ${remSpace[1]} 0 ${remSpace[2]};
-	border-top: 1px solid ${border.secondary};
 	box-sizing: border-box;
-
-	${articleWidthStyles}
+	width: fit-content;
 
 	${from.tablet} {
 		padding-bottom: ${remSpace[3]};
 	}
 `;
+
 const interviewStyles = (kicker: string): SerializedStyles => css`
 	position: absolute;
 	left: 0;
@@ -58,7 +56,11 @@ interface Props {
 const getStyles = (item: Item): SerializedStyles => {
 	const format = getFormat(item);
 	const { kicker } = getThemeStyles(format.theme);
-	if (item.design === Design.Interview) {
+	if (
+		item.design === Design.Interview ||
+		item.display === Display.Immersive ||
+		item.design === Design.Media
+	) {
 		return css(styles(kicker), interviewStyles(kicker));
 	}
 	return styles(kicker);

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -3,6 +3,7 @@
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { neutral, remSpace, text } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { body, headline } from '@guardian/src-foundations/typography';
 import type { Format } from '@guardian/types';
 import { Design, Display } from '@guardian/types';
@@ -55,7 +56,6 @@ const styles = (kickerColor: string): SerializedStyles => css`
 const interviewStyles = css`
 	${sidePadding}
 `;
-
 const showcaseStyles = css`
 	${headline.xxsmall({ lineHeight: 'tight' })}
 	color: ${neutral[20]}
@@ -69,6 +69,19 @@ const galleryStyles = css`
 const greyTextStyles = css`
 	${headline.xxxsmall({ lineHeight: 'tight', fontWeight: 'bold' })}
 	color: ${neutral[46]}
+`;
+
+const immersiveStyles = `
+	${headline.xxxsmall({ lineHeight: 'tight', fontWeight: 'bold' })};
+	color: ${neutral[100]};
+
+	padding-left: ${remSpace[2]};
+	padding-right: ${remSpace[2]};
+
+	${from.tablet} {
+		padding-left: 0;
+		padding-right: 0;
+	}
 `;
 
 interface Props {
@@ -85,6 +98,9 @@ const getStyles = (format: Format): SerializedStyles => {
 	}
 	if (format.design === Design.Analysis || format.design === Design.Comment) {
 		return css(styles(kickerColor), greyTextStyles);
+	}
+	if (format.display === Display.Immersive) {
+		return css(styles(kickerColor), immersiveStyles);
 	}
 	if (format.display === Display.Showcase) {
 		return css(styles(kickerColor), showcaseStyles);

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -4,8 +4,10 @@ import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import * as Palette from '@guardian/src-foundations/palette';
 import type { Format } from '@guardian/types';
-import { Design, Pillar } from '@guardian/types';
+import { Design, Display, Pillar } from '@guardian/types';
 import type { Colour } from 'editorialPalette';
+import type { Item } from 'item';
+import { getFormat } from 'item';
 
 export const tabletContentWidth = 526;
 export const wideContentWidth = 545;
@@ -59,7 +61,16 @@ export const articleMarginStyles: SerializedStyles = css`
 	}
 `;
 
-export const headerBackgroundColour = (format: Format): Colour => {
+export const headerBackgroundColour = (item: Item): Colour => {
+	const format = getFormat(item);
+
+	if (format.design === Design.Feature) {
+		if (format.display === Display.Immersive) {
+			return Palette.neutral[7];
+		}
+		return Palette.neutral[100];
+	}
+
 	if (format.design === Design.Analysis) {
 		return Palette.neutral[97];
 	}

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -61,9 +61,7 @@ export const articleMarginStyles: SerializedStyles = css`
 	}
 `;
 
-export const headerBackgroundColour = (item: Item): Colour => {
-	const format = getFormat(item);
-
+export const headerBackgroundColour = (format: Format): Colour => {
 	if (format.design === Design.Feature) {
 		if (format.display === Display.Immersive) {
 			return Palette.neutral[7];


### PR DESCRIPTION
## Why are you doing this?

Updates the majority of styles for the immersive template. Have added a list of outstanding tasks below screenshots.

## Changes

- Add `Immersive` to to list of templates with no wrapper styles
- Add white text option to Byline Italics
- Add `Immersive` to list of fullwidth image templates
- Add  standfirst styling
- Add  headline styling
- Add series styling
- Add background colour

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/106485493-8f83e080-64a8-11eb-8687-dbfee23483ad.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/106485525-9874b200-64a8-11eb-9738-461e2e5b78c0.png" width="300px" /> |

## Outstanding tasks for Immersive template:
- Lines (triple-line) component needs padding
- Headline needs pillar colours for white bg variant
- Standfirst needs pillar colours for white bg variant
- Byline needs pillar colours for white bg variant
- Image needs positioning lower on page
- Kicker position needs to move, possibly into headline comopnent
