### PR TITLE
Limit Chromatic Runs To main And PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,6 +2,18 @@ name: 'Chromatic'
 
 on:
     push:
+        branches:
+            - main
+        paths-ignore:
+            - 'api-models/'
+            - 'project/'
+            - '*.sbt'
+            - '*.md'
+            - '*.yml'
+            - '.gitignore'
+    pull_request:
+        branches:
+            - main
         paths-ignore:
             - 'api-models/'
             - 'project/'


### PR DESCRIPTION
## Why are you doing this?

Chromatic is currently running on every branch that's pushed. We probably only want to run it in one of two cases:

1. A PR is opened against `main`
2. A PR is merged to `main` (we want to run against `main` once the PR is merged)

This should limit our usage of the Chromatic API.

## Changes

- Only run chromatic on merges to `main` or PRs to `main`
