### PR TITLE
LIVE-997: update widths

### DIFF
--- a/src/components/editions/article.tsx
+++ b/src/components/editions/article.tsx
@@ -30,7 +30,7 @@ interface Props {
 }
 
 const articleWrapperStyles = (item: Format): SerializedStyles => css`
-	background-color: ${item.design === Design.Media ? neutral[0] : 'inherit'};
+	background-color: ${item.design === Design.Media ? neutral[7] : 'inherit'};
 `;
 
 const articleStyles = css`

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -22,7 +22,9 @@ import { ShareIcon } from './shareIcon';
 import {
 	articleWidthStyles,
 	borderWidthStyles,
+	tabletImmersiveWidth,
 	wideArticleMargin,
+	wideImmersiveWidth,
 } from './styles';
 
 // ----- Styles ----- //
@@ -49,16 +51,19 @@ const interviewStyles = css`
 const immersiveStyles = css`
 	padding-left: ${remSpace[2]};
 	padding-right: ${remSpace[2]};
+	box-sizing: border-box;
 
 	${from.tablet} {
+		padding-left: 0;
+		padding-right: ${remSpace[2]};
 		margin-left: ${remSpace[6]};
+		width: ${tabletImmersiveWidth}px;
 	}
 
 	${from.wide} {
 		margin-left: ${wideArticleMargin}px;
+		width: ${wideImmersiveWidth}px;
 	}
-
-	${articleWidthStyles}
 `;
 
 const galleryStyles = css`
@@ -160,12 +165,12 @@ const bylineSecondaryStyles = (
 `;
 
 const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
-	if (format.design === Design.Interview) {
-		return css(styles(kickerColor), interviewStyles);
-	}
-
 	if (format.display === Display.Immersive) {
 		return css(styles(kickerColor), immersiveStyles);
+	}
+
+	if (format.design === Design.Interview) {
+		return css(styles(kickerColor), interviewStyles);
 	}
 
 	if (format.design === Design.Comment) {

--- a/src/components/editions/byline.tsx
+++ b/src/components/editions/byline.tsx
@@ -165,6 +165,7 @@ const bylineSecondaryStyles = (
 `;
 
 const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
+	// Display.Immersive needs to come before Design.Interview
 	if (format.display === Display.Immersive) {
 		return css(styles(kickerColor), immersiveStyles);
 	}

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -220,6 +220,7 @@ const ImmersiveHeader: FC<HeaderProps> = ({ item }) => (
 );
 
 const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
+	// Display.Immersive needs to come before Design.Interview
 	if (item.display === Display.Immersive) {
 		return <ImmersiveHeader item={item} />;
 	} else if (item.design === Design.Interview) {

--- a/src/components/editions/header.tsx
+++ b/src/components/editions/header.tsx
@@ -2,7 +2,7 @@
 
 import { css } from '@emotion/core';
 import type { SerializedStyles } from '@emotion/core';
-import { border, neutral } from '@guardian/src-foundations';
+import { border, neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { Design, Display } from '@guardian/types';
 import Byline from 'components/editions/byline';
@@ -20,8 +20,10 @@ import {
 	sidePadding,
 	tabletArticleMargin,
 	tabletContentWidth,
+	tabletImmersiveWidth,
 	wideArticleMargin,
 	wideContentWidth,
+	wideImmersiveWidth,
 } from './styles';
 
 const wide = wideContentWidth + 12;
@@ -77,11 +79,8 @@ const galleryHeaderBorderStyles = css`
 	}
 `;
 
-const interviewAndImmersiveStyles = (item: Item): SerializedStyles => {
-	const backgroundColour =
-		item.design === Design.Interview
-			? interviewBackgroundColour(item)
-			: headerBackgroundColour(item);
+const interviewStyles = (item: Item): SerializedStyles => {
+	const backgroundColour = interviewBackgroundColour(item);
 
 	return css`
 		${from.tablet} {
@@ -95,6 +94,43 @@ const interviewAndImmersiveStyles = (item: Item): SerializedStyles => {
 		background-color: ${backgroundColour};
 	`;
 };
+
+const immersiveHeadlineStyles = (item: Item): SerializedStyles => {
+	const backgroundColour = headerBackgroundColour(item);
+
+	return css`
+		position: relative;
+		margin-top: -3.3125rem;
+		margin-right: 3.625rem;
+		z-index: 2;
+
+		${from.tablet} {
+			margin-top: -4.625rem;
+			padding-left: ${tabletArticleMargin}px;
+			width: ${tabletImmersiveWidth}px;
+		}
+
+		${from.wide} {
+			padding-left: ${wideArticleMargin}px;
+			width: ${wideImmersiveWidth}px;
+		}
+
+		background-color: ${backgroundColour};
+	`;
+};
+
+const immersiveStandfirstStyles = css`
+	padding-left: ${remSpace[2]};
+	padding-right: ${remSpace[2]};
+
+	${from.tablet} {
+		padding-left: ${tabletArticleMargin}px;
+	}
+
+	${from.wide} {
+		padding-left: ${wideArticleMargin}px;
+	}
+`;
 
 const linesBorderStyles = css`
 	${articleMarginStyles}
@@ -146,7 +182,7 @@ const CommentHeader: FC<HeaderProps> = ({ item }) => (
 const InterviewHeader: FC<HeaderProps> = ({ item }) => (
 	<header>
 		<HeaderMedia item={item} />
-		<div css={interviewAndImmersiveStyles(item)}>
+		<div css={interviewStyles(item)}>
 			<Headline item={item} />
 			<Standfirst item={item} />
 		</div>
@@ -172,8 +208,10 @@ const GalleryHeader: FC<HeaderProps> = ({ item }) => (
 const ImmersiveHeader: FC<HeaderProps> = ({ item }) => (
 	<header>
 		<HeaderMedia item={item} />
-		<div css={interviewAndImmersiveStyles(item)}>
+		<div css={immersiveHeadlineStyles(item)}>
 			<Headline item={item} />
+		</div>
+		<div css={immersiveStandfirstStyles}>
 			<Standfirst item={item} />
 			<Lines />
 		</div>
@@ -182,10 +220,10 @@ const ImmersiveHeader: FC<HeaderProps> = ({ item }) => (
 );
 
 const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
-	if (item.design === Design.Interview) {
-		return <InterviewHeader item={item} />;
-	} else if (item.display === Display.Immersive) {
+	if (item.display === Display.Immersive) {
 		return <ImmersiveHeader item={item} />;
+	} else if (item.design === Design.Interview) {
+		return <InterviewHeader item={item} />;
 	} else if (item.display === Display.Showcase) {
 		return <ShowcaseHeader item={item} />;
 	} else if (item.design === Design.Analysis) {

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -132,6 +132,7 @@ const galleryStyles = css`
 	line-height: 1.2;
 	padding-bottom: ${remSpace[6]};
 	border: 0;
+	${articleWidthStyles}
 `;
 
 const headlineStyles = css`
@@ -146,6 +147,7 @@ const seriesStyles = css`
 `;
 
 const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
+	// Display.Immersive needs to come before Design.Interview
 	if (format.display === Display.Immersive) {
 		return css(
 			styles(format),

--- a/src/components/editions/headline.tsx
+++ b/src/components/editions/headline.tsx
@@ -53,9 +53,8 @@ const styles = (format: Format): SerializedStyles => css`
 	box-sizing: border-box;
 	border-top: 1px solid ${border.secondary};
 	padding-bottom: ${remSpace[4]};
+	padding-right: ${remSpace[2]};
 	margin: 0;
-
-	${articleWidthStyles}
 `;
 
 const underline = (kickerColor: string): SerializedStyles => css`
@@ -83,16 +82,18 @@ const fontStyles = (
 const interviewStyles = css`
 	margin-left: ${remSpace[3]};
 	border: 0;
+
+	${articleWidthStyles}
 `;
 
 const immersiveStyles = css`
 	border: 0;
-	margin-left: ${remSpace[2]};
+	padding-left: ${remSpace[2]};
 	padding-top: 0.0625rem;
 	padding-bottom: ${remSpace[6]};
 
 	${from.tablet} {
-		margin-left: 0;
+		padding-left: 0;
 	}
 `;
 
@@ -115,13 +116,13 @@ const interviewFontStyles = css`
 		font-weight: 400;
 	}
 
-	background-color: ${neutral[0]};
+	background-color: ${neutral[7]};
 	color: ${neutral[100]};
 	white-space: pre-wrap;
 	padding-top: 0.0625rem;
 	padding-bottom: ${remSpace[1]};
-	box-shadow: -${remSpace[3]} 0 0 ${neutral[0]},
-		${remSpace[3]} 0 0 ${neutral[0]};
+	box-shadow: -${remSpace[3]} 0 0 ${neutral[7]},
+		${remSpace[3]} 0 0 ${neutral[7]};
 	display: inline;
 `;
 
@@ -145,6 +146,14 @@ const seriesStyles = css`
 `;
 
 const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
+	if (format.display === Display.Immersive) {
+		return css(
+			styles(format),
+			fontStyles('tight', 'bold'),
+			immersiveStyles,
+		);
+	}
+
 	if (format.design === Design.Interview) {
 		return css(
 			styles(format),
@@ -158,14 +167,6 @@ const getStyles = (format: Format, kickerColor: string): SerializedStyles => {
 		format.display === Display.Showcase
 	) {
 		return css(styles(format), fontStyles('tight', 'bold'));
-	}
-
-	if (format.display === Display.Immersive) {
-		return css(
-			styles(format),
-			fontStyles('tight', 'bold'),
-			immersiveStyles,
-		);
 	}
 
 	if (format.design === Design.Analysis)

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -3,7 +3,6 @@
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { neutral, remSpace, text } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
 import { body, headline } from '@guardian/src-foundations/typography';
 import type { Format } from '@guardian/types';
 import { Design, Display } from '@guardian/types';
@@ -74,14 +73,6 @@ const greyTextStyles = css`
 const immersiveStyles = `
 	${headline.xxxsmall({ lineHeight: 'tight', fontWeight: 'bold' })};
 	color: ${neutral[100]};
-
-	padding-left: ${remSpace[2]};
-	padding-right: ${remSpace[2]};
-
-	${from.tablet} {
-		padding-left: 0;
-		padding-right: 0;
-	}
 `;
 
 interface Props {
@@ -93,14 +84,14 @@ const noLinks = true;
 
 const getStyles = (format: Format): SerializedStyles => {
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
+	if (format.display === Display.Immersive) {
+		return css(styles(kickerColor), immersiveStyles);
+	}
 	if (format.design === Design.Interview) {
 		return css(styles(kickerColor), interviewStyles);
 	}
 	if (format.design === Design.Analysis || format.design === Design.Comment) {
 		return css(styles(kickerColor), greyTextStyles);
-	}
-	if (format.display === Display.Immersive) {
-		return css(styles(kickerColor), immersiveStyles);
 	}
 	if (format.display === Display.Showcase) {
 		return css(styles(kickerColor), showcaseStyles);

--- a/src/components/editions/standfirst.tsx
+++ b/src/components/editions/standfirst.tsx
@@ -84,6 +84,8 @@ const noLinks = true;
 
 const getStyles = (format: Format): SerializedStyles => {
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
+
+	// Display.Immersive needs to come before Design.Interview
 	if (format.display === Display.Immersive) {
 		return css(styles(kickerColor), immersiveStyles);
 	}

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -19,6 +19,9 @@ export const wideArticleMargin = 144;
 const wideBorderWidth = wideContentWidth + 13;
 const tabletBorderWidth = tabletContentWidth + 13;
 
+export const tabletImmersiveWidth = tabletBorderWidth;
+export const wideImmersiveWidth = wideBorderWidth;
+
 export const sidePadding = css`
 	padding-left: ${remSpace[2]};
 	padding-right: ${remSpace[2]};
@@ -60,11 +63,8 @@ export const articleMarginStyles: SerializedStyles = css`
 `;
 
 export const headerBackgroundColour = (format: Format): Colour => {
-	if (format.design === Design.Feature) {
-		if (format.display === Display.Immersive) {
-			return Palette.neutral[7];
-		}
-		return Palette.neutral[100];
+	if (format.display === Display.Immersive) {
+		return Palette.neutral[7];
 	}
 
 	if (format.design === Design.Analysis) {
@@ -72,7 +72,7 @@ export const headerBackgroundColour = (format: Format): Colour => {
 	}
 
 	if (format.design === Design.Media) {
-		return Palette.neutral[0];
+		return Palette.neutral[7];
 	}
 
 	if (format.design === Design.Comment) {


### PR DESCRIPTION
## Why are you doing this?

Fixes Immersive layout and moves Immersive above Interview type in pecking order.

## Changes

- Make all background-colour blacks `neutral[7]`
- Move `Immersive` about `Interview` in terms of priority
- Update margins, widths etc to fit layout.
- Remove all `Immersive` white backgrounds until we receive clarity from design


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/106749119-07274c00-661e-11eb-9175-0953fe286142.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/106749158-14443b00-661e-11eb-900f-6bec1ee9ca84.png" width="300px" /> |

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/106749187-1e663980-661e-11eb-8972-14bb28ed7ac7.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/106749229-2c1bbf00-661e-11eb-9e75-e5bab198536a.png" width="300px" /> |
