### PR TITLE
LIVE-1547: add editions specific caption component

### DIFF
--- a/src/components/editions/headerImageCaption.tsx
+++ b/src/components/editions/headerImageCaption.tsx
@@ -1,0 +1,116 @@
+import type { SerializedStyles } from '@emotion/core';
+import { css } from '@emotion/core';
+import { remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { brandAlt, neutral } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import { SvgCamera } from '@guardian/src-icons';
+import type { Option } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
+import { pipe2 } from 'lib';
+import type { FC, ReactElement } from 'react';
+
+const captionId = 'header-image-caption';
+
+const HeaderImageCaptionStyles = (
+	iconBackgroundColor?: string,
+): SerializedStyles => css`
+	summary {
+		text-align: center;
+		background-color: ${iconBackgroundColor
+			? iconBackgroundColor
+			: brandAlt[400]};
+		width: 34px;
+		height: 34px;
+		position: absolute;
+		bottom: 12px;
+		right: 12px;
+		border-radius: 100%;
+		outline: none;
+
+		&::-webkit-details-marker {
+			display: none;
+		}
+	}
+
+	details[open] {
+		min-height: 44px;
+		max-height: 999px;
+		height: 100%;
+		background-color: rgba(0, 0, 0, 0.8);
+		padding: ${remSpace[2]};
+		overflow: hidden;
+		padding-right: ${remSpace[12]};
+		z-index: 1;
+		color: ${neutral[100]};
+		${textSans.small()};
+		box-sizing: border-box;
+
+		${from.tablet} {
+			padding-left: ${remSpace[6]};
+		}
+
+		${from.wide} {
+			padding-left: 9rem;
+		}
+	}
+
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+`;
+
+const svgStyle = (iconColor?: string): SerializedStyles => css`
+	line-height: 32px;
+	font-size: 0;
+	svg {
+		width: 75%;
+		height: 75%;
+		margin: 12.5%;
+	}
+	path {
+		fill: ${iconColor ? iconColor : neutral[7]};
+	}
+`;
+
+interface Props {
+	caption: Option<string>;
+	credit: Option<string>;
+	styles?: SerializedStyles;
+	iconColor?: string;
+	iconBackgroundColor?: string;
+}
+
+const HeaderImageCaption: FC<Props> = ({
+	caption,
+	credit,
+	styles,
+	iconColor,
+	iconBackgroundColor,
+}: Props) =>
+	pipe2(
+		caption,
+		map((cap) => (
+			<figcaption
+				css={[HeaderImageCaptionStyles(iconBackgroundColor), styles]}
+			>
+				<details>
+					<summary>
+						<span css={svgStyle(iconColor)}>
+							<SvgCamera />
+							Click to see figure caption
+						</span>
+					</summary>
+					<span id={captionId}>
+						{cap} {withDefault('')(credit)}
+					</span>
+				</details>
+			</figcaption>
+		)),
+		withDefault<ReactElement | null>(null),
+	);
+
+export default HeaderImageCaption;
+
+export { captionId };

--- a/src/components/editions/headerImageCaption.tsx
+++ b/src/components/editions/headerImageCaption.tsx
@@ -23,8 +23,8 @@ const HeaderImageCaptionStyles = (
 		width: 34px;
 		height: 34px;
 		position: absolute;
-		bottom: 12px;
-		right: 12px;
+		bottom: ${remSpace[3]};
+		right: ${remSpace[3]};
 		border-radius: 100%;
 		outline: none;
 

--- a/src/components/editions/headerMedia.tsx
+++ b/src/components/editions/headerMedia.tsx
@@ -7,8 +7,10 @@ import { Img } from '@guardian/image-rendering';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';
 import { Design, Display, none, some } from '@guardian/types';
+import HeaderImageCaption, {
+	captionId,
+} from 'components/editions/headerImageCaption';
 import StarRating from 'components/editions/starRating';
-import HeaderImageCaption, { captionId } from 'components/headerImageCaption';
 import { MainMediaKind } from 'headerMedia';
 import type { Image } from 'image';
 import type { Item } from 'item';
@@ -69,6 +71,7 @@ const videoStyles = css`
 
 const fullWidthCaptionStyles = css`
 	width: 100%;
+	height: 100%;
 
 	${from.tablet} {
 		width: 100%;


### PR DESCRIPTION
## Why are you doing this?

Creates an Editions specific HeaderImageCaption component with editions styling.

## Changes
- fix svg positioning
- fix caption height
- fix caption text layout

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/106887896-b9721880-66dd-11eb-8f01-c1d6aeadcec8.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/106887937-c858cb00-66dd-11eb-97ed-f1a137c179cb.png" width="300px" /> |

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/106888000-db6b9b00-66dd-11eb-97b8-cc28653e111a.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/106888044-e58d9980-66dd-11eb-9446-7f05498686ac.png" width="300px" /> |


