### PR TITLE
parse image with secureFile as priority

### DIFF
--- a/src/image.ts
+++ b/src/image.ts
@@ -69,8 +69,13 @@ const parseImage = ({ docParser, salt }: Context) => (
 			}
 
 			return some({
-				src: src(salt, asset.file, 500, Dpr.One),
-				...srcsets(asset.file, salt),
+				src: src(
+					salt,
+					asset.typeData.secureFile ?? asset.file,
+					500,
+					Dpr.One,
+				),
+				...srcsets(asset.typeData.secureFile ?? asset.file, salt),
 				alt: fromNullable(data?.alt),
 				width: asset.typeData.width,
 				height: asset.typeData.height,


### PR DESCRIPTION
## Why are you doing this?

Images should be parsed ideally using `secureFile` from assets, upon call to CAPI.
Currently image parsing only constructs the image URL using the `file` property.

## Changes

- Prioritised the parsing to be based on `secureFile`
- Included `file` url as a back up in case https for secureFile is unavailable (null/undefined) using Nullish coalescing

NOTE: in checking on local host articles return `undefined` for secureFile