### PR TITLE
LIVE-1573: create article header stories

### DIFF
--- a/src/components/editions/article/article.stories.tsx
+++ b/src/components/editions/article/article.stories.tsx
@@ -1,0 +1,125 @@
+// ----- Imports ----- //
+
+import { Display, Pillar } from '@guardian/types';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
+import {
+	analysis,
+	article,
+	comment,
+	feature,
+	interview,
+	media,
+	review,
+} from 'fixtures/item';
+import type { ReactElement } from 'react';
+import { selectPillar } from 'storybookHelpers';
+import Article from '../article';
+
+// ----- Setup ------ //
+
+const isImmersive = (): { display: Display } => {
+	return {
+		display: boolean('Immersive', false)
+			? Display.Immersive
+			: Display.Standard,
+	};
+};
+
+// ----- Stories ----- //
+
+const Default = (): ReactElement => (
+	<Article
+		item={{
+			...article,
+			...isImmersive(),
+			theme: selectPillar(Pillar.News),
+		}}
+	/>
+);
+
+const Analysis = (): ReactElement => (
+	<Article
+		item={{
+			...analysis,
+			...isImmersive(),
+			theme: selectPillar(Pillar.Lifestyle),
+		}}
+	/>
+);
+
+const Feature = (): ReactElement => (
+	<Article
+		item={{
+			...feature,
+			...isImmersive(),
+			theme: selectPillar(Pillar.Sport),
+		}}
+	/>
+);
+
+const Review = (): ReactElement => (
+	<Article
+		item={{
+			...review,
+			theme: selectPillar(Pillar.Culture),
+		}}
+	/>
+);
+
+const Showcase = (): ReactElement => (
+	<Article
+		item={{
+			...article,
+			...isImmersive(),
+			theme: selectPillar(Pillar.News),
+		}}
+	/>
+);
+
+const Interview = (): ReactElement => (
+	<Article
+		item={{
+			...interview,
+			...isImmersive(),
+			theme: selectPillar(Pillar.Sport),
+		}}
+	/>
+);
+
+const Comment = (): ReactElement => (
+	<Article
+		item={{
+			...comment,
+			...isImmersive(),
+			theme: selectPillar(Pillar.News),
+		}}
+	/>
+);
+
+const Media = (): ReactElement => (
+	<Article
+		item={{
+			...media,
+			theme: selectPillar(Pillar.News),
+		}}
+	/>
+);
+
+// ----- Exports ----- //
+
+export default {
+	component: Article,
+	title: 'Editions/Article',
+	decorators: [withKnobs],
+};
+
+export {
+	Default,
+	Analysis,
+	Feature,
+	Review,
+	Showcase,
+	Interview,
+	Comment,
+	Media,
+};

--- a/src/components/editions/article/index.tsx
+++ b/src/components/editions/article/index.tsx
@@ -10,7 +10,7 @@ import { Design, Display, partition } from '@guardian/types';
 import type { Item } from 'item';
 import type { FC } from 'react';
 import { renderEditionsAll } from 'renderer';
-import Header from './header';
+import Header from '../header';
 import {
 	articleMarginStyles,
 	articleWidthStyles,
@@ -18,7 +18,7 @@ import {
 	sidePadding,
 	tabletContentWidth,
 	wideContentWidth,
-} from './styles';
+} from '../styles';
 
 const wide = wideContentWidth + 12;
 const tablet = tabletContentWidth + 12;

--- a/src/components/editions/header/index.tsx
+++ b/src/components/editions/header/index.tsx
@@ -25,7 +25,7 @@ import {
 	wideArticleMargin,
 	wideContentWidth,
 	wideImmersiveWidth,
-} from './styles';
+} from '../styles';
 
 const wide = wideContentWidth + 12;
 const tablet = tabletContentWidth + 12;

--- a/src/components/editions/headerMedia/headerMedia.stories.tsx
+++ b/src/components/editions/headerMedia/headerMedia.stories.tsx
@@ -8,32 +8,6 @@ import HeaderMedia from './index';
 
 // ----- Setup ------ //
 
-const image = {
-	kind: 0,
-	value: {
-		kind: 0,
-		image: {
-			src:
-				'https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f',
-			srcset:
-				'https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w',
-			dpr2Srcset:
-				'https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w',
-			alt: 'image',
-			width: 3000,
-			height: 1800,
-			caption: {},
-			credit: { kind: 0, value: 'Photograph: Philip Keith/The Guardian' },
-			nativeCaption: {
-				kind: 0,
-				value:
-					'‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.',
-			},
-			role: 0,
-		},
-	},
-};
-
 const video = {
 	kind: 0,
 	value: {
@@ -56,7 +30,6 @@ const Image = (): ReactElement => (
 	<HeaderMedia
 		item={{
 			...article,
-			mainMedia: image,
 			theme: selectPillar(Pillar.News),
 		}}
 	/>
@@ -66,7 +39,6 @@ const FullScreen = (): ReactElement => (
 	<HeaderMedia
 		item={{
 			...article,
-			mainMedia: image,
 			display: Display.Immersive,
 			theme: selectPillar(Pillar.News),
 		}}
@@ -77,7 +49,6 @@ const WithStarRating = (): ReactElement => (
 	<HeaderMedia
 		item={{
 			...review,
-			mainMedia: image,
 			theme: selectPillar(Pillar.Culture),
 		}}
 	/>

--- a/src/components/standfirst.stories.tsx
+++ b/src/components/standfirst.stories.tsx
@@ -1,25 +1,11 @@
 // ----- Imports ----- //
 
-import { Display, Pillar, toOption } from '@guardian/types';
-import type { Option } from '@guardian/types';
+import { Display, Pillar } from '@guardian/types';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
-import { parse } from 'client/parser';
 import { article, comment, feature, review } from 'fixtures/item';
-import { pipe2 } from 'lib';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Standfirst from './standfirst';
-
-// ----- Setup ----- //
-
-const parser = new DOMParser();
-const parseStandfirst = parse(parser);
-
-const standfirst: Option<DocumentFragment> = pipe2(
-	'<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>',
-	parseStandfirst,
-	toOption,
-);
 
 // ----- Stories ----- //
 
@@ -27,7 +13,6 @@ const Default = (): ReactElement => (
 	<Standfirst
 		item={{
 			...article,
-			standfirst,
 			display: boolean('Immersive', false)
 				? Display.Immersive
 				: Display.Standard,
@@ -40,7 +25,6 @@ const Review = (): ReactElement => (
 	<Standfirst
 		item={{
 			...review,
-			standfirst,
 			display: boolean('Immersive', false)
 				? Display.Immersive
 				: Display.Standard,
@@ -53,7 +37,6 @@ const Feature = (): ReactElement => (
 	<Standfirst
 		item={{
 			...feature,
-			standfirst,
 			display: boolean('Immersive', false)
 				? Display.Immersive
 				: Display.Standard,
@@ -66,7 +49,6 @@ const Comment = (): ReactElement => (
 	<Standfirst
 		item={{
 			...comment,
-			standfirst,
 			display: boolean('Immersive', false)
 				? Display.Immersive
 				: Display.Standard,

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -1,22 +1,96 @@
 // ----- Imports ----- //
 
-import { Design, Display, none, Pillar, some } from '@guardian/types';
+import { Design, Display, none, Pillar, some, toOption } from '@guardian/types';
+import type { Option } from '@guardian/types';
+import { parse } from 'client/parser';
+import type { Contributor } from 'contributor';
+import type { Image } from 'image';
 import type { Item, Review } from 'item';
+import { pipe2 } from 'lib';
 
 // ----- Fixture ----- //
+
+const parser = new DOMParser();
+const parseHtml = parse(parser);
+
+const headline =
+	'Reclaimed lakes and giant airports: how Mexico City might have looked';
+
+const standfirst: Option<DocumentFragment> = pipe2(
+	'<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>',
+	parseHtml,
+	toOption,
+);
+
+const bylineHtml: Option<DocumentFragment> = pipe2(
+	'<a href="https://theguardian.com">Jane Smith</a> Editor of things',
+	parseHtml,
+	toOption,
+);
+
+const srcset =
+	'https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=32&quality=85&fit=bounds&s=100fc280274e40946afb34d4b561ce9f 32w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e 64w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=128&quality=85&fit=bounds&s=35b6ce614cae19fbdcdefa55a670eda5 128w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=192&quality=85&fit=bounds&s=930a05d87b62a1f613ff76f3ee0c97a0 192w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=256&quality=85&fit=bounds&s=8c44b90de342114bd3bf6145767d4b31 256w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=400&quality=85&fit=bounds&s=8491504dfb944eee7ef173e739cb4f74 400w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=600&quality=85&fit=bounds&s=668fc2d7278f6c4a553f806c9b2d47d3 600w';
+
+const image: Image = {
+	src:
+		'https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e',
+	srcset: srcset,
+	dpr2Srcset: srcset,
+	alt: some('image'),
+	width: 550,
+	height: 550,
+	role: 1,
+	caption: none,
+	nativeCaption: none,
+	credit: none,
+};
+
+const contributors: Contributor[] = [
+	{
+		id: 'profile/hannah-j-davies',
+		apiUrl: 'https://content.guardianapis.com/profile/hannah-j-davies',
+		name: 'Hannah J Davies',
+		image: some(image),
+	},
+];
+
+const mainMedia = {
+	kind: 0,
+	value: {
+		kind: 0,
+		image: {
+			src:
+				'https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f',
+			srcset:
+				'https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w',
+			dpr2Srcset:
+				'https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w',
+			alt: 'image',
+			width: 3000,
+			height: 1800,
+			caption: {},
+			credit: { kind: 0, value: 'Photograph: Philip Keith/The Guardian' },
+			nativeCaption: {
+				kind: 0,
+				value:
+					'‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.',
+			},
+			role: 0,
+		},
+	},
+};
 
 const fields = {
 	theme: Pillar.News,
 	display: Display.Standard,
 	body: [],
-	headline:
-		'Reclaimed lakes and giant airports: how Mexico City might have looked',
-	standfirst: none,
+	headline: headline,
+	standfirst: standfirst,
 	byline: '',
-	bylineHtml: none,
+	bylineHtml: bylineHtml,
 	publishDate: none,
-	contributors: [],
-	mainMedia: none,
+	contributors: contributors,
+	mainMedia: mainMedia,
 	series: some({
 		id: '',
 		type: 0,


### PR DESCRIPTION
## Why are you doing this?

Adds Editions article templates to Storybook. 

Note: does not include article bodies at this stage.

## Changes

- Add mock data for stories to `item.tsx`
- Remove duplication of mock data elsewhere
- Move files to folders within Editions folder.

## To test
Run storybook and look under Editions tabs.
