### PR TITLE
No unsafe-inline (and editions twitter bug fix)

### DIFF
--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -127,9 +127,7 @@ function cspEditions(
 ): string {
 	return `
 	default-src 'self';
-	style-src 'self' https://interactive.guim.co.uk ${assetHashes(
-		styles,
-	)} ${styleSrc(styles, thirdPartyEmbed.twitter, true)};
+	style-src 'self' ${assetHashes(styles)};
 	img-src 'self' https://static.theguardian.com https://*.guim.co.uk ${
 		thirdPartyEmbed.twitter
 			? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:'

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -101,16 +101,17 @@ function render(
 ): Page {
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
 	const body = renderBody(item);
-	const head = renderHead(
-		request,
-		getThirdPartyEmbeds(request.content),
-		body.css,
-		body.ids,
-	);
+	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
+	const head = renderHead(request, thirdPartyEmbeds, body.css, body.ids);
 
 	const clientScript = map(getAssetLocation)(some('editions.js'));
 
-	const scripts = <Scripts clientScript={clientScript} twitter={false} />;
+	const scripts = (
+		<Scripts
+			clientScript={clientScript}
+			twitter={thirdPartyEmbeds.twitter}
+		/>
+	);
 
 	return {
 		html: buildHtml(head, body.html, scripts),


### PR DESCRIPTION
I've committed an unnecessary unsafe CSP change. While at it, I noticed that twitter embeds weren't fully working so fixed that one up too. 
