### PR TITLE
LIVE-1578: add shareIcon stories and make default export

### DIFF
--- a/src/client/editions.ts
+++ b/src/client/editions.ts
@@ -3,7 +3,7 @@ import {
 	MessageKind,
 	pingEditionsNative,
 } from '@guardian/renditions';
-import { ShareIcon } from 'components/editions/shareIcon';
+import ShareIcon from 'components/editions/shareIcon';
 import { createElement as h } from 'react';
 import ReactDOM from 'react-dom';
 import interactives from './interactives';

--- a/src/components/editions/byline/index.tsx
+++ b/src/components/editions/byline/index.tsx
@@ -18,7 +18,7 @@ import { maybeRender } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import EditionsAvatar from '../avatar';
-import { ShareIcon } from '../shareIcon';
+import ShareIcon from '../shareIcon';
 import {
 	articleWidthStyles,
 	borderWidthStyles,

--- a/src/components/editions/shareIcon/index.tsx
+++ b/src/components/editions/shareIcon/index.tsx
@@ -52,7 +52,7 @@ const buttonStyles = css`
 	height: 2.5rem;
 `;
 
-export const ShareIcon: FC = () => {
+const ShareIcon: FC = () => {
 	const platform = usePlatform(Platform.IOS);
 	useEffect(() => {
 		pingEditionsNative({ kind: MessageKind.PlatformQuery });
@@ -72,3 +72,5 @@ export const ShareIcon: FC = () => {
 		</button>
 	);
 };
+
+export default ShareIcon;

--- a/src/components/editions/shareIcon/shareIcon.stories.tsx
+++ b/src/components/editions/shareIcon/shareIcon.stories.tsx
@@ -1,0 +1,54 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from '@emotion/core';
+import { css } from '@emotion/core';
+import { Pillar } from '@guardian/types';
+import { withKnobs } from '@storybook/addon-knobs';
+import type { ReactElement } from 'react';
+import { selectPillar } from 'storybookHelpers';
+import { getThemeStyles } from 'themeStyles';
+import ShareIcon from '.';
+
+// ----- Setup ----- //
+
+const styles = (kickerColor: string): SerializedStyles => {
+	return css`
+		svg {
+			flex: 0 0 1.875rem;
+			padding-top: 0.375rem;
+			width: 1.875rem;
+			height: 1.875rem;
+
+			circle {
+				stroke: ${kickerColor};
+			}
+
+			path {
+				fill: ${kickerColor};
+			}
+		}
+	`;
+};
+
+// ----- Stories ----- //
+
+const Default = (): ReactElement => {
+	const theme = selectPillar(Pillar.News);
+	const { kicker } = getThemeStyles(theme);
+
+	return (
+		<div css={styles(kicker)}>
+			<ShareIcon />
+		</div>
+	);
+};
+
+// ----- Exports ----- //
+
+export default {
+	component: ShareIcon,
+	title: 'Editions/ShareIcon',
+	decorators: [withKnobs],
+};
+
+export { Default };

--- a/src/components/editions/standfirst/index.tsx
+++ b/src/components/editions/standfirst/index.tsx
@@ -11,7 +11,7 @@ import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { renderStandfirstText } from 'renderer';
 import { getThemeStyles } from 'themeStyles';
-import { ShareIcon } from '../shareIcon';
+import ShareIcon from '../shareIcon';
 import { articleWidthStyles, sidePadding } from '../styles';
 
 // ----- Template Format Specific Styles ----- //


### PR DESCRIPTION
## Why are you doing this?

Adds ShareIcon story for Editions.

## Changes

- Make ShareIcon a default export inline with other components
- Add story and implement pillar colour selector in wrapper

