### PR TITLE
LIVE-1659: Update to Bridget 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1754,9 +1754,9 @@
       "integrity": "sha512-wSRfsfzddCgVC7rXookfvKU7jJe+769ZXQU79+6rMRih/AJ7qPnE2QNcqtfvLZLXZ/UfkKX0MTNuBHxq7iU8Bg=="
     },
     "@guardian/bridget": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-1.7.0.tgz",
-      "integrity": "sha512-SsX27OiPyQM9VjcOVt/wjFjZ3fK2budawuoxR+xm56z05G5JdkN7B9ZIwuL2h2UnSGtQYaurVykR0/e3z7U/tw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-1.8.0.tgz",
+      "integrity": "sha512-NUaaFIZq8OP7ghmbvDsR58nABcu44x8xOZPalUHcTTUMeGQrqFRNEK2i8eJ218C6c8iyq6QjAUdApsrN36r6aQ=="
     },
     "@guardian/content-api-models": {
       "version": "15.9.6",
@@ -1838,6 +1838,10 @@
           "version": "2.8.2",
           "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-2.8.2.tgz",
           "integrity": "sha512-DUluJNGcOIgx5/EvgE4T5JZSKfceR+oMMZw8UAUVWOrKH8W9xeE4AGCquZlh/COXJDCP6YvDyRW6yk4EVqEwww=="
+        },
+        "@guardian/types": {
+          "version": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
+          "from": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32"
         },
         "react": {
           "version": "16.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1839,10 +1839,6 @@
           "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-2.8.2.tgz",
           "integrity": "sha512-DUluJNGcOIgx5/EvgE4T5JZSKfceR+oMMZw8UAUVWOrKH8W9xeE4AGCquZlh/COXJDCP6YvDyRW6yk4EVqEwww=="
         },
-        "@guardian/types": {
-          "version": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
-          "from": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32"
-        },
         "react": {
           "version": "16.14.0",
           "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/apps-rendering-api-models": "^0.11.0",
     "@guardian/atoms-rendering": "2.0.7",
-    "@guardian/bridget": "^1.7.0",
+    "@guardian/bridget": "^1.8.0",
     "@guardian/content-api-models": "^15.9.6",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^3.2.1",

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -1,6 +1,6 @@
 import { AdSlot } from '@guardian/bridget/AdSlot';
-import { FrictionScreenReason } from '@guardian/bridget/FrictionScreenReason';
 import { Image } from '@guardian/bridget/Image';
+import { PurchaseScreenReason } from '@guardian/bridget/PurchaseScreenReason';
 import type { IRect } from '@guardian/bridget/Rect';
 import { Rect } from '@guardian/bridget/Rect';
 import { VideoSlot } from '@guardian/bridget/VideoSlot';
@@ -117,8 +117,8 @@ function ads(): void {
 				document.querySelectorAll('.ad-labels, .upgrade-banner button'),
 			).forEach((adLabel) => {
 				adLabel.addEventListener('click', () => {
-					void acquisitionsClient.launchFrictionScreen(
-						FrictionScreenReason.hideAds,
+					void acquisitionsClient.launchPurchaseScreen(
+						PurchaseScreenReason.hideAds,
 					);
 				});
 			});

--- a/src/components/shared/epic.tsx
+++ b/src/components/shared/epic.tsx
@@ -2,7 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
-import { FrictionScreenReason } from '@guardian/bridget/FrictionScreenReason';
+import { PurchaseScreenReason } from '@guardian/bridget/PurchaseScreenReason';
 import { Button, buttonReaderRevenue } from '@guardian/src-button';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
@@ -140,14 +140,14 @@ function Epic({
 			<div className="button-container">
 				<ThemeProvider theme={buttonReaderRevenue}>
 					{epicButton(firstButton, () =>
-						acquisitionsClient.launchFrictionScreen(
-							FrictionScreenReason.epic,
+						acquisitionsClient.launchPurchaseScreen(
+							PurchaseScreenReason.epic,
 						),
 					)}
 					{secondButton
 						? epicButton(secondButton, () =>
-								acquisitionsClient.launchFrictionScreen(
-									FrictionScreenReason.epic,
+								acquisitionsClient.launchPurchaseScreen(
+									PurchaseScreenReason.epic,
 								),
 						  )
 						: null}


### PR DESCRIPTION
# Bridget 1.8.0

In the latest release ([PR](https://github.com/guardian/bridget/pull/71)) We have renamed:
- `FrictionScreenReason` -> `PurchaseScreenReason`
- `launchFrictionScreen` -> `launchPurchaseScreen` 

Since we have removed the old types this basically could count as a breaking change, but we're not in production yet, and this shouldn't break it for beta users either (basically they won't get the purchase screen pop up). 
I've considered this better than using the `nativeThriftPackageVersion` and peppering our codebase with if and else before going to prod.