### PR TITLE
LIVE-1662: investigate adding Storyshots snapshot testing

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -1,38 +1,39 @@
 module.exports = {
-    collectCoverage: true,
-    preset: "ts-jest/presets/js-with-ts",
-    rootDir: "../",
-    globals: {
-        "ts-jest": {
-            babelConfig: {
-                presets: [
-                    [
-                        "@babel/preset-env",
-                        { targets: { node: "12" }, modules: "cjs" },
-                    ],
-                    [
-                        "@babel/preset-react",
-                        {
-                            "runtime": "automatic",
-                            "importSource": "@emotion/core"
-                        }
-                    ],
-                ],
-                plugins: [ '@emotion' ],
-            },
-            tsconfig: "config/tsconfig.test.json",
-        },
-    },
-    coverageThreshold: {
-        global: {
-            branches: 75,
-            functions: 75,
-            lines: 75,
-            statements: 75,
-        },
-    },
-    coverageReporters: ["text", "html", "text-summary"],
-    collectCoverageFrom: ["<rootDir>/src/renderer.ts", "<rootDir>/src/item.ts"],
-    moduleDirectories: ["node_modules", "src"],
-    transformIgnorePatterns: ["node_modules/(?!@guardian)"],
+	collectCoverage: true,
+	preset: 'ts-jest/presets/js-with-ts',
+	rootDir: '../',
+	globals: {
+		'ts-jest': {
+			babelConfig: {
+				presets: [
+					[
+						'@babel/preset-env',
+						{ targets: { node: '12' }, modules: 'cjs' },
+					],
+					[
+						'@babel/preset-react',
+						{
+							runtime: 'automatic',
+							importSource: '@emotion/core',
+						},
+					],
+				],
+				plugins: ['@emotion'],
+			},
+			tsconfig: 'config/tsconfig.test.json',
+		},
+	},
+	coverageThreshold: {
+		global: {
+			branches: 75,
+			functions: 75,
+			lines: 75,
+			statements: 75,
+		},
+	},
+	coverageReporters: ['text', 'html', 'text-summary'],
+	collectCoverageFrom: ['<rootDir>/src/renderer.ts', '<rootDir>/src/item.ts'],
+	moduleDirectories: ['node_modules', 'src'],
+	snapshotSerializers: ['@emotion/jest/serializer'],
+	transformIgnorePatterns: ['node_modules/(?!@guardian)'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4665,6 +4665,605 @@
         }
       }
     },
+    "@storybook/addon-storyshots": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-storyshots/-/addon-storyshots-6.1.17.tgz",
+      "integrity": "sha512-iiTnT4B0S/y9NEALQu902plqn17WeCUpMrFKUq++SVhNBgrxpll8CIjdUWG18eUfpWZ0VxQg/4lqNaJJYjY2Ow==",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^26.0.0",
+        "@storybook/addons": "6.1.17",
+        "@storybook/client-api": "6.1.17",
+        "@storybook/core": "6.1.17",
+        "@types/glob": "^7.1.1",
+        "@types/jest": "^25.1.1",
+        "@types/jest-specific-snapshot": "^0.5.3",
+        "babel-plugin-require-context-hook": "^1.0.0",
+        "core-js": "^3.0.1",
+        "glob": "^7.1.3",
+        "global": "^4.3.2",
+        "jest-specific-snapshot": "^4.0.0",
+        "pretty-format": "^26.4.0",
+        "react-test-renderer": "^16.8.0 || ^17.0.0",
+        "read-pkg-up": "^7.0.0",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            }
+          }
+        },
+        "@storybook/addons": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.1.17.tgz",
+          "integrity": "sha512-3upDPJPzUkls2V3Fozzg+JOcv138bF90pbdRe9YSNu37QvRIL+iQODY7oFygMl+kqjG2F1FGw5EvxAV1mnlwCw==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.1.17",
+            "@storybook/channels": "6.1.17",
+            "@storybook/client-logger": "6.1.17",
+            "@storybook/core-events": "6.1.17",
+            "@storybook/router": "6.1.17",
+            "@storybook/theming": "6.1.17",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.1.17.tgz",
+          "integrity": "sha512-sthcfuk2EQ3F5R620PBqpI4Pno3g7KQm6YPZA0DXB+LD/z61xH9ToE1gTLF4nzlE6HwghwkXOZyRwDowRdG+7A==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.3",
+            "@storybook/channels": "6.1.17",
+            "@storybook/client-logger": "6.1.17",
+            "@storybook/core-events": "6.1.17",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.1.17",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.1.17",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^3.1.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.7.1",
+            "telejson": "^5.0.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.1.17.tgz",
+          "integrity": "sha512-2nVqxq4oZdSITqhFOnkh1rmDMjCwHuobnK5Fp3l7ftCkbmiZHMheKK9Tz4Rb803dhXvcGYs0zRS8NjKyxlOLsA==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.1.17",
+            "@storybook/client-logger": "6.1.17",
+            "@storybook/core-events": "6.1.17",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "qs": "^6.6.0",
+            "telejson": "^5.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.1.17.tgz",
+          "integrity": "sha512-MUdj0eKr/AbxevHTSXX7AsgxAz6e5O4ZxoYX5G8ggoqSXrWzws6zRFmUmmTdjpIvVmP2M1Kh4SYFAKcS/AGw9w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-api": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.1.17.tgz",
+          "integrity": "sha512-Loz/wdh0axgq0PS19tx0tGEFEkFWlYc6YauJGHjygYa1xX7mJ54hDoaTolySCXN1HtfZn08D847yjGSN2oIqVg==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.1.17",
+            "@storybook/channel-postmessage": "6.1.17",
+            "@storybook/channels": "6.1.17",
+            "@storybook/client-logger": "6.1.17",
+            "@storybook/core-events": "6.1.17",
+            "@storybook/csf": "0.0.1",
+            "@types/qs": "^6.9.0",
+            "@types/webpack-env": "^1.15.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0",
+            "regenerator-runtime": "^0.13.7",
+            "stable": "^0.1.8",
+            "store2": "^2.7.1",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.1.17.tgz",
+          "integrity": "sha512-oqExrxhmws0ihB47sjdynZHd3OpUP4KWkx4udG+74lYIvBH+EZmQ9xF+UofeY3j5p1I9k8ugEcVKy0sqh1yR3w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1",
+            "global": "^4.3.2"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.1.17.tgz",
+          "integrity": "sha512-rIEll0UTxEKmG4IsSS5K+6DjRLVtX8J+9cg79GSAC7N1ZHUR1UQmjjJaehJa5q/NQ5H8C39acxpT4Py/BcsL2g==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.5.4",
+            "@storybook/client-logger": "6.1.17",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.1.17",
+            "@types/overlayscrollbars": "^1.9.0",
+            "@types/react-color": "^3.0.1",
+            "@types/react-syntax-highlighter": "11.0.4",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^3.1.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "markdown-to-jsx": "^6.11.4",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.10.2",
+            "polished": "^3.4.4",
+            "react-color": "^2.17.0",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.0",
+            "react-textarea-autosize": "^8.1.1",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/core": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.1.17.tgz",
+          "integrity": "sha512-9x8ezlKlm8SQ+OW3kKwJwuVcaTDCw2OlA9YZEOo1kdRKsiiy5X14VqjJocl/BqnDt2VgzUUchz3m4neHYMAivQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.3",
+            "@babel/plugin-proposal-class-properties": "^7.12.1",
+            "@babel/plugin-proposal-decorators": "^7.12.1",
+            "@babel/plugin-proposal-export-default-from": "^7.12.1",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+            "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+            "@babel/plugin-proposal-optional-chaining": "^7.12.1",
+            "@babel/plugin-proposal-private-methods": "^7.12.1",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-arrow-functions": "^7.12.1",
+            "@babel/plugin-transform-block-scoping": "^7.12.1",
+            "@babel/plugin-transform-classes": "^7.12.1",
+            "@babel/plugin-transform-destructuring": "^7.12.1",
+            "@babel/plugin-transform-for-of": "^7.12.1",
+            "@babel/plugin-transform-parameters": "^7.12.1",
+            "@babel/plugin-transform-shorthand-properties": "^7.12.1",
+            "@babel/plugin-transform-spread": "^7.12.1",
+            "@babel/plugin-transform-template-literals": "^7.12.1",
+            "@babel/preset-env": "^7.12.1",
+            "@babel/preset-react": "^7.12.1",
+            "@babel/preset-typescript": "^7.12.1",
+            "@babel/register": "^7.12.1",
+            "@storybook/addons": "6.1.17",
+            "@storybook/api": "6.1.17",
+            "@storybook/channel-postmessage": "6.1.17",
+            "@storybook/channels": "6.1.17",
+            "@storybook/client-api": "6.1.17",
+            "@storybook/client-logger": "6.1.17",
+            "@storybook/components": "6.1.17",
+            "@storybook/core-events": "6.1.17",
+            "@storybook/csf": "0.0.1",
+            "@storybook/node-logger": "6.1.17",
+            "@storybook/router": "6.1.17",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.1.17",
+            "@storybook/ui": "6.1.17",
+            "@types/glob-base": "^0.3.0",
+            "@types/micromatch": "^4.0.1",
+            "@types/node-fetch": "^2.5.4",
+            "airbnb-js-shims": "^2.2.1",
+            "ansi-to-html": "^0.6.11",
+            "autoprefixer": "^9.7.2",
+            "babel-loader": "^8.0.6",
+            "babel-plugin-emotion": "^10.0.20",
+            "babel-plugin-macros": "^2.8.0",
+            "babel-preset-minify": "^0.5.0 || 0.6.0-alpha.5",
+            "better-opn": "^2.0.0",
+            "boxen": "^4.1.0",
+            "case-sensitive-paths-webpack-plugin": "^2.2.0",
+            "chalk": "^4.0.0",
+            "cli-table3": "0.6.0",
+            "commander": "^5.0.0",
+            "core-js": "^3.0.1",
+            "cpy": "^8.1.1",
+            "css-loader": "^3.5.3",
+            "detect-port": "^1.3.0",
+            "dotenv-webpack": "^1.7.0",
+            "ejs": "^3.1.2",
+            "express": "^4.17.0",
+            "file-loader": "^6.0.0",
+            "file-system-cache": "^1.0.5",
+            "find-up": "^4.1.0",
+            "fork-ts-checker-webpack-plugin": "^4.1.4",
+            "fs-extra": "^9.0.0",
+            "glob": "^7.1.6",
+            "glob-base": "^0.3.0",
+            "glob-promise": "^3.4.0",
+            "global": "^4.3.2",
+            "html-webpack-plugin": "^4.2.1",
+            "inquirer": "^7.0.0",
+            "interpret": "^2.0.0",
+            "ip": "^1.1.5",
+            "json5": "^2.1.1",
+            "lazy-universal-dotenv": "^3.0.1",
+            "micromatch": "^4.0.2",
+            "node-fetch": "^2.6.0",
+            "pkg-dir": "^4.2.0",
+            "pnp-webpack-plugin": "1.6.4",
+            "postcss-flexbugs-fixes": "^4.1.0",
+            "postcss-loader": "^3.0.0",
+            "pretty-hrtime": "^1.0.3",
+            "qs": "^6.6.0",
+            "raw-loader": "^4.0.1",
+            "react-dev-utils": "^10.0.0",
+            "regenerator-runtime": "^0.13.7",
+            "resolve-from": "^5.0.0",
+            "serve-favicon": "^2.5.0",
+            "shelljs": "^0.8.4",
+            "stable": "^0.1.8",
+            "style-loader": "^1.2.1",
+            "telejson": "^5.0.2",
+            "terser-webpack-plugin": "^3.0.0",
+            "ts-dedent": "^2.0.0",
+            "unfetch": "^4.1.0",
+            "url-loader": "^4.0.0",
+            "util-deprecate": "^1.0.2",
+            "webpack": "^4.44.2",
+            "webpack-dev-middleware": "^3.7.0",
+            "webpack-filter-warnings-plugin": "^1.2.1",
+            "webpack-hot-middleware": "^2.25.0",
+            "webpack-virtual-modules": "^0.2.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.1.17.tgz",
+          "integrity": "sha512-xBI7kmyROcqhYNmFv4QBjD77CzV+k/0F051YFS5WicEI4qDWPPvzaShhm96ZrGobUX3+di4pC11gqdsrFeNCEg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.1.17.tgz",
+          "integrity": "sha512-Z0xQ4kzvf7GnwFG9UY1HJO2UR66t8IBnC5GxvWrJ/kwXE+DRF3mm/MT41Zz/d9zAY5Vo4mhE5zRwlYSAtrxQIQ==",
+          "dev": true,
+          "requires": {
+            "@types/npmlog": "^4.1.2",
+            "chalk": "^4.0.0",
+            "core-js": "^3.0.1",
+            "npmlog": "^4.1.2",
+            "pretty-hrtime": "^1.0.3"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.1.17.tgz",
+          "integrity": "sha512-wLqSOB5yLXgNyDGy008RUvjVRtVMq7lhmMRicSIxgJpkakPrMRN8n/nK7pxgQc/xDTphnS0u1nT01i97WszhCg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.3.3",
+            "@types/reach__router": "^1.3.7",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.1.17.tgz",
+          "integrity": "sha512-LpRuY2aIh2td+qZi7E8cp2oM88LudNMmTsBT6N2/Id69u/a9qQd2cYCA9k9fAsg7rjor+wR/N695jk3SGtoFTw==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.23",
+            "@storybook/client-logger": "6.1.17",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.4.4",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/ui": {
+          "version": "6.1.17",
+          "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-6.1.17.tgz",
+          "integrity": "sha512-D4Vri1MmqfmNq+g1hSRqZyld5zX2VLUexQHGSPmNj+FhlOzkeNA5RcoMBWMvIUSUENiBx3a5gmr/6cbXo7ljdQ==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@storybook/addons": "6.1.17",
+            "@storybook/api": "6.1.17",
+            "@storybook/channels": "6.1.17",
+            "@storybook/client-logger": "6.1.17",
+            "@storybook/components": "6.1.17",
+            "@storybook/core-events": "6.1.17",
+            "@storybook/router": "6.1.17",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.1.17",
+            "@types/markdown-to-jsx": "^6.11.0",
+            "copy-to-clipboard": "^3.0.8",
+            "core-js": "^3.0.1",
+            "core-js-pure": "^3.0.1",
+            "downshift": "^6.0.6",
+            "emotion-theming": "^10.0.19",
+            "fuse.js": "^3.6.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "markdown-to-jsx": "^6.11.4",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.4.4",
+            "qs": "^6.6.0",
+            "react-draggable": "^4.0.3",
+            "react-helmet-async": "^1.0.2",
+            "react-hotkeys": "2.0.0",
+            "react-sizeme": "^2.6.7",
+            "regenerator-runtime": "^0.13.7",
+            "resolve-from": "^5.0.0",
+            "store2": "^2.7.1"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "*",
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/jest": {
+          "version": "25.2.3",
+          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
+          "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+          "dev": true,
+          "requires": {
+            "jest-diff": "^25.2.1",
+            "pretty-format": "^25.2.1"
+          },
+          "dependencies": {
+            "pretty-format": {
+              "version": "25.5.0",
+              "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+              "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+              "dev": true,
+              "requires": {
+                "@jest/types": "^25.5.0",
+                "ansi-regex": "^5.0.0",
+                "ansi-styles": "^4.0.0",
+                "react-is": "^16.12.0"
+              }
+            }
+          }
+        },
+        "@types/reach__router": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.7.tgz",
+          "integrity": "sha512-cyBEb8Ef3SJNH5NYEIDGPoMMmYUxROatuxbICusVRQIqZUB85UCt6R2Ok60tKS/TABJsJYaHyNTW3kqbpxlMjg==",
+          "dev": true,
+          "requires": {
+            "@types/react": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "pretty-format": {
+              "version": "25.5.0",
+              "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+              "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+              "dev": true,
+              "requires": {
+                "@jest/types": "^25.5.0",
+                "ansi-regex": "^5.0.0",
+                "ansi-styles": "^4.0.0",
+                "react-is": "^16.12.0"
+              }
+            }
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "ts-dedent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.0.0.tgz",
+          "integrity": "sha512-DfxKjSFQfw9+uf7N9Cy8Ebx9fv5fquK4hZ6SD3Rzr+1jKP6AVA6H8+B5457ZpUs0JKsGpGqIevbpZ9DMQJDp1A==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
     "@storybook/addon-toolbars": {
       "version": "6.1.17",
       "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-6.1.17.tgz",
@@ -6091,6 +6690,15 @@
       "requires": {
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
+      }
+    },
+    "@types/jest-specific-snapshot": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jest-specific-snapshot/-/jest-specific-snapshot-0.5.5.tgz",
+      "integrity": "sha512-AaPPw2tE8ewfjD6qGLkEd4DOfM6pPOK7ob/RSOe1Z8Oo70r9Jgo0SlWyfxslPAOvLfQukQtiVPm6DcnjSoZU5A==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
       }
     },
     "@types/jsdom": {
@@ -8182,6 +8790,12 @@
         "lodash": "^4.17.15",
         "react-docgen": "^5.0.0"
       }
+    },
+    "babel-plugin-require-context-hook": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-require-context-hook/-/babel-plugin-require-context-hook-1.0.0.tgz",
+      "integrity": "sha512-EMZD1563QUqLhzrqcThk759RhuNVX/ZJdrtGK6drwzgvnR+ARjWyXIHPbu+tUNaMGtPz/gQeAM2M6VUw2UiUeA==",
+      "dev": true
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
@@ -16031,6 +16645,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "jest-specific-snapshot": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jest-specific-snapshot/-/jest-specific-snapshot-4.0.0.tgz",
+      "integrity": "sha512-YdW5P/MVwOizWR0MJwURxdrjdXvdG2MMpXKVGr7dZ2YrBmE6E6Ab74UL3DOYmGmzaCnNAW1CL02pY5MTHE3ulQ==",
+      "dev": true,
+      "requires": {
+        "jest-snapshot": "^26.3.0"
       }
     },
     "jest-util": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,6 +1635,16 @@
         "babel-plugin-emotion": "^10.0.27"
       }
     },
+    "@emotion/css-prettifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/css-prettifier/-/css-prettifier-1.0.0.tgz",
+      "integrity": "sha512-efxSrRTiTqHTQVKW15Gz5H4pNAw8OqcG8NaiwkJIkqIdNXTD4Qr1zC1Ou6r2acd1oJJ2s56nb1ClnXMiWoj6gQ==",
+      "dev": true,
+      "requires": {
+        "@emotion/memoize": "^0.7.4",
+        "stylis": "^4.0.3"
+      }
+    },
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -1646,6 +1656,70 @@
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "requires": {
         "@emotion/memoize": "0.7.4"
+      }
+    },
+    "@emotion/jest": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/jest/-/jest-11.2.0.tgz",
+      "integrity": "sha512-/IHfepppnbf5KHOuz5e145oKR2JOV0hz4chy3HHSz/JrIDa9EyQLGIo6ZqLku1XdieMYvnxaCA2ReJRo7EvUIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@emotion/css-prettifier": "^1.0.0",
+        "chalk": "^4.1.0",
+        "specificity": "^0.4.1",
+        "stylis": "^4.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@emotion/memoize": {
@@ -22556,6 +22630,12 @@
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
       }
+    },
+    "specificity": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+      "dev": true
     },
     "speedometer": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.10",
     "@emotion/babel-plugin": "^11.1.2",
+    "@emotion/jest": "^11.2.0",
     "@guardian/eslint-config-typescript": "^0.4.2",
     "@guardian/prettier": "^0.4.1",
     "@storybook/addon-essentials": "^6.1.17",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@guardian/prettier": "^0.4.1",
     "@storybook/addon-essentials": "^6.1.17",
     "@storybook/addon-knobs": "^6.1.11",
+    "@storybook/addon-storyshots": "^6.1.17",
     "@storybook/react": "^6.1.9",
     "@storybook/storybook-deployer": "^2.8.7",
     "@types/clean-css": "^4.2.3",

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -1,8 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Anchor Default 1`] = `
+.emotion-0 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #AB0613;
+  border-bottom: 0.0625rem solid #DCDCDC;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #DCDCDC;
+    border-color: #767676;
+  }
+}
+
 <a
-  className="css-5uwmeq-Anchor"
+  className="emotion-0"
   href="https://theguardian.com"
 >
   “everything that was recommended was done”.
@@ -10,11 +24,42 @@ exports[`Storyshots Anchor Default 1`] = `
 `;
 
 exports[`Storyshots Bullet Default 1`] = `
+.emotion-0 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  display: inline;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-1 {
+  color: transparent;
+  display: inline-block;
+}
+
+.emotion-1::before {
+  content: '';
+  background-color: #C70000;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.5rem;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1::before {
+    background-color: #FF5943;
+  }
+}
+
 <p
-  className="css-3s648a-Bullet"
+  className="emotion-0"
 >
   <span
-    className="css-2g8li-Bullet"
+    className="emotion-1"
   >
     •
   </span>
@@ -23,11 +68,33 @@ exports[`Storyshots Bullet Default 1`] = `
 `;
 
 exports[`Storyshots Byline Comment 1`] = `
+.emotion-0 {
+  color: #E05E00;
+  width: 75%;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.125rem;
+  line-height: 1.15;
+  font-weight: 300;
+  font-style: italic;
+}
+
+.emotion-1 {
+  color: #E05E00;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #FF7F0F;
+  }
+}
+
 <address
-  className="css-1r4n4os"
+  className="emotion-0"
 >
   <a
-    className="css-17bjzi4"
+    className="emotion-1"
     href="https://theguardian.com"
   >
     Jane Smith
@@ -37,11 +104,42 @@ exports[`Storyshots Byline Comment 1`] = `
 `;
 
 exports[`Storyshots Byline Default 1`] = `
+.emotion-0 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  color: #C70000;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #999999;
+  }
+}
+
+.emotion-1 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  font-style: normal;
+  color: #C70000;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #FF5943;
+  }
+}
+
 <address
-  className="css-1ry8e32"
+  className="emotion-0"
 >
   <a
-    className="css-xw3z4n"
+    className="emotion-1"
     href="https://theguardian.com"
   >
     Jane Smith
@@ -51,11 +149,39 @@ exports[`Storyshots Byline Default 1`] = `
 `;
 
 exports[`Storyshots Byline Labs 1`] = `
+.emotion-0 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.35;
+  font-weight: 400;
+  color: #65A897;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #69D1CA;
+  }
+}
+
+.emotion-1 {
+  font-weight: bold;
+  color: #65A897;
+  font-style: normal;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #69D1CA;
+  }
+}
+
 <address
-  className="css-17wdvyp"
+  className="emotion-0"
 >
   <a
-    className="css-eav8uk"
+    className="emotion-1"
     href="https://theguardian.com"
   >
     Jane Smith
@@ -65,11 +191,36 @@ exports[`Storyshots Byline Labs 1`] = `
 `;
 
 exports[`Storyshots CommentCount Default 1`] = `
+.emotion-0 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  border: none;
+  background: none;
+  border-left: 1px solid #DCDCDC;
+  padding-top: 0.5rem;
+  color: #C70000;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    border-left: 1px solid #333333;
+  }
+}
+
+.emotion-1 {
+  width: 1rem;
+  display: block;
+  margin-left: auto;
+  fill: #C70000;
+}
+
 <button
-  className="css-19mgwvn"
+  className="emotion-0"
 >
   <svg
-    className="css-9iqumf"
+    className="emotion-1"
     viewBox="0 0 9 8"
     xmlns="http://www.w3.org/2000/svg"
   >
@@ -89,8 +240,22 @@ exports[`Storyshots CommentCount Default 1`] = `
 `;
 
 exports[`Storyshots Dateline Default 1`] = `
+.emotion-0 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #333333;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #999999;
+  }
+}
+
 <time
-  className="date js-date css-l03xpa"
+  className="date js-date emotion-0"
   data-date={2019-12-17T03:24:00.000Z}
 >
   Tue 17 Dec 2019 03.24 UTC
@@ -98,24 +263,907 @@ exports[`Storyshots Dateline Default 1`] = `
 `;
 
 exports[`Storyshots Editions/Article Analysis 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #F6F6F6;
+}
+
+.emotion-3 {
+  border-bottom: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    width: 545px;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-3 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-4 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width:740px) {
+  .emotion-5 {
+    width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    width: 750px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.emotion-6 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 740px;
+    height: calc(740px * 0.6);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 980px;
+    height: calc(980px * 0.6);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-6 {
+    background-color: #333333;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 720px;
+    height: 432px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-7 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-7 summary {
+  text-align: center;
+  background-color: #BB3B80;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-7 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-7 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-7 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    width: 720px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 {
+    width: 750px;
+  }
+}
+
+.emotion-8 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-8 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-8 path {
+  fill: #FEEEF7;
+}
+
+.emotion-9 {
+  position: relative;
+}
+
+.emotion-10 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 300;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-thickness: from-font;
+  text-decoration-thickness: from-font;
+  -webkit-text-decoration-color: #BB3B80;
+  text-decoration-color: #BB3B80;
+  padding-bottom: 0;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-10 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 300;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 300;
+  }
+}
+
+.emotion-11 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-11 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-11 svg circle {
+  stroke: #BB3B80;
+}
+
+.emotion-11 svg path {
+  fill: #BB3B80;
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-12 {
+  color: #BB3B80;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 700;
+  font-style: normal;
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 700;
+    font-style: normal;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-12 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 700;
+    font-style: normal;
+  }
+}
+
+.emotion-13 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: undefined;
+  font-weight: 300;
+  font-style: italic;
+  color: #121212;
+}
+
+@media (min-width:740px) {
+  .emotion-13 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: undefined;
+    font-weight: 300;
+    font-style: italic;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-13 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: undefined;
+    font-weight: 300;
+    font-style: italic;
+  }
+}
+
+.emotion-14 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-14 {
+    width: 558px;
+  }
+}
+
+.emotion-15 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-16 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #767676;
+}
+
+@media (min-width:740px) {
+  .emotion-16 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-16 {
+    width: 545px;
+  }
+}
+
+.emotion-16 p,
+.emotion-16 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-16 address {
+  font-style: normal;
+}
+
+.emotion-16 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-16 svg circle {
+  stroke: #BB3B80;
+}
+
+.emotion-16 svg path {
+  fill: #BB3B80;
+}
+
+.emotion-17 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+.emotion-18 {
+  padding-right: 0.75rem;
+  border-right: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-18 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-18 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-18 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-18 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-19 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-19 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-19 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:660px) {
+  .emotion-19 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-19 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-20 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-21 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width:660px) {
+  .emotion-21 {
+    width: 620px;
+  }
+}
+
+.emotion-22 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:660px) {
+  .emotion-22 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-22 {
+    background-color: #333333;
+  }
+}
+
+.emotion-25 {
+  display: block;
+  position: relative;
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.emotion-26 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-26 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-26 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-26 summary:focus {
+  outline: none;
+}
+
+.emotion-27 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #BB3B80;
+}
+
+.emotion-28 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-29 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0,50%);
+  -ms-transform: translate(0,50%);
+  transform: translate(0,50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-29:hover {
+  background: #BB3B80;
+}
+
+.emotion-30 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-31 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-32 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-32 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-32 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-32 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-32 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-32 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-32 b {
+  font-weight: 700;
+}
+
+.emotion-32 i {
+  font-style: italic;
+}
+
+.emotion-32 a {
+  color: #7D0068;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-32 a:hover {
+  border-bottom: solid 0.0625rem #BB3B80;
+}
+
+.emotion-33 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.emotion-34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-35 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-35:hover {
+  background: #BB3B80;
+}
+
+.emotion-35:focus {
+  border: none;
+}
+
+.emotion-36 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-37 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-37:hover {
+  background: #BB3B80;
+}
+
+.emotion-37:focus {
+  border: none;
+}
+
+.emotion-39 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-42 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #BB3B80;
+  border: 1px solid #BB3B80;
+  border-top: 0.75rem solid #BB3B80;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:1300px) {
+  .emotion-42 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-42:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #BB3B80;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-42:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #BB3B80;
+}
+
+.emotion-43 {
+  margin: 0;
+}
+
+.emotion-44 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-44 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #BB3B80;
+}
+
+.emotion-45 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
 <main
-  className="css-2qsm3-Article"
+  className="emotion-0"
 >
   <article
-    className="css-2ammhe-Article"
+    className="emotion-1"
   >
     <div
-      className="css-cezksd-Article"
+      className="emotion-2"
     >
       <section
-        className="css-wzgevt-Article"
+        className="emotion-3"
       >
         <header
-          className="css-3qmmbh-AnalysisHeader"
+          className="emotion-4"
         >
           <figure
             aria-labelledby="header-image-caption"
-            className="css-12lxyki-HeaderMedia"
+            className="emotion-5"
           >
             <picture>
               <source
@@ -129,18 +1177,18 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               />
               <img
                 alt=""
-                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                className="js-launch-slideshow js-main-image emotion-6"
                 data-ratio={0.6}
                 src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
               />
             </picture>
             <figcaption
-              className="css-afvmvk-HeaderImageCaption"
+              className="emotion-7"
             >
               <details>
                 <summary>
                   <span
-                    className="css-1bvtd5i"
+                    className="emotion-8"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -166,39 +1214,39 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
             </figcaption>
           </figure>
           <div
-            className="css-165wy3b-Headline"
+            className="emotion-9"
           >
             <h1
-              className="css-acwztd-Headline"
+              className="emotion-10"
             >
               Reclaimed lakes and giant airports: how Mexico City might have looked
             </h1>
           </div>
           <div
-            className="css-s7agzf"
+            className="emotion-11"
           >
             <address>
               <span
-                className="css-11gwkgb"
+                className="emotion-12"
               >
                 Jane Smith
               </span>
               <span
-                className="css-15jtyuf"
+                className="emotion-13"
               >
                  Editor of things
               </span>
             </address>
           </div>
           <div
-            className="css-7m2n2v-EditionsLines"
+            className="emotion-14"
           >
             <div
-              className="css-1xgmaw8-straightLines-fourLines-Lines"
+              className="emotion-15"
             />
           </div>
           <div
-            className="css-1fihjfe"
+            className="emotion-16"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -208,7 +1256,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               role="button"
             >
               <button
-                className="css-rdfey0-ShareIcon"
+                className="emotion-17"
                 onClick={[Function]}
               >
                 <svg
@@ -232,16 +1280,16 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
       </section>
     </div>
     <div
-      className="css-yn5fb1-Article"
+      className="emotion-18"
     >
       <section
-        className="css-1rrc8kn-Article"
+        className="emotion-19"
       >
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <figure
-          className="css-huy3rj-BodyImage"
+          className="emotion-21"
         >
           <picture>
             <source
@@ -255,7 +1303,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow css-1we7mgb-Img"
+              className="js-launch-slideshow emotion-22"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -264,18 +1312,18 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
           </picture>
         </figure>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <div
-          className="css-cq3eyp-containerStyling"
+          className="emotion-25"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="css-l8n9ox-detailStyling"
+            className="emotion-26"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -283,23 +1331,23 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               onClick={[Function]}
             >
               <span
-                className="css-dp9r84-atomTitleStyling"
+                className="emotion-27"
               >
                 Quick Guide
               </span>
               <h4
-                className="css-gpo7xk-titleStyling"
+                className="emotion-28"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="css-1rv27d3-showHideStyling"
+                className="emotion-29"
               >
                 <span
-                  className="css-117w3ky-iconSpacing"
+                  className="emotion-30"
                 >
                   <span
-                    className="css-kd64v9-plusStyling"
+                    className="emotion-31"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -318,7 +1366,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
             </summary>
             <div>
               <div
-                className="css-1vg8ran-bodyStyling"
+                className="emotion-32"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -327,24 +1375,24 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               />
             </div>
             <footer
-              className="css-dc74hn-footerStyling"
+              className="emotion-33"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="css-fgqqde-className"
+                  className="emotion-34"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="css-1hq58dr-buttonStyling"
+                    className="emotion-35"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-36"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -354,12 +1402,12 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="css-soya5m-buttonStyling-className"
+                    className="emotion-37"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-36"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -371,7 +1419,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
                 </div>
               </div>
               <div
-                className="css-5a9sl9-className"
+                className="emotion-39"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -381,19 +1429,19 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
           </details>
         </div>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <aside
-          className="css-c1l0e9-Pullquote"
+          className="emotion-42"
         >
           <blockquote
-            className="css-vhllol-Pullquote"
+            className="emotion-43"
           >
             <p
-              className="css-a5coej-Pullquote"
+              className="emotion-44"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -408,17 +1456,17 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="css-1znb75"
+              className="emotion-45"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
       </section>
     </div>
@@ -427,24 +1475,937 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 `;
 
 exports[`Storyshots Editions/Article Comment 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FFF4F2;
+}
+
+.emotion-3 {
+  border-bottom: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    width: 545px;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-3 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-4 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width:740px) {
+  .emotion-5 {
+    width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    width: 750px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.emotion-6 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #DCDCDC;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 740px;
+    height: calc(740px * 0.6);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 980px;
+    height: calc(980px * 0.6);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-6 {
+    background-color: #333333;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 720px;
+    height: 432px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-7 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-7 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-7 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-7 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-7 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    width: 720px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 {
+    width: 750px;
+  }
+}
+
+.emotion-8 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-8 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-8 path {
+  fill: #FFF4F2;
+}
+
+.emotion-9 {
+  position: relative;
+}
+
+.emotion-10 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 300;
+  padding-bottom: 0;
+  padding-right: 6rem;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-10 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 300;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 300;
+  }
+}
+
+.emotion-11 {
+  margin: 0;
+}
+
+.emotion-11 svg {
+  margin-bottom: -0.65rem;
+  width: 40px;
+  margin-left: -0.3rem;
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-11 svg {
+    margin-bottom: -0.75rem;
+    width: 50px;
+  }
+}
+
+.emotion-12 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+  padding-right: 6.5625rem;
+}
+
+.emotion-12 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-12 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-12 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-13 {
+  color: #C70000;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 700;
+  font-style: normal;
+}
+
+@media (min-width:740px) {
+  .emotion-13 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 700;
+    font-style: normal;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-13 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 700;
+    font-style: normal;
+  }
+}
+
+.emotion-14 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: undefined;
+  font-weight: 300;
+  font-style: italic;
+  color: #121212;
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: undefined;
+    font-weight: 300;
+    font-style: italic;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-14 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: undefined;
+    font-weight: 300;
+    font-style: italic;
+  }
+}
+
+.emotion-15 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
+.emotion-16 {
+  width: 105px;
+  height: calc(105px * 1);
+  background-color: #DCDCDC;
+  color: #999999;
+  display: block;
+  background: none;
+  width: 125px;
+}
+
+.emotion-17 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-17 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-17 {
+    width: 558px;
+  }
+}
+
+.emotion-18 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-19 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #767676;
+}
+
+@media (min-width:740px) {
+  .emotion-19 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-19 {
+    width: 545px;
+  }
+}
+
+.emotion-19 p,
+.emotion-19 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-19 address {
+  font-style: normal;
+}
+
+.emotion-19 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-19 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-19 svg path {
+  fill: #C70000;
+}
+
+.emotion-20 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+.emotion-21 {
+  padding-right: 0.75rem;
+  border-right: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-21 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-21 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-22 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-22 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-22 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:660px) {
+  .emotion-22 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-22 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-23 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-24 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width:660px) {
+  .emotion-24 {
+    width: 620px;
+  }
+}
+
+.emotion-25 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #DCDCDC;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:660px) {
+  .emotion-25 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-25 {
+    background-color: #333333;
+  }
+}
+
+.emotion-28 {
+  display: block;
+  position: relative;
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.emotion-29 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-29 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-29 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-29 summary:focus {
+  outline: none;
+}
+
+.emotion-30 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #C70000;
+}
+
+.emotion-31 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-32 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0,50%);
+  -ms-transform: translate(0,50%);
+  transform: translate(0,50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-32:hover {
+  background: #C70000;
+}
+
+.emotion-33 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-34 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-35 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-35 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-35 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-35 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-35 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-35 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-35 b {
+  font-weight: 700;
+}
+
+.emotion-35 i {
+  font-style: italic;
+}
+
+.emotion-35 a {
+  color: #AB0613;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-35 a:hover {
+  border-bottom: solid 0.0625rem #C70000;
+}
+
+.emotion-36 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.emotion-37 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-38 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-38:hover {
+  background: #C70000;
+}
+
+.emotion-38:focus {
+  border: none;
+}
+
+.emotion-39 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-40 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-40:hover {
+  background: #C70000;
+}
+
+.emotion-40:focus {
+  border: none;
+}
+
+.emotion-42 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-45 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #C70000;
+  border: 1px solid #C70000;
+  border-top: 0.75rem solid #C70000;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:1300px) {
+  .emotion-45 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-45:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #C70000;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-45:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #C70000;
+}
+
+.emotion-46 {
+  margin: 0;
+}
+
+.emotion-47 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-47 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #C70000;
+}
+
+.emotion-48 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
 <main
-  className="css-2qsm3-Article"
+  className="emotion-0"
 >
   <article
-    className="css-2ammhe-Article"
+    className="emotion-1"
   >
     <div
-      className="css-v93u6i-Article"
+      className="emotion-2"
     >
       <section
-        className="css-wzgevt-Article"
+        className="emotion-3"
       >
         <header
-          className="css-1d01hcu-CommentHeader"
+          className="emotion-4"
         >
           <figure
             aria-labelledby="header-image-caption"
-            className="css-12lxyki-HeaderMedia"
+            className="emotion-5"
           >
             <picture>
               <source
@@ -458,18 +2419,18 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               />
               <img
                 alt=""
-                className="js-launch-slideshow js-main-image css-xqx25p-Img"
+                className="js-launch-slideshow js-main-image emotion-6"
                 data-ratio={0.6}
                 src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
               />
             </picture>
             <figcaption
-              className="css-169o3q0-HeaderImageCaption"
+              className="emotion-7"
             >
               <details>
                 <summary>
                   <span
-                    className="css-6okjyw"
+                    className="emotion-8"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -495,13 +2456,13 @@ exports[`Storyshots Editions/Article Comment 1`] = `
             </figcaption>
           </figure>
           <div
-            className="css-165wy3b-Headline"
+            className="emotion-9"
           >
             <h1
-              className="css-k4j3s4-Headline"
+              className="emotion-10"
             >
               <span
-                className="css-1od8ezt"
+                className="emotion-11"
               >
                 <svg
                   viewBox="0 0 30 30"
@@ -518,22 +2479,22 @@ exports[`Storyshots Editions/Article Comment 1`] = `
             </h1>
           </div>
           <div
-            className="css-1xck3cj"
+            className="emotion-12"
           >
             <address>
               <span
-                className="css-1tnqwjd"
+                className="emotion-13"
               >
                 Jane Smith
               </span>
               <span
-                className="css-15jtyuf"
+                className="emotion-14"
               >
                  Editor of things
               </span>
             </address>
             <div
-              className="css-17kiv7u"
+              className="emotion-15"
             >
               <picture>
                 <source
@@ -547,7 +2508,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
                 />
                 <img
                   alt="image"
-                  className="css-1w5z5b1-Img"
+                  className="emotion-16"
                   data-ratio={1}
                   src="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e"
                 />
@@ -555,14 +2516,14 @@ exports[`Storyshots Editions/Article Comment 1`] = `
             </div>
           </div>
           <div
-            className="css-7m2n2v-EditionsLines"
+            className="emotion-17"
           >
             <div
-              className="css-1xgmaw8-straightLines-fourLines-Lines"
+              className="emotion-18"
             />
           </div>
           <div
-            className="css-a9bgr4"
+            className="emotion-19"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -572,7 +2533,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               role="button"
             >
               <button
-                className="css-rdfey0-ShareIcon"
+                className="emotion-20"
                 onClick={[Function]}
               >
                 <svg
@@ -596,16 +2557,16 @@ exports[`Storyshots Editions/Article Comment 1`] = `
       </section>
     </div>
     <div
-      className="css-yn5fb1-Article"
+      className="emotion-21"
     >
       <section
-        className="css-1rrc8kn-Article"
+        className="emotion-22"
       >
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-23"
         />
         <figure
-          className="css-huy3rj-BodyImage"
+          className="emotion-24"
         >
           <picture>
             <source
@@ -619,7 +2580,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow css-198316x-Img"
+              className="js-launch-slideshow emotion-25"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -628,18 +2589,18 @@ exports[`Storyshots Editions/Article Comment 1`] = `
           </picture>
         </figure>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-23"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-23"
         />
         <div
-          className="css-cq3eyp-containerStyling"
+          className="emotion-28"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="css-l8n9ox-detailStyling"
+            className="emotion-29"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -647,23 +2608,23 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               onClick={[Function]}
             >
               <span
-                className="css-3w82vu-atomTitleStyling"
+                className="emotion-30"
               >
                 Quick Guide
               </span>
               <h4
-                className="css-gpo7xk-titleStyling"
+                className="emotion-31"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="css-1p3af4l-showHideStyling"
+                className="emotion-32"
               >
                 <span
-                  className="css-117w3ky-iconSpacing"
+                  className="emotion-33"
                 >
                   <span
-                    className="css-kd64v9-plusStyling"
+                    className="emotion-34"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -682,7 +2643,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
             </summary>
             <div>
               <div
-                className="css-5oaelj-bodyStyling"
+                className="emotion-35"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -691,24 +2652,24 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               />
             </div>
             <footer
-              className="css-dc74hn-footerStyling"
+              className="emotion-36"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="css-fgqqde-className"
+                  className="emotion-37"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="css-con9lg-buttonStyling"
+                    className="emotion-38"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-39"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -718,12 +2679,12 @@ exports[`Storyshots Editions/Article Comment 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="css-av88v2-buttonStyling-className"
+                    className="emotion-40"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-39"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -735,7 +2696,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
                 </div>
               </div>
               <div
-                className="css-5a9sl9-className"
+                className="emotion-42"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -745,19 +2706,19 @@ exports[`Storyshots Editions/Article Comment 1`] = `
           </details>
         </div>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-23"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-23"
         />
         <aside
-          className="css-1f6ukfo-Pullquote"
+          className="emotion-45"
         >
           <blockquote
-            className="css-vhllol-Pullquote"
+            className="emotion-46"
           >
             <p
-              className="css-cgf9f8-Pullquote"
+              className="emotion-47"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -772,17 +2733,17 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="css-1znb75"
+              className="emotion-48"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-23"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-23"
         />
       </section>
     </div>
@@ -791,24 +2752,853 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 `;
 
 exports[`Storyshots Editions/Article Default 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FFFFFF;
+}
+
+.emotion-3 {
+  border-bottom: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    width: 545px;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-3 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-4 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width:740px) {
+  .emotion-5 {
+    width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    width: 750px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.emotion-6 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 740px;
+    height: calc(740px * 0.6);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 980px;
+    height: calc(980px * 0.6);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-6 {
+    background-color: #333333;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 720px;
+    height: 432px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-7 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-7 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-7 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-7 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-7 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    width: 720px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 {
+    width: 750px;
+  }
+}
+
+.emotion-8 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-8 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-8 path {
+  fill: #FFF4F2;
+}
+
+.emotion-9 {
+  position: relative;
+}
+
+.emotion-10 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-10 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+.emotion-11 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-11 {
+    width: 545px;
+  }
+}
+
+.emotion-11 p,
+.emotion-11 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-11 address {
+  font-style: normal;
+}
+
+.emotion-11 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-11 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-11 svg path {
+  fill: #C70000;
+}
+
+.emotion-12 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-12 {
+    width: 558px;
+  }
+}
+
+.emotion-13 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-14 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-14 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-14 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-14 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-15 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-16 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-17 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+.emotion-18 {
+  padding-right: 0.75rem;
+  border-right: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-18 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-18 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-18 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-18 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-19 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-19 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-19 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:660px) {
+  .emotion-19 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-19 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-20 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-21 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width:660px) {
+  .emotion-21 {
+    width: 620px;
+  }
+}
+
+.emotion-22 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:660px) {
+  .emotion-22 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-22 {
+    background-color: #333333;
+  }
+}
+
+.emotion-25 {
+  display: block;
+  position: relative;
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.emotion-26 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-26 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-26 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-26 summary:focus {
+  outline: none;
+}
+
+.emotion-27 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #C70000;
+}
+
+.emotion-28 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-29 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0,50%);
+  -ms-transform: translate(0,50%);
+  transform: translate(0,50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-29:hover {
+  background: #C70000;
+}
+
+.emotion-30 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-31 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-32 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-32 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-32 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-32 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-32 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-32 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-32 b {
+  font-weight: 700;
+}
+
+.emotion-32 i {
+  font-style: italic;
+}
+
+.emotion-32 a {
+  color: #AB0613;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-32 a:hover {
+  border-bottom: solid 0.0625rem #C70000;
+}
+
+.emotion-33 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.emotion-34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-35 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-35:hover {
+  background: #C70000;
+}
+
+.emotion-35:focus {
+  border: none;
+}
+
+.emotion-36 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-37 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-37:hover {
+  background: #C70000;
+}
+
+.emotion-37:focus {
+  border: none;
+}
+
+.emotion-39 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-42 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #C70000;
+  border: 1px solid #C70000;
+  border-top: 0.75rem solid #C70000;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:1300px) {
+  .emotion-42 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-42:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #C70000;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-42:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #C70000;
+}
+
+.emotion-43 {
+  margin: 0;
+}
+
+.emotion-44 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-44 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #C70000;
+}
+
+.emotion-45 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
 <main
-  className="css-2qsm3-Article"
+  className="emotion-0"
 >
   <article
-    className="css-2ammhe-Article"
+    className="emotion-1"
   >
     <div
-      className="css-16sk62p-Article"
+      className="emotion-2"
     >
       <section
-        className="css-wzgevt-Article"
+        className="emotion-3"
       >
         <header
-          className="css-10xsu7p-StandardHeader"
+          className="emotion-4"
         >
           <figure
             aria-labelledby="header-image-caption"
-            className="css-12lxyki-HeaderMedia"
+            className="emotion-5"
           >
             <picture>
               <source
@@ -822,18 +3612,18 @@ exports[`Storyshots Editions/Article Default 1`] = `
               />
               <img
                 alt=""
-                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                className="js-launch-slideshow js-main-image emotion-6"
                 data-ratio={0.6}
                 src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
               />
             </picture>
             <figcaption
-              className="css-169o3q0-HeaderImageCaption"
+              className="emotion-7"
             >
               <details>
                 <summary>
                   <span
-                    className="css-6okjyw"
+                    className="emotion-8"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -859,39 +3649,39 @@ exports[`Storyshots Editions/Article Default 1`] = `
             </figcaption>
           </figure>
           <div
-            className="css-165wy3b-Headline"
+            className="emotion-9"
           >
             <h1
-              className="css-13o616v-Headline"
+              className="emotion-10"
             >
               Reclaimed lakes and giant airports: how Mexico City might have looked
             </h1>
           </div>
           <div
-            className="css-h42k03"
+            className="emotion-11"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
             </p>
           </div>
           <div
-            className="css-7m2n2v-EditionsLines"
+            className="emotion-12"
           >
             <div
-              className="css-1xgmaw8-straightLines-fourLines-Lines"
+              className="emotion-13"
             />
           </div>
           <div
-            className="css-teh8lu"
+            className="emotion-14"
           >
             <address>
               <span
-                className="css-s6pm0t"
+                className="emotion-15"
               >
                 Jane Smith
               </span>
               <span
-                className="css-1yh100x"
+                className="emotion-16"
               >
                  Editor of things
               </span>
@@ -901,7 +3691,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
               role="button"
             >
               <button
-                className="css-rdfey0-ShareIcon"
+                className="emotion-17"
                 onClick={[Function]}
               >
                 <svg
@@ -925,16 +3715,16 @@ exports[`Storyshots Editions/Article Default 1`] = `
       </section>
     </div>
     <div
-      className="css-yn5fb1-Article"
+      className="emotion-18"
     >
       <section
-        className="css-1rrc8kn-Article"
+        className="emotion-19"
       >
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <figure
-          className="css-huy3rj-BodyImage"
+          className="emotion-21"
         >
           <picture>
             <source
@@ -948,7 +3738,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow css-1we7mgb-Img"
+              className="js-launch-slideshow emotion-22"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -957,18 +3747,18 @@ exports[`Storyshots Editions/Article Default 1`] = `
           </picture>
         </figure>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <div
-          className="css-cq3eyp-containerStyling"
+          className="emotion-25"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="css-l8n9ox-detailStyling"
+            className="emotion-26"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -976,23 +3766,23 @@ exports[`Storyshots Editions/Article Default 1`] = `
               onClick={[Function]}
             >
               <span
-                className="css-3w82vu-atomTitleStyling"
+                className="emotion-27"
               >
                 Quick Guide
               </span>
               <h4
-                className="css-gpo7xk-titleStyling"
+                className="emotion-28"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="css-1p3af4l-showHideStyling"
+                className="emotion-29"
               >
                 <span
-                  className="css-117w3ky-iconSpacing"
+                  className="emotion-30"
                 >
                   <span
-                    className="css-kd64v9-plusStyling"
+                    className="emotion-31"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -1011,7 +3801,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
             </summary>
             <div>
               <div
-                className="css-5oaelj-bodyStyling"
+                className="emotion-32"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -1020,24 +3810,24 @@ exports[`Storyshots Editions/Article Default 1`] = `
               />
             </div>
             <footer
-              className="css-dc74hn-footerStyling"
+              className="emotion-33"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="css-fgqqde-className"
+                  className="emotion-34"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="css-con9lg-buttonStyling"
+                    className="emotion-35"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-36"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -1047,12 +3837,12 @@ exports[`Storyshots Editions/Article Default 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="css-av88v2-buttonStyling-className"
+                    className="emotion-37"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-36"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -1064,7 +3854,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
                 </div>
               </div>
               <div
-                className="css-5a9sl9-className"
+                className="emotion-39"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -1074,19 +3864,19 @@ exports[`Storyshots Editions/Article Default 1`] = `
           </details>
         </div>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <aside
-          className="css-1f6ukfo-Pullquote"
+          className="emotion-42"
         >
           <blockquote
-            className="css-vhllol-Pullquote"
+            className="emotion-43"
           >
             <p
-              className="css-cgf9f8-Pullquote"
+              className="emotion-44"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -1101,17 +3891,17 @@ exports[`Storyshots Editions/Article Default 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="css-1znb75"
+              className="emotion-45"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
       </section>
     </div>
@@ -1120,24 +3910,853 @@ exports[`Storyshots Editions/Article Default 1`] = `
 `;
 
 exports[`Storyshots Editions/Article Feature 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FFFFFF;
+}
+
+.emotion-3 {
+  border-bottom: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    width: 545px;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-3 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-4 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width:740px) {
+  .emotion-5 {
+    width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    width: 750px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.emotion-6 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 740px;
+    height: calc(740px * 0.6);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 980px;
+    height: calc(980px * 0.6);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-6 {
+    background-color: #333333;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 720px;
+    height: 432px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-7 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-7 summary {
+  text-align: center;
+  background-color: #0084C6;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-7 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-7 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-7 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    width: 720px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 {
+    width: 750px;
+  }
+}
+
+.emotion-8 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-8 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-8 path {
+  fill: #F1F8FC;
+}
+
+.emotion-9 {
+  position: relative;
+}
+
+.emotion-10 {
+  color: #005689;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-10 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+.emotion-11 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-11 {
+    width: 545px;
+  }
+}
+
+.emotion-11 p,
+.emotion-11 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-11 address {
+  font-style: normal;
+}
+
+.emotion-11 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-11 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-11 svg path {
+  fill: #0084C6;
+}
+
+.emotion-12 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-12 {
+    width: 558px;
+  }
+}
+
+.emotion-13 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-14 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-14 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-14 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-14 svg path {
+  fill: #0084C6;
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-15 {
+  color: #0084C6;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-16 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-17 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+.emotion-18 {
+  padding-right: 0.75rem;
+  border-right: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-18 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-18 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-18 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-18 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-19 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-19 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-19 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:660px) {
+  .emotion-19 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-19 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-20 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-21 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width:660px) {
+  .emotion-21 {
+    width: 620px;
+  }
+}
+
+.emotion-22 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:660px) {
+  .emotion-22 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-22 {
+    background-color: #333333;
+  }
+}
+
+.emotion-25 {
+  display: block;
+  position: relative;
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.emotion-26 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-26 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-26 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-26 summary:focus {
+  outline: none;
+}
+
+.emotion-27 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #0084C6;
+}
+
+.emotion-28 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-29 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0,50%);
+  -ms-transform: translate(0,50%);
+  transform: translate(0,50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-29:hover {
+  background: #0084C6;
+}
+
+.emotion-30 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-31 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-32 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-32 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-32 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-32 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-32 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-32 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-32 b {
+  font-weight: 700;
+}
+
+.emotion-32 i {
+  font-style: italic;
+}
+
+.emotion-32 a {
+  color: #005689;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-32 a:hover {
+  border-bottom: solid 0.0625rem #0084C6;
+}
+
+.emotion-33 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.emotion-34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-35 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-35:hover {
+  background: #0084C6;
+}
+
+.emotion-35:focus {
+  border: none;
+}
+
+.emotion-36 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-37 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-37:hover {
+  background: #0084C6;
+}
+
+.emotion-37:focus {
+  border: none;
+}
+
+.emotion-39 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-42 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #0084C6;
+  border: 1px solid #0084C6;
+  border-top: 0.75rem solid #0084C6;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:1300px) {
+  .emotion-42 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-42:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #0084C6;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-42:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #0084C6;
+}
+
+.emotion-43 {
+  margin: 0;
+}
+
+.emotion-44 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-44 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #0084C6;
+}
+
+.emotion-45 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
 <main
-  className="css-2qsm3-Article"
+  className="emotion-0"
 >
   <article
-    className="css-2ammhe-Article"
+    className="emotion-1"
   >
     <div
-      className="css-16sk62p-Article"
+      className="emotion-2"
     >
       <section
-        className="css-wzgevt-Article"
+        className="emotion-3"
       >
         <header
-          className="css-10xsu7p-StandardHeader"
+          className="emotion-4"
         >
           <figure
             aria-labelledby="header-image-caption"
-            className="css-12lxyki-HeaderMedia"
+            className="emotion-5"
           >
             <picture>
               <source
@@ -1151,18 +4770,18 @@ exports[`Storyshots Editions/Article Feature 1`] = `
               />
               <img
                 alt=""
-                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                className="js-launch-slideshow js-main-image emotion-6"
                 data-ratio={0.6}
                 src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
               />
             </picture>
             <figcaption
-              className="css-1tza6s1-HeaderImageCaption"
+              className="emotion-7"
             >
               <details>
                 <summary>
                   <span
-                    className="css-1vqrqak"
+                    className="emotion-8"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -1188,39 +4807,39 @@ exports[`Storyshots Editions/Article Feature 1`] = `
             </figcaption>
           </figure>
           <div
-            className="css-165wy3b-Headline"
+            className="emotion-9"
           >
             <h1
-              className="css-3zxxdv-Headline"
+              className="emotion-10"
             >
               Reclaimed lakes and giant airports: how Mexico City might have looked
             </h1>
           </div>
           <div
-            className="css-1rir6qk"
+            className="emotion-11"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
             </p>
           </div>
           <div
-            className="css-7m2n2v-EditionsLines"
+            className="emotion-12"
           >
             <div
-              className="css-1xgmaw8-straightLines-fourLines-Lines"
+              className="emotion-13"
             />
           </div>
           <div
-            className="css-t8cjud"
+            className="emotion-14"
           >
             <address>
               <span
-                className="css-1410z7r"
+                className="emotion-15"
               >
                 Jane Smith
               </span>
               <span
-                className="css-1yh100x"
+                className="emotion-16"
               >
                  Editor of things
               </span>
@@ -1230,7 +4849,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
               role="button"
             >
               <button
-                className="css-rdfey0-ShareIcon"
+                className="emotion-17"
                 onClick={[Function]}
               >
                 <svg
@@ -1254,16 +4873,16 @@ exports[`Storyshots Editions/Article Feature 1`] = `
       </section>
     </div>
     <div
-      className="css-yn5fb1-Article"
+      className="emotion-18"
     >
       <section
-        className="css-1rrc8kn-Article"
+        className="emotion-19"
       >
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <figure
-          className="css-huy3rj-BodyImage"
+          className="emotion-21"
         >
           <picture>
             <source
@@ -1277,7 +4896,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow css-1we7mgb-Img"
+              className="js-launch-slideshow emotion-22"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -1286,18 +4905,18 @@ exports[`Storyshots Editions/Article Feature 1`] = `
           </picture>
         </figure>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <div
-          className="css-cq3eyp-containerStyling"
+          className="emotion-25"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="css-l8n9ox-detailStyling"
+            className="emotion-26"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -1305,23 +4924,23 @@ exports[`Storyshots Editions/Article Feature 1`] = `
               onClick={[Function]}
             >
               <span
-                className="css-lzpv1d-atomTitleStyling"
+                className="emotion-27"
               >
                 Quick Guide
               </span>
               <h4
-                className="css-gpo7xk-titleStyling"
+                className="emotion-28"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="css-1s5nci7-showHideStyling"
+                className="emotion-29"
               >
                 <span
-                  className="css-117w3ky-iconSpacing"
+                  className="emotion-30"
                 >
                   <span
-                    className="css-kd64v9-plusStyling"
+                    className="emotion-31"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -1340,7 +4959,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
             </summary>
             <div>
               <div
-                className="css-dv25nz-bodyStyling"
+                className="emotion-32"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -1349,24 +4968,24 @@ exports[`Storyshots Editions/Article Feature 1`] = `
               />
             </div>
             <footer
-              className="css-dc74hn-footerStyling"
+              className="emotion-33"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="css-fgqqde-className"
+                  className="emotion-34"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="css-27e8o5-buttonStyling"
+                    className="emotion-35"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-36"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -1376,12 +4995,12 @@ exports[`Storyshots Editions/Article Feature 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="css-dl0cko-buttonStyling-className"
+                    className="emotion-37"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-36"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -1393,7 +5012,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
                 </div>
               </div>
               <div
-                className="css-5a9sl9-className"
+                className="emotion-39"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -1403,19 +5022,19 @@ exports[`Storyshots Editions/Article Feature 1`] = `
           </details>
         </div>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <aside
-          className="css-llu3t1-Pullquote"
+          className="emotion-42"
         >
           <blockquote
-            className="css-vhllol-Pullquote"
+            className="emotion-43"
           >
             <p
-              className="css-19my7cx-Pullquote"
+              className="emotion-44"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -1430,17 +5049,17 @@ exports[`Storyshots Editions/Article Feature 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="css-1znb75"
+              className="emotion-45"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
       </section>
     </div>
@@ -1449,22 +5068,882 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 `;
 
 exports[`Storyshots Editions/Article Interview 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FFFFFF;
+}
+
+.emotion-4 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-5 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-5 {
+    background-color: #333333;
+  }
+}
+
+.emotion-6 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-6 summary {
+  text-align: center;
+  background-color: #0084C6;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-6 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-6 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-6 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 100%;
+  }
+}
+
+.emotion-7 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-7 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-7 path {
+  fill: #F1F8FC;
+}
+
+.emotion-8 {
+  background-color: #FFE500;
+}
+
+@media (min-width:740px) {
+  .emotion-8 {
+    padding-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-8 {
+    padding-left: 144px;
+  }
+}
+
+.emotion-9 {
+  position: relative;
+}
+
+.emotion-10 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+
+.emotion-11 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 700;
+  margin-left: 0.75rem;
+  border: 0;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-11 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-11 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-11 {
+    width: 545px;
+  }
+}
+
+.emotion-12 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 500;
+  font-weight: 400;
+  background-color: #121212;
+  color: #FFFFFF;
+  white-space: pre-wrap;
+  padding-top: 0.0625rem;
+  padding-bottom: 0.25rem;
+  box-shadow: -0.75rem 0 0 #121212,0.75rem 0 0 #121212;
+  display: inline;
+}
+
+@media (min-width:375px) {
+  .emotion-12 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 500;
+    font-weight: 400;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 500;
+    font-weight: 400;
+  }
+}
+
+.emotion-13 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-13 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-13 {
+    width: 545px;
+  }
+}
+
+.emotion-13 p,
+.emotion-13 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-13 address {
+  font-style: normal;
+}
+
+.emotion-13 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-13 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-13 svg path {
+  fill: #0084C6;
+}
+
+@media (min-width:740px) {
+  .emotion-13 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-14 {
+  box-sizing: border-box;
+  border-right: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-14 {
+    width: 558px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-14 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-15 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-16 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-bottom: 1px solid #DCDCDC;
+  border-right: 1px solid #DCDCDC;
+}
+
+.emotion-16 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-16 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-16 svg path {
+  fill: #0084C6;
+}
+
+@media (min-width:740px) {
+  .emotion-16 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-16 {
+    box-sizing: border-box;
+    margin-left: 1.5rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-16 {
+    margin-left: 144px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-16 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-16 {
+    width: 558px;
+  }
+}
+
+.emotion-17 {
+  color: #0084C6;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-18 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-19 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+.emotion-20 {
+  padding-right: 0.75rem;
+  border-right: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-20 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-20 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-20 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-20 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-21 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-21 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-21 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:660px) {
+  .emotion-21 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-22 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-23 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width:660px) {
+  .emotion-23 {
+    width: 620px;
+  }
+}
+
+.emotion-24 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:660px) {
+  .emotion-24 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-24 {
+    background-color: #333333;
+  }
+}
+
+.emotion-27 {
+  display: block;
+  position: relative;
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.emotion-28 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-28 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-28 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-28 summary:focus {
+  outline: none;
+}
+
+.emotion-29 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #0084C6;
+}
+
+.emotion-30 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-31 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0,50%);
+  -ms-transform: translate(0,50%);
+  transform: translate(0,50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-31:hover {
+  background: #0084C6;
+}
+
+.emotion-32 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-33 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-34 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-34 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-34 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-34 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-34 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-34 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-34 b {
+  font-weight: 700;
+}
+
+.emotion-34 i {
+  font-style: italic;
+}
+
+.emotion-34 a {
+  color: #005689;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-34 a:hover {
+  border-bottom: solid 0.0625rem #0084C6;
+}
+
+.emotion-35 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.emotion-36 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-37 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-37:hover {
+  background: #0084C6;
+}
+
+.emotion-37:focus {
+  border: none;
+}
+
+.emotion-38 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-39 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-39:hover {
+  background: #0084C6;
+}
+
+.emotion-39:focus {
+  border: none;
+}
+
+.emotion-41 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-44 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #0084C6;
+  border: 1px solid #0084C6;
+  border-top: 0.75rem solid #0084C6;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:1300px) {
+  .emotion-44 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-44:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #0084C6;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-44:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #0084C6;
+}
+
+.emotion-45 {
+  margin: 0;
+}
+
+.emotion-46 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-46 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #0084C6;
+}
+
+.emotion-47 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
 <main
-  className="css-2qsm3-Article"
+  className="emotion-0"
 >
   <article
-    className="css-2ammhe-Article"
+    className="emotion-1"
   >
     <div
-      className="css-16sk62p-Article"
+      className="emotion-2"
     >
       <section
-        className="css-1dhlyus-Article"
+        className="emotion-3"
       >
         <header>
           <figure
             aria-labelledby="header-image-caption"
-            className="css-dej5xk-HeaderMedia"
+            className="emotion-4"
           >
             <picture>
               <source
@@ -1478,18 +5957,18 @@ exports[`Storyshots Editions/Article Interview 1`] = `
               />
               <img
                 alt=""
-                className="js-launch-slideshow js-main-image css-1ly9xbv-Img"
+                className="js-launch-slideshow js-main-image emotion-5"
                 data-ratio={0.6}
                 src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
               />
             </picture>
             <figcaption
-              className="css-ianha0-HeaderImageCaption"
+              className="emotion-6"
             >
               <details>
                 <summary>
                   <span
-                    className="css-1vqrqak"
+                    className="emotion-7"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -1515,26 +5994,26 @@ exports[`Storyshots Editions/Article Interview 1`] = `
             </figcaption>
           </figure>
           <div
-            className="css-c356nv-InterviewHeader"
+            className="emotion-8"
           >
             <div
-              className="css-165wy3b-Headline"
+              className="emotion-9"
             >
               <div
-                className="css-1duggjj-Headline"
+                className="emotion-10"
               />
               <h1
-                className="css-ghqarw-Headline"
+                className="emotion-11"
               >
                 <span
-                  className="css-1hvs9iy"
+                  className="emotion-12"
                 >
                   Reclaimed lakes and giant airports: how Mexico City might have looked
                 </span>
               </h1>
             </div>
             <div
-              className="css-18316b1"
+              className="emotion-13"
             >
               <p>
                 The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -1542,23 +6021,23 @@ exports[`Storyshots Editions/Article Interview 1`] = `
             </div>
           </div>
           <div
-            className="css-ybmkx6-EditionsLines"
+            className="emotion-14"
           >
             <div
-              className="css-1xgmaw8-straightLines-fourLines-Lines"
+              className="emotion-15"
             />
           </div>
           <div
-            className="css-1r6t5jr"
+            className="emotion-16"
           >
             <address>
               <span
-                className="css-1410z7r"
+                className="emotion-17"
               >
                 Jane Smith
               </span>
               <span
-                className="css-1yh100x"
+                className="emotion-18"
               >
                  Editor of things
               </span>
@@ -1568,7 +6047,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
               role="button"
             >
               <button
-                className="css-rdfey0-ShareIcon"
+                className="emotion-19"
                 onClick={[Function]}
               >
                 <svg
@@ -1592,16 +6071,16 @@ exports[`Storyshots Editions/Article Interview 1`] = `
       </section>
     </div>
     <div
-      className="css-yn5fb1-Article"
+      className="emotion-20"
     >
       <section
-        className="css-1rrc8kn-Article"
+        className="emotion-21"
       >
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-22"
         />
         <figure
-          className="css-huy3rj-BodyImage"
+          className="emotion-23"
         >
           <picture>
             <source
@@ -1615,7 +6094,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow css-1we7mgb-Img"
+              className="js-launch-slideshow emotion-24"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -1624,18 +6103,18 @@ exports[`Storyshots Editions/Article Interview 1`] = `
           </picture>
         </figure>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-22"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-22"
         />
         <div
-          className="css-cq3eyp-containerStyling"
+          className="emotion-27"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="css-l8n9ox-detailStyling"
+            className="emotion-28"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -1643,23 +6122,23 @@ exports[`Storyshots Editions/Article Interview 1`] = `
               onClick={[Function]}
             >
               <span
-                className="css-lzpv1d-atomTitleStyling"
+                className="emotion-29"
               >
                 Quick Guide
               </span>
               <h4
-                className="css-gpo7xk-titleStyling"
+                className="emotion-30"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="css-1s5nci7-showHideStyling"
+                className="emotion-31"
               >
                 <span
-                  className="css-117w3ky-iconSpacing"
+                  className="emotion-32"
                 >
                   <span
-                    className="css-kd64v9-plusStyling"
+                    className="emotion-33"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -1678,7 +6157,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
             </summary>
             <div>
               <div
-                className="css-dv25nz-bodyStyling"
+                className="emotion-34"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -1687,24 +6166,24 @@ exports[`Storyshots Editions/Article Interview 1`] = `
               />
             </div>
             <footer
-              className="css-dc74hn-footerStyling"
+              className="emotion-35"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="css-fgqqde-className"
+                  className="emotion-36"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="css-27e8o5-buttonStyling"
+                    className="emotion-37"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-38"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -1714,12 +6193,12 @@ exports[`Storyshots Editions/Article Interview 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="css-dl0cko-buttonStyling-className"
+                    className="emotion-39"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-38"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -1731,7 +6210,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
                 </div>
               </div>
               <div
-                className="css-5a9sl9-className"
+                className="emotion-41"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -1741,19 +6220,19 @@ exports[`Storyshots Editions/Article Interview 1`] = `
           </details>
         </div>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-22"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-22"
         />
         <aside
-          className="css-llu3t1-Pullquote"
+          className="emotion-44"
         >
           <blockquote
-            className="css-vhllol-Pullquote"
+            className="emotion-45"
           >
             <p
-              className="css-19my7cx-Pullquote"
+              className="emotion-46"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -1768,17 +6247,17 @@ exports[`Storyshots Editions/Article Interview 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="css-1znb75"
+              className="emotion-47"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-22"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-22"
         />
       </section>
     </div>
@@ -1787,24 +6266,472 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 `;
 
 exports[`Storyshots Editions/Article Media 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: #121212;
+}
+
+.emotion-2 {
+  background-color: #121212;
+}
+
+.emotion-4 {
+  border-bottom: 1px solid #FFFFFF;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    border: none;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-6 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #333333;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-6 {
+    background-color: #333333;
+  }
+}
+
+.emotion-7 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-7 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-7 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-7 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-7 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    width: 100%;
+  }
+}
+
+.emotion-8 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-8 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-8 path {
+  fill: #FFF4F2;
+}
+
+.emotion-9 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-9 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-9 {
+    padding-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-9 {
+    padding-left: 144px;
+  }
+}
+
+.emotion-10 {
+  position: relative;
+}
+
+.emotion-11 {
+  color: #FFFFFF;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GT Guardian Titlepiece,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  font-size: 2rem;
+  line-height: 1.2;
+  padding-bottom: 1.5rem;
+  background-color: #121212;
+  border: 0;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-11 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-11 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    border-bottom: 1px solid #FFFFFF;
+    border-right: 1px solid #FFFFFF;
+    box-sizing: border-box;
+    width: 538px;
+  }
+
+  @media (min-width:1300px) {
+    .emotion-12 {
+      width: 557px;
+    }
+  }
+}
+
+.emotion-13 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  color: #FFFFFF;
+}
+
+@media (min-width:740px) {
+  .emotion-13 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-13 {
+    width: 545px;
+  }
+}
+
+.emotion-13 p,
+.emotion-13 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-13 address {
+  font-style: normal;
+}
+
+.emotion-13 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-13 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-13 svg path {
+  fill: #C70000;
+}
+
+.emotion-14 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-14 {
+    width: 558px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    margin-left: 0;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-14 {
+    margin-left: 0;
+  }
+}
+
+.emotion-15 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-16 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-16 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-16 svg circle {
+  stroke: #FFFFFF;
+}
+
+.emotion-16 svg path {
+  fill: #FFFFFF;
+}
+
+@media (min-width:740px) {
+  .emotion-16 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-16 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-16 {
+    width: 545px;
+  }
+}
+
+.emotion-17 {
+  color: #FFFFFF;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-18 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #FFFFFF;
+}
+
+.emotion-19 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+.emotion-20 {
+  padding-right: 0.75rem;
+  border-right: 1px solid #DCDCDC;
+  box-sizing: border-box;
+  padding-top: 0.75rem;
+  padding-right: 0;
+  padding-left: 0;
+  border: none;
+}
+
+@media (min-width:740px) {
+  .emotion-20 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-20 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-20 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-20 {
+    margin-left: 144px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-20 {
+    width: 538px;
+    padding-right: 1rem;
+    border-right: 1px solid #FFFFFF;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-20 {
+    width: 557px;
+  }
+}
+
+.emotion-21 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-21 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-21 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:660px) {
+  .emotion-21 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
 <main
-  className="css-2qsm3-Article"
+  className="emotion-0"
 >
   <article
-    className="css-58dfiu-Article"
+    className="emotion-1"
   >
     <div
-      className="css-18oto43-Article"
+      className="emotion-2"
     >
       <section
-        className="css-1dhlyus-Article"
+        className="emotion-3"
       >
         <header
-          className="css-70tn5r-GalleryHeader"
+          className="emotion-4"
         >
           <figure
             aria-labelledby="header-image-caption"
-            className="css-dej5xk-HeaderMedia"
+            className="emotion-5"
           >
             <picture>
               <source
@@ -1818,18 +6745,18 @@ exports[`Storyshots Editions/Article Media 1`] = `
               />
               <img
                 alt=""
-                className="js-launch-slideshow js-main-image css-vgwzwo-Img"
+                className="js-launch-slideshow js-main-image emotion-6"
                 data-ratio={0.6}
                 src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
               />
             </picture>
             <figcaption
-              className="css-nr1xa1-HeaderImageCaption"
+              className="emotion-7"
             >
               <details>
                 <summary>
                   <span
-                    className="css-6okjyw"
+                    className="emotion-8"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -1855,45 +6782,45 @@ exports[`Storyshots Editions/Article Media 1`] = `
             </figcaption>
           </figure>
           <div
-            className="css-cm0bg2-GalleryHeader"
+            className="emotion-9"
           >
             <div
-              className="css-165wy3b-Headline"
+              className="emotion-10"
             >
               <h1
-                className="css-1cwqm68-Headline"
+                className="emotion-11"
               >
                 Reclaimed lakes and giant airports: how Mexico City might have looked
               </h1>
             </div>
             <div
-              className="css-y9xf0m-GalleryHeader"
+              className="emotion-12"
             >
               <div
-                className="css-mwiu58"
+                className="emotion-13"
               >
                 <p>
                   The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
                 </p>
               </div>
               <div
-                className="css-22kpax-EditionsLines"
+                className="emotion-14"
               >
                 <div
-                  className="css-1xgmaw8-straightLines-fourLines-Lines"
+                  className="emotion-15"
                 />
               </div>
               <div
-                className="css-o0edii"
+                className="emotion-16"
               >
                 <address>
                   <span
-                    className="css-1vsgm6a"
+                    className="emotion-17"
                   >
                     Jane Smith
                   </span>
                   <span
-                    className="css-1u4yveu"
+                    className="emotion-18"
                   >
                      Editor of things
                   </span>
@@ -1903,7 +6830,7 @@ exports[`Storyshots Editions/Article Media 1`] = `
                   role="button"
                 >
                   <button
-                    className="css-rdfey0-ShareIcon"
+                    className="emotion-19"
                     onClick={[Function]}
                   >
                     <svg
@@ -1929,10 +6856,10 @@ exports[`Storyshots Editions/Article Media 1`] = `
       </section>
     </div>
     <div
-      className="css-1f5frn6-Article"
+      className="emotion-20"
     >
       <section
-        className="css-1rrc8kn-Article"
+        className="emotion-21"
       />
     </div>
   </article>
@@ -1940,24 +6867,889 @@ exports[`Storyshots Editions/Article Media 1`] = `
 `;
 
 exports[`Storyshots Editions/Article Review 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FBF6EF;
+}
+
+.emotion-3 {
+  border-bottom: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    width: 545px;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-3 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-4 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width:740px) {
+  .emotion-5 {
+    width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    width: 750px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.emotion-6 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 740px;
+    height: calc(740px * 0.6);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 980px;
+    height: calc(980px * 0.6);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-6 {
+    background-color: #333333;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 720px;
+    height: 432px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-7 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-7 summary {
+  text-align: center;
+  background-color: #A1845C;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-7 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-7 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-7 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    width: 720px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 {
+    width: 750px;
+  }
+}
+
+.emotion-8 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-8 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-8 path {
+  fill: #FBF6EF;
+}
+
+.emotion-9 {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+}
+
+.emotion-10 {
+  background-color: #FFE500;
+  display: inline-block;
+}
+
+.emotion-10:nth-of-type(5) {
+  padding-right: 2px;
+}
+
+.emotion-10 svg {
+  margin: 0 -0.125rem;
+  height: 1.75rem;
+}
+
+.emotion-14 {
+  background-color: #FFE500;
+  display: inline-block;
+  fill: transparent;
+  stroke: #121212;
+}
+
+.emotion-14:nth-of-type(5) {
+  padding-right: 2px;
+}
+
+.emotion-14 svg {
+  margin: 0 -0.125rem;
+  height: 1.75rem;
+}
+
+.emotion-15 {
+  position: relative;
+}
+
+.emotion-16 {
+  color: #6B5840;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-16 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-16 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-16 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+.emotion-17 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+@media (min-width:740px) {
+  .emotion-17 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-17 {
+    width: 545px;
+  }
+}
+
+.emotion-17 p,
+.emotion-17 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-17 address {
+  font-style: normal;
+}
+
+.emotion-17 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-17 svg circle {
+  stroke: #A1845C;
+}
+
+.emotion-17 svg path {
+  fill: #A1845C;
+}
+
+.emotion-18 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-18 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-18 {
+    width: 558px;
+  }
+}
+
+.emotion-19 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-20 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-20 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-20 svg circle {
+  stroke: #A1845C;
+}
+
+.emotion-20 svg path {
+  fill: #A1845C;
+}
+
+@media (min-width:740px) {
+  .emotion-20 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-21 {
+  color: #A1845C;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-22 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-23 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+.emotion-24 {
+  padding-right: 0.75rem;
+  border-right: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-24 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-24 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-24 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-24 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-25 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-25 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-25 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:660px) {
+  .emotion-25 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-25 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-26 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-27 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width:660px) {
+  .emotion-27 {
+    width: 620px;
+  }
+}
+
+.emotion-28 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:660px) {
+  .emotion-28 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-28 {
+    background-color: #333333;
+  }
+}
+
+.emotion-31 {
+  display: block;
+  position: relative;
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.emotion-32 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-32 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-32 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-32 summary:focus {
+  outline: none;
+}
+
+.emotion-33 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #A1845C;
+}
+
+.emotion-34 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-35 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0,50%);
+  -ms-transform: translate(0,50%);
+  transform: translate(0,50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-35:hover {
+  background: #A1845C;
+}
+
+.emotion-36 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-37 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-38 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-38 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-38 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-38 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-38 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-38 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-38 b {
+  font-weight: 700;
+}
+
+.emotion-38 i {
+  font-style: italic;
+}
+
+.emotion-38 a {
+  color: #6B5840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-38 a:hover {
+  border-bottom: solid 0.0625rem #A1845C;
+}
+
+.emotion-39 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.emotion-40 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-41 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-41:hover {
+  background: #A1845C;
+}
+
+.emotion-41:focus {
+  border: none;
+}
+
+.emotion-42 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-43 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-43:hover {
+  background: #A1845C;
+}
+
+.emotion-43:focus {
+  border: none;
+}
+
+.emotion-45 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-48 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #A1845C;
+  border: 1px solid #A1845C;
+  border-top: 0.75rem solid #A1845C;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:1300px) {
+  .emotion-48 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-48:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #A1845C;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-48:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #A1845C;
+}
+
+.emotion-49 {
+  margin: 0;
+}
+
+.emotion-50 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-50 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #A1845C;
+}
+
+.emotion-51 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
 <main
-  className="css-2qsm3-Article"
+  className="emotion-0"
 >
   <article
-    className="css-2ammhe-Article"
+    className="emotion-1"
   >
     <div
-      className="css-8rvrj7-Article"
+      className="emotion-2"
     >
       <section
-        className="css-wzgevt-Article"
+        className="emotion-3"
       >
         <header
-          className="css-10xsu7p-StandardHeader"
+          className="emotion-4"
         >
           <figure
             aria-labelledby="header-image-caption"
-            className="css-12lxyki-HeaderMedia"
+            className="emotion-5"
           >
             <picture>
               <source
@@ -1971,18 +7763,18 @@ exports[`Storyshots Editions/Article Review 1`] = `
               />
               <img
                 alt=""
-                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                className="js-launch-slideshow js-main-image emotion-6"
                 data-ratio={0.6}
                 src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
               />
             </picture>
             <figcaption
-              className="css-mx0oi0-HeaderImageCaption"
+              className="emotion-7"
             >
               <details>
                 <summary>
                   <span
-                    className="css-pfziyb"
+                    className="emotion-8"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -2007,10 +7799,10 @@ exports[`Storyshots Editions/Article Review 1`] = `
               </details>
             </figcaption>
             <div
-              className="css-qw9jwe-StarRating"
+              className="emotion-9"
             >
               <span
-                className="css-kuz013"
+                className="emotion-10"
               >
                 <svg
                   viewBox="0 0 30 30"
@@ -2024,7 +7816,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
                 </svg>
               </span>
               <span
-                className="css-kuz013"
+                className="emotion-10"
               >
                 <svg
                   viewBox="0 0 30 30"
@@ -2038,7 +7830,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
                 </svg>
               </span>
               <span
-                className="css-kuz013"
+                className="emotion-10"
               >
                 <svg
                   viewBox="0 0 30 30"
@@ -2052,7 +7844,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
                 </svg>
               </span>
               <span
-                className="css-kuz013"
+                className="emotion-10"
               >
                 <svg
                   viewBox="0 0 30 30"
@@ -2066,7 +7858,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
                 </svg>
               </span>
               <span
-                className="css-w8n5c6-empty"
+                className="emotion-14"
               >
                 <svg
                   viewBox="0 0 30 30"
@@ -2082,39 +7874,39 @@ exports[`Storyshots Editions/Article Review 1`] = `
             </div>
           </figure>
           <div
-            className="css-165wy3b-Headline"
+            className="emotion-15"
           >
             <h1
-              className="css-1r46rn4-Headline"
+              className="emotion-16"
             >
               Reclaimed lakes and giant airports: how Mexico City might have looked
             </h1>
           </div>
           <div
-            className="css-1193fgv"
+            className="emotion-17"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
             </p>
           </div>
           <div
-            className="css-7m2n2v-EditionsLines"
+            className="emotion-18"
           >
             <div
-              className="css-1xgmaw8-straightLines-fourLines-Lines"
+              className="emotion-19"
             />
           </div>
           <div
-            className="css-1acgyo2"
+            className="emotion-20"
           >
             <address>
               <span
-                className="css-ixhtuz"
+                className="emotion-21"
               >
                 Jane Smith
               </span>
               <span
-                className="css-1yh100x"
+                className="emotion-22"
               >
                  Editor of things
               </span>
@@ -2124,7 +7916,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
               role="button"
             >
               <button
-                className="css-rdfey0-ShareIcon"
+                className="emotion-23"
                 onClick={[Function]}
               >
                 <svg
@@ -2148,16 +7940,16 @@ exports[`Storyshots Editions/Article Review 1`] = `
       </section>
     </div>
     <div
-      className="css-yn5fb1-Article"
+      className="emotion-24"
     >
       <section
-        className="css-1rrc8kn-Article"
+        className="emotion-25"
       >
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-26"
         />
         <figure
-          className="css-huy3rj-BodyImage"
+          className="emotion-27"
         >
           <picture>
             <source
@@ -2171,7 +7963,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow css-1we7mgb-Img"
+              className="js-launch-slideshow emotion-28"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -2180,18 +7972,18 @@ exports[`Storyshots Editions/Article Review 1`] = `
           </picture>
         </figure>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-26"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-26"
         />
         <div
-          className="css-cq3eyp-containerStyling"
+          className="emotion-31"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="css-l8n9ox-detailStyling"
+            className="emotion-32"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -2199,23 +7991,23 @@ exports[`Storyshots Editions/Article Review 1`] = `
               onClick={[Function]}
             >
               <span
-                className="css-1mdioea-atomTitleStyling"
+                className="emotion-33"
               >
                 Quick Guide
               </span>
               <h4
-                className="css-gpo7xk-titleStyling"
+                className="emotion-34"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="css-bawg6n-showHideStyling"
+                className="emotion-35"
               >
                 <span
-                  className="css-117w3ky-iconSpacing"
+                  className="emotion-36"
                 >
                   <span
-                    className="css-kd64v9-plusStyling"
+                    className="emotion-37"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -2234,7 +8026,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
             </summary>
             <div>
               <div
-                className="css-1piahod-bodyStyling"
+                className="emotion-38"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -2243,24 +8035,24 @@ exports[`Storyshots Editions/Article Review 1`] = `
               />
             </div>
             <footer
-              className="css-dc74hn-footerStyling"
+              className="emotion-39"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="css-fgqqde-className"
+                  className="emotion-40"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="css-8jszxu-buttonStyling"
+                    className="emotion-41"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-42"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -2270,12 +8062,12 @@ exports[`Storyshots Editions/Article Review 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="css-1dn7oml-buttonStyling-className"
+                    className="emotion-43"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-42"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -2287,7 +8079,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
                 </div>
               </div>
               <div
-                className="css-5a9sl9-className"
+                className="emotion-45"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -2297,19 +8089,19 @@ exports[`Storyshots Editions/Article Review 1`] = `
           </details>
         </div>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-26"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-26"
         />
         <aside
-          className="css-zws4bj-Pullquote"
+          className="emotion-48"
         >
           <blockquote
-            className="css-vhllol-Pullquote"
+            className="emotion-49"
           >
             <p
-              className="css-1eb8lfx-Pullquote"
+              className="emotion-50"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -2324,17 +8116,17 @@ exports[`Storyshots Editions/Article Review 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="css-1znb75"
+              className="emotion-51"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-26"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-26"
         />
       </section>
     </div>
@@ -2343,24 +8135,853 @@ exports[`Storyshots Editions/Article Review 1`] = `
 `;
 
 exports[`Storyshots Editions/Article Showcase 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FFFFFF;
+}
+
+.emotion-3 {
+  border-bottom: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    width: 545px;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-3 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-3 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-4 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width:740px) {
+  .emotion-5 {
+    width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    width: 750px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.emotion-6 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 740px;
+    height: calc(740px * 0.6);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 980px;
+    height: calc(980px * 0.6);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-6 {
+    background-color: #333333;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-6 {
+    width: 720px;
+    height: 432px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-6 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-7 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-7 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-7 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-7 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-7 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    width: 720px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 {
+    width: 750px;
+  }
+}
+
+.emotion-8 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-8 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-8 path {
+  fill: #FFF4F2;
+}
+
+.emotion-9 {
+  position: relative;
+}
+
+.emotion-10 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-10 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-10 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+.emotion-11 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-11 {
+    width: 545px;
+  }
+}
+
+.emotion-11 p,
+.emotion-11 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-11 address {
+  font-style: normal;
+}
+
+.emotion-11 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-11 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-11 svg path {
+  fill: #C70000;
+}
+
+.emotion-12 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-12 {
+    width: 558px;
+  }
+}
+
+.emotion-13 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-14 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-14 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-14 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-14 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-15 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-16 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-17 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+.emotion-18 {
+  padding-right: 0.75rem;
+  border-right: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-18 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-18 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-18 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-18 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-19 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-19 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-19 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:660px) {
+  .emotion-19 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-19 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-20 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-21 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width:660px) {
+  .emotion-21 {
+    width: 620px;
+  }
+}
+
+.emotion-22 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:660px) {
+  .emotion-22 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-22 {
+    background-color: #333333;
+  }
+}
+
+.emotion-25 {
+  display: block;
+  position: relative;
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.emotion-26 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-26 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-26 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-26 summary:focus {
+  outline: none;
+}
+
+.emotion-27 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #C70000;
+}
+
+.emotion-28 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-29 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0,50%);
+  -ms-transform: translate(0,50%);
+  transform: translate(0,50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-29:hover {
+  background: #C70000;
+}
+
+.emotion-30 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-31 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-32 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-32 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-32 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-32 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-32 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-32 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-32 b {
+  font-weight: 700;
+}
+
+.emotion-32 i {
+  font-style: italic;
+}
+
+.emotion-32 a {
+  color: #AB0613;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-32 a:hover {
+  border-bottom: solid 0.0625rem #C70000;
+}
+
+.emotion-33 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.emotion-34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-35 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-35:hover {
+  background: #C70000;
+}
+
+.emotion-35:focus {
+  border: none;
+}
+
+.emotion-36 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-37 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-37:hover {
+  background: #C70000;
+}
+
+.emotion-37:focus {
+  border: none;
+}
+
+.emotion-39 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-42 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #C70000;
+  border: 1px solid #C70000;
+  border-top: 0.75rem solid #C70000;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:1300px) {
+  .emotion-42 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-42:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #C70000;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-42:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #C70000;
+}
+
+.emotion-43 {
+  margin: 0;
+}
+
+.emotion-44 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-44 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #C70000;
+}
+
+.emotion-45 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
 <main
-  className="css-2qsm3-Article"
+  className="emotion-0"
 >
   <article
-    className="css-2ammhe-Article"
+    className="emotion-1"
   >
     <div
-      className="css-16sk62p-Article"
+      className="emotion-2"
     >
       <section
-        className="css-wzgevt-Article"
+        className="emotion-3"
       >
         <header
-          className="css-10xsu7p-StandardHeader"
+          className="emotion-4"
         >
           <figure
             aria-labelledby="header-image-caption"
-            className="css-12lxyki-HeaderMedia"
+            className="emotion-5"
           >
             <picture>
               <source
@@ -2374,18 +8995,18 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               />
               <img
                 alt=""
-                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                className="js-launch-slideshow js-main-image emotion-6"
                 data-ratio={0.6}
                 src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
               />
             </picture>
             <figcaption
-              className="css-169o3q0-HeaderImageCaption"
+              className="emotion-7"
             >
               <details>
                 <summary>
                   <span
-                    className="css-6okjyw"
+                    className="emotion-8"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -2411,39 +9032,39 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
             </figcaption>
           </figure>
           <div
-            className="css-165wy3b-Headline"
+            className="emotion-9"
           >
             <h1
-              className="css-13o616v-Headline"
+              className="emotion-10"
             >
               Reclaimed lakes and giant airports: how Mexico City might have looked
             </h1>
           </div>
           <div
-            className="css-h42k03"
+            className="emotion-11"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
             </p>
           </div>
           <div
-            className="css-7m2n2v-EditionsLines"
+            className="emotion-12"
           >
             <div
-              className="css-1xgmaw8-straightLines-fourLines-Lines"
+              className="emotion-13"
             />
           </div>
           <div
-            className="css-teh8lu"
+            className="emotion-14"
           >
             <address>
               <span
-                className="css-s6pm0t"
+                className="emotion-15"
               >
                 Jane Smith
               </span>
               <span
-                className="css-1yh100x"
+                className="emotion-16"
               >
                  Editor of things
               </span>
@@ -2453,7 +9074,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               role="button"
             >
               <button
-                className="css-rdfey0-ShareIcon"
+                className="emotion-17"
                 onClick={[Function]}
               >
                 <svg
@@ -2477,16 +9098,16 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
       </section>
     </div>
     <div
-      className="css-yn5fb1-Article"
+      className="emotion-18"
     >
       <section
-        className="css-1rrc8kn-Article"
+        className="emotion-19"
       >
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <figure
-          className="css-huy3rj-BodyImage"
+          className="emotion-21"
         >
           <picture>
             <source
@@ -2500,7 +9121,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow css-1we7mgb-Img"
+              className="js-launch-slideshow emotion-22"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -2509,18 +9130,18 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
           </picture>
         </figure>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <div
-          className="css-cq3eyp-containerStyling"
+          className="emotion-25"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="css-l8n9ox-detailStyling"
+            className="emotion-26"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -2528,23 +9149,23 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               onClick={[Function]}
             >
               <span
-                className="css-3w82vu-atomTitleStyling"
+                className="emotion-27"
               >
                 Quick Guide
               </span>
               <h4
-                className="css-gpo7xk-titleStyling"
+                className="emotion-28"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="css-1p3af4l-showHideStyling"
+                className="emotion-29"
               >
                 <span
-                  className="css-117w3ky-iconSpacing"
+                  className="emotion-30"
                 >
                   <span
-                    className="css-kd64v9-plusStyling"
+                    className="emotion-31"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -2563,7 +9184,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
             </summary>
             <div>
               <div
-                className="css-5oaelj-bodyStyling"
+                className="emotion-32"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -2572,24 +9193,24 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               />
             </div>
             <footer
-              className="css-dc74hn-footerStyling"
+              className="emotion-33"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="css-fgqqde-className"
+                  className="emotion-34"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="css-con9lg-buttonStyling"
+                    className="emotion-35"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-36"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -2599,12 +9220,12 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="css-av88v2-buttonStyling-className"
+                    className="emotion-37"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="css-15k23p-className"
+                      className="emotion-36"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -2616,7 +9237,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
                 </div>
               </div>
               <div
-                className="css-5a9sl9-className"
+                className="emotion-39"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -2626,19 +9247,19 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
           </details>
         </div>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <aside
-          className="css-1f6ukfo-Pullquote"
+          className="emotion-42"
         >
           <blockquote
-            className="css-vhllol-Pullquote"
+            className="emotion-43"
           >
             <p
-              className="css-cgf9f8-Pullquote"
+              className="emotion-44"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -2653,17 +9274,17 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="css-1znb75"
+              className="emotion-45"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
         <p
-          className="css-ril8fi-Paragraph"
+          className="emotion-20"
         />
       </section>
     </div>
@@ -2672,6 +9293,16 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 `;
 
 exports[`Storyshots Editions/Avatar Default 1`] = `
+.emotion-0 {
+  width: 105px;
+  height: calc(105px * 1);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  background: none;
+  width: 125px;
+}
+
 <picture>
   <source
     media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
@@ -2684,7 +9315,7 @@ exports[`Storyshots Editions/Avatar Default 1`] = `
   />
   <img
     alt="image"
-    className="css-1i77lxz-Img"
+    className="emotion-0"
     data-ratio={1}
     src="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e"
   />
@@ -2692,17 +9323,112 @@ exports[`Storyshots Editions/Avatar Default 1`] = `
 `;
 
 exports[`Storyshots Editions/Byline Analysis 1`] = `
+.emotion-0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-1 {
+  color: #C70000;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 700;
+  font-style: normal;
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 700;
+    font-style: normal;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 700;
+    font-style: normal;
+  }
+}
+
+.emotion-2 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: undefined;
+  font-weight: 300;
+  font-style: italic;
+  color: #121212;
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: undefined;
+    font-weight: 300;
+    font-style: italic;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: undefined;
+    font-weight: 300;
+    font-style: italic;
+  }
+}
+
 <div
-  className="css-teh8lu"
+  className="emotion-0"
 >
   <address>
     <span
-      className="css-1tnqwjd"
+      className="emotion-1"
     >
       Jane Smith
     </span>
     <span
-      className="css-15jtyuf"
+      className="emotion-2"
     >
        Editor of things
     </span>
@@ -2711,6 +9437,118 @@ exports[`Storyshots Editions/Byline Analysis 1`] = `
 `;
 
 exports[`Storyshots Editions/Byline Comment 1`] = `
+.emotion-0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+  padding-right: 6.5625rem;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-1 {
+  color: #C70000;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 700;
+  font-style: normal;
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 700;
+    font-style: normal;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 700;
+    font-style: normal;
+  }
+}
+
+.emotion-2 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: undefined;
+  font-weight: 300;
+  font-style: italic;
+  color: #121212;
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: undefined;
+    font-weight: 300;
+    font-style: italic;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: undefined;
+    font-weight: 300;
+    font-style: italic;
+  }
+}
+
+.emotion-3 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
+.emotion-4 {
+  width: 105px;
+  height: calc(105px * 1);
+  background-color: #DCDCDC;
+  color: #999999;
+  display: block;
+  background: none;
+  width: 125px;
+}
+
 <div
   style={
     Object {
@@ -2719,22 +9557,22 @@ exports[`Storyshots Editions/Byline Comment 1`] = `
   }
 >
   <div
-    className="css-1xck3cj"
+    className="emotion-0"
   >
     <address>
       <span
-        className="css-1tnqwjd"
+        className="emotion-1"
       >
         Jane Smith
       </span>
       <span
-        className="css-15jtyuf"
+        className="emotion-2"
       >
          Editor of things
       </span>
     </address>
     <div
-      className="css-17kiv7u"
+      className="emotion-3"
     >
       <picture>
         <source
@@ -2748,7 +9586,7 @@ exports[`Storyshots Editions/Byline Comment 1`] = `
         />
         <img
           alt="image"
-          className="css-1w5z5b1-Img"
+          className="emotion-4"
           data-ratio={1}
           src="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e"
         />
@@ -2759,17 +9597,77 @@ exports[`Storyshots Editions/Byline Comment 1`] = `
 `;
 
 exports[`Storyshots Editions/Byline Default 1`] = `
+.emotion-0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-1 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-2 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-3 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
-  className="css-teh8lu"
+  className="emotion-0"
 >
   <address>
     <span
-      className="css-s6pm0t"
+      className="emotion-1"
     >
       Jane Smith
     </span>
     <span
-      className="css-1yh100x"
+      className="emotion-2"
     >
        Editor of things
     </span>
@@ -2779,7 +9677,7 @@ exports[`Storyshots Editions/Byline Default 1`] = `
     role="button"
   >
     <button
-      className="css-rdfey0-ShareIcon"
+      className="emotion-3"
       onClick={[Function]}
     >
       <svg
@@ -2802,17 +9700,77 @@ exports[`Storyshots Editions/Byline Default 1`] = `
 `;
 
 exports[`Storyshots Editions/Byline Feature 1`] = `
+.emotion-0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-1 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-2 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-3 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
-  className="css-teh8lu"
+  className="emotion-0"
 >
   <address>
     <span
-      className="css-s6pm0t"
+      className="emotion-1"
     >
       Jane Smith
     </span>
     <span
-      className="css-1yh100x"
+      className="emotion-2"
     >
        Editor of things
     </span>
@@ -2822,7 +9780,7 @@ exports[`Storyshots Editions/Byline Feature 1`] = `
     role="button"
   >
     <button
-      className="css-rdfey0-ShareIcon"
+      className="emotion-3"
       onClick={[Function]}
     >
       <svg
@@ -2845,17 +9803,108 @@ exports[`Storyshots Editions/Byline Feature 1`] = `
 `;
 
 exports[`Storyshots Editions/Byline Interview 1`] = `
+.emotion-0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-bottom: 1px solid #DCDCDC;
+  border-right: 1px solid #DCDCDC;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    box-sizing: border-box;
+    margin-left: 1.5rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin-left: 144px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    width: 539px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 558px;
+  }
+}
+
+.emotion-1 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-2 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-3 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
-  className="css-8x2t1u"
+  className="emotion-0"
 >
   <address>
     <span
-      className="css-s6pm0t"
+      className="emotion-1"
     >
       Jane Smith
     </span>
     <span
-      className="css-1yh100x"
+      className="emotion-2"
     >
        Editor of things
     </span>
@@ -2865,7 +9914,7 @@ exports[`Storyshots Editions/Byline Interview 1`] = `
     role="button"
   >
     <button
-      className="css-rdfey0-ShareIcon"
+      className="emotion-3"
       onClick={[Function]}
     >
       <svg
@@ -2888,17 +9937,77 @@ exports[`Storyshots Editions/Byline Interview 1`] = `
 `;
 
 exports[`Storyshots Editions/Byline Review 1`] = `
+.emotion-0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-1 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-2 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-3 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
-  className="css-teh8lu"
+  className="emotion-0"
 >
   <address>
     <span
-      className="css-s6pm0t"
+      className="emotion-1"
     >
       Jane Smith
     </span>
     <span
-      className="css-1yh100x"
+      className="emotion-2"
     >
        Editor of things
     </span>
@@ -2908,7 +10017,7 @@ exports[`Storyshots Editions/Byline Review 1`] = `
     role="button"
   >
     <button
-      className="css-rdfey0-ShareIcon"
+      className="emotion-3"
       onClick={[Function]}
     >
       <svg
@@ -2931,17 +10040,78 @@ exports[`Storyshots Editions/Byline Review 1`] = `
 `;
 
 exports[`Storyshots Editions/Byline Showcase 1`] = `
+.emotion-0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+  padding-bottom: 1.5rem;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-1 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-2 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-3 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
-  className="css-58spt4"
+  className="emotion-0"
 >
   <address>
     <span
-      className="css-s6pm0t"
+      className="emotion-1"
     >
       Jane Smith
     </span>
     <span
-      className="css-1yh100x"
+      className="emotion-2"
     >
        Editor of things
     </span>
@@ -2951,7 +10121,7 @@ exports[`Storyshots Editions/Byline Showcase 1`] = `
     role="button"
   >
     <button
-      className="css-rdfey0-ShareIcon"
+      className="emotion-3"
       onClick={[Function]}
     >
       <svg
@@ -2974,9 +10144,108 @@ exports[`Storyshots Editions/Byline Showcase 1`] = `
 `;
 
 exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
+.emotion-0 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-1 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    background-color: #333333;
+  }
+}
+
+.emotion-2 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-2 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-2 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-2 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-2 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    width: 100%;
+  }
+}
+
+.emotion-3 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-3 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-3 path {
+  fill: #FFF4F2;
+}
+
 <figure
   aria-labelledby="header-image-caption"
-  className="css-dej5xk-HeaderMedia"
+  className="emotion-0"
 >
   <picture>
     <source
@@ -2990,18 +10259,18 @@ exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
     />
     <img
       alt=""
-      className="js-launch-slideshow js-main-image css-1ly9xbv-Img"
+      className="js-launch-slideshow js-main-image emotion-1"
       data-ratio={0.6}
       src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
     />
   </picture>
   <figcaption
-    className="css-nr1xa1-HeaderImageCaption"
+    className="emotion-2"
   >
     <details>
       <summary>
         <span
-          className="css-6okjyw"
+          className="emotion-3"
         >
           <svg
             viewBox="0 0 30 30"
@@ -3029,9 +10298,155 @@ exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
 `;
 
 exports[`Storyshots Editions/HeaderMedia Image 1`] = `
+.emotion-0 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 750px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.emotion-1 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    width: 740px;
+    height: calc(740px * 0.6);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    width: 980px;
+    height: calc(980px * 0.6);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    background-color: #333333;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    width: 720px;
+    height: 432px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-2 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-2 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-2 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-2 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-2 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    width: 720px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    width: 750px;
+  }
+}
+
+.emotion-3 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-3 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-3 path {
+  fill: #FFF4F2;
+}
+
 <figure
   aria-labelledby="header-image-caption"
-  className="css-12lxyki-HeaderMedia"
+  className="emotion-0"
 >
   <picture>
     <source
@@ -3045,18 +10460,18 @@ exports[`Storyshots Editions/HeaderMedia Image 1`] = `
     />
     <img
       alt=""
-      className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+      className="js-launch-slideshow js-main-image emotion-1"
       data-ratio={0.6}
       src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
     />
   </picture>
   <figcaption
-    className="css-169o3q0-HeaderImageCaption"
+    className="emotion-2"
   >
     <details>
       <summary>
         <span
-          className="css-6okjyw"
+          className="emotion-3"
         >
           <svg
             viewBox="0 0 30 30"
@@ -3084,12 +10499,26 @@ exports[`Storyshots Editions/HeaderMedia Image 1`] = `
 `;
 
 exports[`Storyshots Editions/HeaderMedia Video 1`] = `
+.emotion-0 {
+  width: 100%;
+  position: relative;
+  padding-bottom: 56.25%;
+}
+
+.emotion-1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
 <div
-  className="css-x1sm9l"
+  className="emotion-0"
 >
   <iframe
     allowFullScreen={true}
-    className="css-7y7f6n"
+    className="emotion-1"
     frameBorder="0"
     scrolling="no"
     src="https://embed.theguardian.com/embed/atom/media/26401ff7-24d0-4ba5-8882-2c32c2b379f0#noadsaf"
@@ -3099,9 +10528,191 @@ exports[`Storyshots Editions/HeaderMedia Video 1`] = `
 `;
 
 exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
+.emotion-0 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 750px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.emotion-1 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: calc(100vw * 0.6);
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    width: 740px;
+    height: calc(740px * 0.6);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    width: 980px;
+    height: calc(980px * 0.6);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    background-color: #333333;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    width: 720px;
+    height: 432px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-2 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-2 summary {
+  text-align: center;
+  background-color: #A1845C;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-2 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-2 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-2 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    width: 720px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    width: 750px;
+  }
+}
+
+.emotion-3 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-3 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-3 path {
+  fill: #FBF6EF;
+}
+
+.emotion-4 {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+}
+
+.emotion-5 {
+  background-color: #FFE500;
+  display: inline-block;
+}
+
+.emotion-5:nth-of-type(5) {
+  padding-right: 2px;
+}
+
+.emotion-5 svg {
+  margin: 0 -0.125rem;
+  height: 1.75rem;
+}
+
+.emotion-9 {
+  background-color: #FFE500;
+  display: inline-block;
+  fill: transparent;
+  stroke: #121212;
+}
+
+.emotion-9:nth-of-type(5) {
+  padding-right: 2px;
+}
+
+.emotion-9 svg {
+  margin: 0 -0.125rem;
+  height: 1.75rem;
+}
+
 <figure
   aria-labelledby="header-image-caption"
-  className="css-12lxyki-HeaderMedia"
+  className="emotion-0"
 >
   <picture>
     <source
@@ -3115,18 +10726,18 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
     />
     <img
       alt=""
-      className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+      className="js-launch-slideshow js-main-image emotion-1"
       data-ratio={0.6}
       src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
     />
   </picture>
   <figcaption
-    className="css-mx0oi0-HeaderImageCaption"
+    className="emotion-2"
   >
     <details>
       <summary>
         <span
-          className="css-pfziyb"
+          className="emotion-3"
         >
           <svg
             viewBox="0 0 30 30"
@@ -3151,10 +10762,10 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
     </details>
   </figcaption>
   <div
-    className="css-qw9jwe-StarRating"
+    className="emotion-4"
   >
     <span
-      className="css-kuz013"
+      className="emotion-5"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3168,7 +10779,7 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
       </svg>
     </span>
     <span
-      className="css-kuz013"
+      className="emotion-5"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3182,7 +10793,7 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
       </svg>
     </span>
     <span
-      className="css-kuz013"
+      className="emotion-5"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3196,7 +10807,7 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
       </svg>
     </span>
     <span
-      className="css-kuz013"
+      className="emotion-5"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3210,7 +10821,7 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
       </svg>
     </span>
     <span
-      className="css-w8n5c6-empty"
+      className="emotion-9"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3228,11 +10839,59 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
 `;
 
 exports[`Storyshots Editions/Headline Analysis 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-1 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 300;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-thickness: from-font;
+  text-decoration-thickness: from-font;
+  -webkit-text-decoration-color: #C70000;
+  text-decoration-color: #C70000;
+  padding-bottom: 0;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 300;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 300;
+  }
+}
+
 <div
-  className="css-165wy3b-Headline"
+  className="emotion-0"
 >
   <h1
-    className="css-1qz0qx9-Headline"
+    className="emotion-1"
   >
     Reclaimed lakes and giant airports: how Mexico City might have looked
   </h1>
@@ -3240,14 +10899,75 @@ exports[`Storyshots Editions/Headline Analysis 1`] = `
 `;
 
 exports[`Storyshots Editions/Headline Comment 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-1 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 300;
+  padding-bottom: 0;
+  padding-right: 6rem;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 300;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 300;
+  }
+}
+
+.emotion-2 {
+  margin: 0;
+}
+
+.emotion-2 svg {
+  margin-bottom: -0.65rem;
+  width: 40px;
+  margin-left: -0.3rem;
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-2 svg {
+    margin-bottom: -0.75rem;
+    width: 50px;
+  }
+}
+
 <div
-  className="css-165wy3b-Headline"
+  className="emotion-0"
 >
   <h1
-    className="css-k4j3s4-Headline"
+    className="emotion-1"
   >
     <span
-      className="css-1od8ezt"
+      className="emotion-2"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3266,11 +10986,52 @@ exports[`Storyshots Editions/Headline Comment 1`] = `
 `;
 
 exports[`Storyshots Editions/Headline Default 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-1 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
 <div
-  className="css-165wy3b-Headline"
+  className="emotion-0"
 >
   <h1
-    className="css-13o616v-Headline"
+    className="emotion-1"
   >
     Reclaimed lakes and giant airports: how Mexico City might have looked
   </h1>
@@ -3278,11 +11039,52 @@ exports[`Storyshots Editions/Headline Default 1`] = `
 `;
 
 exports[`Storyshots Editions/Headline Feature 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-1 {
+  color: #AB0613;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
 <div
-  className="css-165wy3b-Headline"
+  className="emotion-0"
 >
   <h1
-    className="css-1v4opfu-Headline"
+    className="emotion-1"
   >
     Reclaimed lakes and giant airports: how Mexico City might have looked
   </h1>
@@ -3290,17 +11092,114 @@ exports[`Storyshots Editions/Headline Feature 1`] = `
 `;
 
 exports[`Storyshots Editions/Headline Interview 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+
+.emotion-2 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 700;
+  margin-left: 0.75rem;
+  border: 0;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-2 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-2 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    width: 545px;
+  }
+}
+
+.emotion-3 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 500;
+  font-weight: 400;
+  background-color: #121212;
+  color: #FFFFFF;
+  white-space: pre-wrap;
+  padding-top: 0.0625rem;
+  padding-bottom: 0.25rem;
+  box-shadow: -0.75rem 0 0 #121212,0.75rem 0 0 #121212;
+  display: inline;
+}
+
+@media (min-width:375px) {
+  .emotion-3 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 500;
+    font-weight: 400;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 500;
+    font-weight: 400;
+  }
+}
+
 <div
-  className="css-165wy3b-Headline"
+  className="emotion-0"
 >
   <div
-    className="css-1duggjj-Headline"
+    className="emotion-1"
   />
   <h1
-    className="css-ghqarw-Headline"
+    className="emotion-2"
   >
     <span
-      className="css-1hvs9iy"
+      className="emotion-3"
     >
       Reclaimed lakes and giant airports: how Mexico City might have looked
     </span>
@@ -3309,11 +11208,51 @@ exports[`Storyshots Editions/Headline Interview 1`] = `
 `;
 
 exports[`Storyshots Editions/Headline Media 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-1 {
+  color: #FFFFFF;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GT Guardian Titlepiece,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  font-size: 2rem;
+  line-height: 1.2;
+  padding-bottom: 1.5rem;
+  background-color: #121212;
+  border: 0;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    width: 545px;
+  }
+}
+
 <div
-  className="css-165wy3b-Headline"
+  className="emotion-0"
 >
   <h1
-    className="css-1cwqm68-Headline"
+    className="emotion-1"
   >
     Reclaimed lakes and giant airports: how Mexico City might have looked
   </h1>
@@ -3321,11 +11260,52 @@ exports[`Storyshots Editions/Headline Media 1`] = `
 `;
 
 exports[`Storyshots Editions/Headline Review 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-1 {
+  color: #6B5840;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
 <div
-  className="css-165wy3b-Headline"
+  className="emotion-0"
 >
   <h1
-    className="css-1r46rn4-Headline"
+    className="emotion-1"
   >
     Reclaimed lakes and giant airports: how Mexico City might have looked
   </h1>
@@ -3333,11 +11313,52 @@ exports[`Storyshots Editions/Headline Review 1`] = `
 `;
 
 exports[`Storyshots Editions/Headline Showcase 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-1 {
+  color: #AB0613;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #DCDCDC;
+  }
+}
+
+@media (min-width:375px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
 <div
-  className="css-165wy3b-Headline"
+  className="emotion-0"
 >
   <h1
-    className="css-1kmuawa-Headline"
+    className="emotion-1"
   >
     Reclaimed lakes and giant airports: how Mexico City might have looked
   </h1>
@@ -3345,14 +11366,84 @@ exports[`Storyshots Editions/Headline Showcase 1`] = `
 `;
 
 exports[`Storyshots Editions/PullQuote Default 1`] = `
+.emotion-0 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #C70000;
+  border: 1px solid #C70000;
+  border-top: 0.75rem solid #C70000;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-0:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #C70000;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-0:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #C70000;
+}
+
+.emotion-1 {
+  margin: 0;
+}
+
+.emotion-2 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-2 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #C70000;
+}
+
+.emotion-3 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
 <aside
-  className="css-1f6ukfo-Pullquote"
+  className="emotion-0"
 >
   <blockquote
-    className="css-vhllol-Pullquote"
+    className="emotion-1"
   >
     <p
-      className="css-cgf9f8-Pullquote"
+      className="emotion-2"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3367,7 +11458,7 @@ exports[`Storyshots Editions/PullQuote Default 1`] = `
       The anti-slaughter movement is declining due to increased surveillance and repression that criminalises Tibetan identity
     </p>
     <cite
-      className="css-1znb75"
+      className="emotion-3"
     >
       Katia Buffetrille, anthropologist
     </cite>
@@ -3376,35 +11467,136 @@ exports[`Storyshots Editions/PullQuote Default 1`] = `
 `;
 
 exports[`Storyshots Editions/Series Default 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  font-family: GT Guardian Titlepiece,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #C70000;
+  font-size: 1.0625rem;
+  padding: 0.25rem 0 0.5rem;
+  box-sizing: border-box;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 0.75rem;
+  }
+}
+
 <nav
-  className="css-zzo0sh"
+  className="emotion-0"
 >
   Running
 </nav>
 `;
 
 exports[`Storyshots Editions/Series Immersive 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  font-family: GT Guardian Titlepiece,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #C70000;
+  font-size: 1.0625rem;
+  padding: 0.25rem 0 0.5rem;
+  box-sizing: border-box;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  border: 0;
+  color: #FFFFFF;
+  background-color: #C70000;
+  padding: 0.5rem 0.75rem;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 0.75rem;
+  }
+}
+
 <nav
-  className="css-103n3es"
+  className="emotion-0"
 >
   The long read
 </nav>
 `;
 
 exports[`Storyshots Editions/Series Interview 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  font-family: GT Guardian Titlepiece,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #A1845C;
+  font-size: 1.0625rem;
+  padding: 0.25rem 0 0.5rem;
+  box-sizing: border-box;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  border: 0;
+  color: #FFFFFF;
+  background-color: #A1845C;
+  padding: 0.5rem 0.75rem;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    padding-bottom: 0.75rem;
+  }
+}
+
 <nav
-  className="css-dtesww"
+  className="emotion-0"
 >
   Interview
 </nav>
 `;
 
 exports[`Storyshots Editions/ShareIcon Default 1`] = `
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
+.emotion-1 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
-  className="css-1wlqhgk-Default"
+  className="emotion-0"
 >
   <button
-    className="css-rdfey0-ShareIcon"
+    className="emotion-1"
     onClick={[Function]}
   >
     <svg
@@ -3426,8 +11618,70 @@ exports[`Storyshots Editions/ShareIcon Default 1`] = `
 `;
 
 exports[`Storyshots Editions/Standfirst Analysis 1`] = `
+.emotion-0 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #767676;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 545px;
+  }
+}
+
+.emotion-0 p,
+.emotion-0 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-0 address {
+  font-style: normal;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
 <div
-  className="css-a9bgr4"
+  className="emotion-0"
 >
   <p>
     The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -3436,8 +11690,70 @@ exports[`Storyshots Editions/Standfirst Analysis 1`] = `
 `;
 
 exports[`Storyshots Editions/Standfirst Comment 1`] = `
+.emotion-0 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #767676;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 545px;
+  }
+}
+
+.emotion-0 p,
+.emotion-0 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-0 address {
+  font-style: normal;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
 <div
-  className="css-a9bgr4"
+  className="emotion-0"
 >
   <p>
     The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -3446,8 +11762,65 @@ exports[`Storyshots Editions/Standfirst Comment 1`] = `
 `;
 
 exports[`Storyshots Editions/Standfirst Default 1`] = `
+.emotion-0 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 545px;
+  }
+}
+
+.emotion-0 p,
+.emotion-0 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-0 address {
+  font-style: normal;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
 <div
-  className="css-h42k03"
+  className="emotion-0"
 >
   <p>
     The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -3456,6 +11829,67 @@ exports[`Storyshots Editions/Standfirst Default 1`] = `
 `;
 
 exports[`Storyshots Editions/Standfirst Media 1`] = `
+.emotion-0 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  color: #FFFFFF;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 545px;
+  }
+}
+
+.emotion-0 p,
+.emotion-0 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-0 address {
+  font-style: normal;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
 <div
   style={
     Object {
@@ -3464,7 +11898,7 @@ exports[`Storyshots Editions/Standfirst Media 1`] = `
   }
 >
   <div
-    className="css-mwiu58"
+    className="emotion-0"
   >
     <p>
       The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -3474,8 +11908,70 @@ exports[`Storyshots Editions/Standfirst Media 1`] = `
 `;
 
 exports[`Storyshots Editions/Standfirst Showcase 1`] = `
+.emotion-0 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 500;
+  color: #333333;
+}
+
+@media (min-width:740px) {
+  .emotion-0 {
+    width: 526px;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 545px;
+  }
+}
+
+.emotion-0 p,
+.emotion-0 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-0 address {
+  font-style: normal;
+}
+
+.emotion-0 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-0 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-0 svg path {
+  fill: #C70000;
+}
+
 <div
-  className="css-1mgym3w"
+  className="emotion-0"
 >
   <p>
     The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -3484,8 +11980,27 @@ exports[`Storyshots Editions/Standfirst Showcase 1`] = `
 `;
 
 exports[`Storyshots Follow Default 1`] = `
+.emotion-0 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #C70000;
+  display: block;
+  padding: 0;
+  border: none;
+  background: none;
+  margin-left: 0;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #FF5943;
+  }
+}
+
 <button
-  className="js-follow css-ylaspq-Follow"
+  className="js-follow emotion-0"
   data-display-name="Jane Smith"
   data-id="profile/janesmith"
 >
@@ -3499,15 +12014,56 @@ exports[`Storyshots Follow Default 1`] = `
 `;
 
 exports[`Storyshots Footer Default 1`] = `
+.emotion-0 {
+  border-width: 0 1px;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.35;
+  font-weight: 400;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  padding-top: 1rem;
+  padding-bottom: 1.5rem;
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 1300px;
+    margin: 0 auto;
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #999999;
+  }
+}
+
+.emotion-1 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.35;
+  font-weight: 400;
+  color: #121212;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #999999;
+  }
+}
+
 <div
-  className="css-1tni85m-FooterCcpa"
+  className="emotion-0"
 >
   © 
   2021
    Guardian News and Media Limited or its affiliated companies. All rights reserved.
   <br />
   <a
-    className="css-j4jbe3-FooterCcpa"
+    className="emotion-1"
     href="https://www.theguardian.com/help/privacy-policy"
   >
     Privacy Policy
@@ -3516,22 +12072,79 @@ exports[`Storyshots Footer Default 1`] = `
 `;
 
 exports[`Storyshots Footer With Ccpa 1`] = `
+.emotion-0 {
+  border-width: 0 1px;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.35;
+  font-weight: 400;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  padding-top: 1rem;
+  padding-bottom: 1.5rem;
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    width: 1300px;
+    margin: 0 auto;
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #999999;
+  }
+}
+
+.emotion-1 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.35;
+  font-weight: 400;
+  color: #121212;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    color: #999999;
+  }
+}
+
+.emotion-2 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.35;
+  font-weight: 400;
+  color: #121212;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-2 {
+    color: #999999;
+  }
+}
+
 <div
-  className="css-1tni85m-FooterCcpa"
+  className="emotion-0"
 >
   © 
   2021
    Guardian News and Media Limited or its affiliated companies. All rights reserved.
   <br />
   <a
-    className="css-1telkou"
+    className="emotion-1"
     href="https://www.theguardian.com/help/privacy-policy"
   >
     California Residents - Do Not Sell
   </a>
    · 
   <a
-    className="css-j4jbe3-FooterCcpa"
+    className="emotion-2"
     href="https://www.theguardian.com/help/privacy-policy"
   >
     Privacy Policy
@@ -3540,8 +12153,68 @@ exports[`Storyshots Footer With Ccpa 1`] = `
 `;
 
 exports[`Storyshots Headline Analysis 1`] = `
+.emotion-0 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.125rem;
+  line-height: 1.15;
+  font-weight: 500;
+  color: #121212;
+  background-color: #FFFFFF;
+  padding-bottom: 2.25rem;
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.125rem;
+  line-height: 1.35;
+  font-weight: 300;
+  font-size: 34px;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #DCDCDC;
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background-color: #1A1A1A;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-0 {
+    width: 620px;
+  }
+}
+
+.emotion-0 span {
+  box-shadow: inset 0 -0.025rem #C70000;
+  padding-bottom: 0.2rem;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 span {
+    box-shadow: inset 0 -0.025rem #767676;
+  }
+}
+
 <h1
-  className="css-5hyg8b-Headline"
+  className="emotion-0"
 >
   <span>
     Reclaimed lakes and giant airports: how Mexico City might have looked
@@ -3550,8 +12223,53 @@ exports[`Storyshots Headline Analysis 1`] = `
 `;
 
 exports[`Storyshots Headline Default 1`] = `
+.emotion-0 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.125rem;
+  line-height: 1.15;
+  font-weight: 500;
+  color: #121212;
+  background-color: #FFFFFF;
+  padding-bottom: 2.25rem;
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  font-size: 34px;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #DCDCDC;
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background-color: #1A1A1A;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-0 {
+    width: 620px;
+  }
+}
+
 <h1
-  className="css-swyj2a-Headline"
+  className="emotion-0"
 >
   <span>
     Reclaimed lakes and giant airports: how Mexico City might have looked
@@ -3560,8 +12278,57 @@ exports[`Storyshots Headline Default 1`] = `
 `;
 
 exports[`Storyshots Headline Feature 1`] = `
+.emotion-0 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.125rem;
+  line-height: 1.15;
+  font-weight: 500;
+  color: #AB0613;
+  background-color: #FFFFFF;
+  padding-bottom: 2.25rem;
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.125rem;
+  line-height: 1.15;
+  font-weight: 700;
+  font-size: 34px;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #DCDCDC;
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background-color: #1A1A1A;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-0 {
+    width: 620px;
+  }
+}
+
 <h1
-  className="css-1wsu5kv-Headline"
+  className="emotion-0"
 >
   <span>
     Reclaimed lakes and giant airports: how Mexico City might have looked
@@ -3570,8 +12337,57 @@ exports[`Storyshots Headline Feature 1`] = `
 `;
 
 exports[`Storyshots Headline Labs 1`] = `
+.emotion-0 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.125rem;
+  line-height: 1.15;
+  font-weight: 500;
+  color: #121212;
+  background-color: #FFFFFF;
+  padding-bottom: 2.25rem;
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 2.125rem;
+  line-height: 1.35;
+  font-weight: 400;
+  font-size: 34px;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #DCDCDC;
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background-color: #1A1A1A;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-0 {
+    width: 620px;
+  }
+}
+
 <h1
-  className="css-10s8ewe-Headline"
+  className="emotion-0"
 >
   <span>
     Reclaimed lakes and giant airports: how Mexico City might have looked
@@ -3580,15 +12396,104 @@ exports[`Storyshots Headline Labs 1`] = `
 `;
 
 exports[`Storyshots Headline Review 1`] = `
+.emotion-0 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.125rem;
+  line-height: 1.15;
+  font-weight: 500;
+  color: #AB0613;
+  background-color: #FFFFFF;
+  padding-bottom: 2.25rem;
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  font-size: 34px;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    color: #DCDCDC;
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background-color: #1A1A1A;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:660px) {
+  .emotion-0 {
+    width: 620px;
+  }
+}
+
+.emotion-1 {
+  background-color: #FFE500;
+  display: inline-block;
+  line-height: 0;
+}
+
+.emotion-1:nth-of-type(5) {
+  padding-right: 2px;
+}
+
+.emotion-1 svg {
+  margin: 0 -0.125rem;
+  height: 1.75rem;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    background-color: #F3C100;
+  }
+}
+
+.emotion-4 {
+  background-color: #FFE500;
+  display: inline-block;
+  line-height: 0;
+  fill: transparent;
+  stroke: #121212;
+}
+
+.emotion-4:nth-of-type(5) {
+  padding-right: 2px;
+}
+
+.emotion-4 svg {
+  margin: 0 -0.125rem;
+  height: 1.75rem;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-4 {
+    background-color: #F3C100;
+  }
+}
+
 <h1
-  className="css-p4webw-Headline"
+  className="emotion-0"
 >
   <span>
     Reclaimed lakes and giant airports: how Mexico City might have looked
   </span>
   <div>
     <span
-      className="css-ihxckh"
+      className="emotion-1"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3602,7 +12507,7 @@ exports[`Storyshots Headline Review 1`] = `
       </svg>
     </span>
     <span
-      className="css-ihxckh"
+      className="emotion-1"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3616,7 +12521,7 @@ exports[`Storyshots Headline Review 1`] = `
       </svg>
     </span>
     <span
-      className="css-ihxckh"
+      className="emotion-1"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3630,7 +12535,7 @@ exports[`Storyshots Headline Review 1`] = `
       </svg>
     </span>
     <span
-      className="css-hfq1j9-empty"
+      className="emotion-4"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3644,7 +12549,7 @@ exports[`Storyshots Headline Review 1`] = `
       </svg>
     </span>
     <span
-      className="css-hfq1j9-empty"
+      className="emotion-4"
     >
       <svg
         viewBox="0 0 30 30"
@@ -3662,33 +12567,327 @@ exports[`Storyshots Headline Review 1`] = `
 `;
 
 exports[`Storyshots HorizontalRule Default 1`] = `
+.emotion-0 {
+  display: block;
+  width: 8.75rem;
+  height: 0.125rem;
+  margin: 3rem 0 0.25rem;
+  border: 0;
+  background-color: #EDEDED;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background-color: #333333;
+  }
+}
+
 <hr
-  className="css-lmf0pc-HorizontalRule"
+  className="emotion-0"
 />
 `;
 
 exports[`Storyshots Paragraph Default 1`] = `
+.emotion-0 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
 <p
-  className="css-ril8fi-Paragraph"
+  className="emotion-0"
 >
   Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have dreamed of water: containing it, draining it and now retaining it.
 </p>
 `;
 
 exports[`Storyshots Paragraph Labs 1`] = `
+.emotion-0 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 <p
-  className="css-ludswr-Paragraph"
+  className="emotion-0"
 >
   Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have dreamed of water: containing it, draining it and now retaining it.
 </p>
 `;
 
 exports[`Storyshots Rich Link Default 1`] = `
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin-left: calc(8.75rem + 1rem + 1.5rem);
+  }
+}
+
+.emotion-1 {
+  background: #F6F6F6;
+  padding: 0.5rem;
+  border-top: solid 1px #999999;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+  float: left;
+  clear: left;
+  margin: 0.5rem 1rem 0.5rem 0;
+  width: 8.75rem;
+}
+
+.emotion-1.js-news {
+  border-top: solid 1px #C70000;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-news {
+    border-top: solid 1px #999999;
+  }
+}
+
+.emotion-1.js-news svg {
+  fill: white;
+  background: #C70000;
+  border-color: #C70000;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-news svg {
+    border-color: #999999;
+    background: #333333;
+    fill: #999999;
+  }
+}
+
+.emotion-1.js-news button {
+  color: #C70000;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-news button {
+    color: #999999;
+  }
+}
+
+.emotion-1.js-opinion {
+  border-top: solid 1px #E05E00;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-opinion {
+    border-top: solid 1px #999999;
+  }
+}
+
+.emotion-1.js-opinion svg {
+  fill: white;
+  background: #E05E00;
+  border-color: #E05E00;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-opinion svg {
+    border-color: #999999;
+    background: #333333;
+    fill: #999999;
+  }
+}
+
+.emotion-1.js-opinion button {
+  color: #E05E00;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-opinion button {
+    color: #999999;
+  }
+}
+
+.emotion-1.js-sport {
+  border-top: solid 1px #0084C6;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-sport {
+    border-top: solid 1px #999999;
+  }
+}
+
+.emotion-1.js-sport svg {
+  fill: white;
+  background: #0084C6;
+  border-color: #0084C6;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-sport svg {
+    border-color: #999999;
+    background: #333333;
+    fill: #999999;
+  }
+}
+
+.emotion-1.js-sport button {
+  color: #0084C6;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-sport button {
+    color: #999999;
+  }
+}
+
+.emotion-1.js-culture {
+  border-top: solid 1px #A1845C;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-culture {
+    border-top: solid 1px #999999;
+  }
+}
+
+.emotion-1.js-culture svg {
+  fill: white;
+  background: #A1845C;
+  border-color: #A1845C;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-culture svg {
+    border-color: #999999;
+    background: #333333;
+    fill: #999999;
+  }
+}
+
+.emotion-1.js-culture button {
+  color: #A1845C;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-culture button {
+    color: #999999;
+  }
+}
+
+.emotion-1.js-lifestyle {
+  border-top: solid 1px #BB3B80;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-lifestyle {
+    border-top: solid 1px #999999;
+  }
+}
+
+.emotion-1.js-lifestyle svg {
+  fill: white;
+  background: #BB3B80;
+  border-color: #BB3B80;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-lifestyle svg {
+    border-color: #999999;
+    background: #333333;
+    fill: #999999;
+  }
+}
+
+.emotion-1.js-lifestyle button {
+  color: #BB3B80;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1.js-lifestyle button {
+    color: #999999;
+  }
+}
+
+.emotion-1 .js-image img {
+  width: calc(100% + 1rem);
+  margin: -0.5rem 0 0 -0.5rem;
+}
+
+.emotion-1 button {
+  background: none;
+  border: none;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  padding: 0;
+  margin: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+}
+
+.emotion-1 svg {
+  width: 1.0625rem;
+  border-radius: 100%;
+  border: solid 1px #121212;
+  padding: 4px;
+  display: inline-block;
+  margin-right: 0.5rem;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+}
+
+.emotion-1 a {
+  display: inline-block;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #121212;
+}
+
+.emotion-1 a h1 {
+  margin: 0 0 1rem 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    margin-left: calc( -8.75rem - 1rem - 1.5rem );
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-1 {
+    background-color: #333333;
+  }
+
+  .emotion-1 a,
+  .emotion-1 h1 {
+    color: #999999;
+  }
+}
+
 <section
-  className="css-ke3kvz-Default"
+  className="emotion-0"
 >
   <aside
-    className="js-rich-link css-1xpjeoh-RichLink"
+    className="js-rich-link emotion-1"
   >
     <a
       href="https://theguardian.com"
@@ -3718,8 +12917,52 @@ exports[`Storyshots Rich Link Default 1`] = `
 `;
 
 exports[`Storyshots Shared Tags 1`] = `
+.emotion-0 {
+  margin-top: 0;
+  margin-bottom: 0;
+  display: block;
+  list-style: none;
+  padding: 0.5rem 0 1rem 0;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-0 li {
+  margin: 0.5rem 0.5rem 0 0;
+  display: inline-block;
+}
+
+.emotion-0 li a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 6px 16px;
+  border-radius: 30px;
+  text-overflow: ellipsis;
+  max-width: 18.75rem;
+  color: #121212;
+  background-color: #F6F6F6;
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background: #1A1A1A;
+    color: #DCDCDC;
+  }
+
+  .emotion-0 li a {
+    color: #999999;
+    background-color: #333333;
+  }
+}
+
 <ul
-  className="css-y50d1d-Tags"
+  className="emotion-0"
 >
   <li>
     <a
@@ -3746,8 +12989,38 @@ exports[`Storyshots Shared Tags 1`] = `
 `;
 
 exports[`Storyshots Standfirst Comment 1`] = `
+.emotion-0 {
+  margin-bottom: 0.5rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 300;
+}
+
+.emotion-0 p,
+.emotion-0 ul {
+  margin: 0.5rem 0;
+}
+
+.emotion-0 address {
+  font-style: normal;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background: #1A1A1A;
+    color: #999999;
+  }
+
+  .emotion-0 a {
+    color: #999999;
+    border-bottom: 0.0625rem solid #767676;
+  }
+}
+
 <div
-  className="css-qiidkb"
+  className="emotion-0"
 >
   <p>
     The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -3756,8 +13029,39 @@ exports[`Storyshots Standfirst Comment 1`] = `
 `;
 
 exports[`Storyshots Standfirst Default 1`] = `
+.emotion-0 {
+  margin-bottom: 0.5rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  padding: 0;
+}
+
+.emotion-0 p,
+.emotion-0 ul {
+  margin: 0.5rem 0;
+}
+
+.emotion-0 address {
+  font-style: normal;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background: #1A1A1A;
+    color: #999999;
+  }
+
+  .emotion-0 a {
+    color: #999999;
+    border-bottom: 0.0625rem solid #767676;
+  }
+}
+
 <div
-  className="css-bb3wik"
+  className="emotion-0"
 >
   <p>
     The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -3766,8 +13070,38 @@ exports[`Storyshots Standfirst Default 1`] = `
 `;
 
 exports[`Storyshots Standfirst Feature 1`] = `
+.emotion-0 {
+  margin-bottom: 0.5rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 300;
+}
+
+.emotion-0 p,
+.emotion-0 ul {
+  margin: 0.5rem 0;
+}
+
+.emotion-0 address {
+  font-style: normal;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background: #1A1A1A;
+    color: #999999;
+  }
+
+  .emotion-0 a {
+    color: #999999;
+    border-bottom: 0.0625rem solid #767676;
+  }
+}
+
 <div
-  className="css-qiidkb"
+  className="emotion-0"
 >
   <p>
     The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -3776,8 +13110,38 @@ exports[`Storyshots Standfirst Feature 1`] = `
 `;
 
 exports[`Storyshots Standfirst Review 1`] = `
+.emotion-0 {
+  margin-bottom: 0.5rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 300;
+}
+
+.emotion-0 p,
+.emotion-0 ul {
+  margin: 0.5rem 0;
+}
+
+.emotion-0 address {
+  font-style: normal;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background: #1A1A1A;
+    color: #999999;
+  }
+
+  .emotion-0 a {
+    color: #999999;
+    border-bottom: 0.0625rem solid #767676;
+  }
+}
+
 <div
-  className="css-qiidkb"
+  className="emotion-0"
 >
   <p>
     The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -3786,9 +13150,53 @@ exports[`Storyshots Standfirst Review 1`] = `
 `;
 
 exports[`Storyshots Star Rating Default 1`] = `
+.emotion-0 {
+  background-color: #FFE500;
+  display: inline-block;
+  line-height: 0;
+}
+
+.emotion-0:nth-of-type(5) {
+  padding-right: 2px;
+}
+
+.emotion-0 svg {
+  margin: 0 -0.125rem;
+  height: 1.75rem;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-0 {
+    background-color: #F3C100;
+  }
+}
+
+.emotion-3 {
+  background-color: #FFE500;
+  display: inline-block;
+  line-height: 0;
+  fill: transparent;
+  stroke: #121212;
+}
+
+.emotion-3:nth-of-type(5) {
+  padding-right: 2px;
+}
+
+.emotion-3 svg {
+  margin: 0 -0.125rem;
+  height: 1.75rem;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-3 {
+    background-color: #F3C100;
+  }
+}
+
 <div>
   <span
-    className="css-ihxckh"
+    className="emotion-0"
   >
     <svg
       viewBox="0 0 30 30"
@@ -3802,7 +13210,7 @@ exports[`Storyshots Star Rating Default 1`] = `
     </svg>
   </span>
   <span
-    className="css-ihxckh"
+    className="emotion-0"
   >
     <svg
       viewBox="0 0 30 30"
@@ -3816,7 +13224,7 @@ exports[`Storyshots Star Rating Default 1`] = `
     </svg>
   </span>
   <span
-    className="css-ihxckh"
+    className="emotion-0"
   >
     <svg
       viewBox="0 0 30 30"
@@ -3830,7 +13238,7 @@ exports[`Storyshots Star Rating Default 1`] = `
     </svg>
   </span>
   <span
-    className="css-hfq1j9-empty"
+    className="emotion-3"
   >
     <svg
       viewBox="0 0 30 30"
@@ -3844,7 +13252,7 @@ exports[`Storyshots Star Rating Default 1`] = `
     </svg>
   </span>
   <span
-    className="css-hfq1j9-empty"
+    className="emotion-3"
   >
     <svg
       viewBox="0 0 30 30"

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -1,0 +1,3863 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Anchor Default 1`] = `
+<a
+  className="css-5uwmeq-Anchor"
+  href="https://theguardian.com"
+>
+  “everything that was recommended was done”.
+</a>
+`;
+
+exports[`Storyshots Bullet Default 1`] = `
+<p
+  className="css-3s648a-Bullet"
+>
+  <span
+    className="css-2g8li-Bullet"
+  >
+    •
+  </span>
+   Lorem ipsum
+</p>
+`;
+
+exports[`Storyshots Byline Comment 1`] = `
+<address
+  className="css-1r4n4os"
+>
+  <a
+    className="css-17bjzi4"
+    href="https://theguardian.com"
+  >
+    Jane Smith
+  </a>
+   Editor of things
+</address>
+`;
+
+exports[`Storyshots Byline Default 1`] = `
+<address
+  className="css-1ry8e32"
+>
+  <a
+    className="css-xw3z4n"
+    href="https://theguardian.com"
+  >
+    Jane Smith
+  </a>
+   Editor of things
+</address>
+`;
+
+exports[`Storyshots Byline Labs 1`] = `
+<address
+  className="css-17wdvyp"
+>
+  <a
+    className="css-eav8uk"
+    href="https://theguardian.com"
+  >
+    Jane Smith
+  </a>
+   Editor of things
+</address>
+`;
+
+exports[`Storyshots CommentCount Default 1`] = `
+<button
+  className="css-19mgwvn"
+>
+  <svg
+    className="css-9iqumf"
+    viewBox="0 0 9 8"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect
+      height="6"
+      rx="1.2"
+      width="9"
+      x="0"
+      y="0"
+    />
+    <polygon
+      points="2,6 2,8 2.5,8 4,6"
+    />
+  </svg>
+  1,234
+</button>
+`;
+
+exports[`Storyshots Dateline Default 1`] = `
+<time
+  className="date js-date css-l03xpa"
+  data-date={2019-12-17T03:24:00.000Z}
+>
+  Tue 17 Dec 2019 03.24 UTC
+</time>
+`;
+
+exports[`Storyshots Editions/Article Analysis 1`] = `
+<main
+  className="css-2qsm3-Article"
+>
+  <article
+    className="css-2ammhe-Article"
+  >
+    <div
+      className="css-cezksd-Article"
+    >
+      <section
+        className="css-wzgevt-Article"
+      >
+        <header
+          className="css-3qmmbh-AnalysisHeader"
+        >
+          <figure
+            aria-labelledby="header-image-caption"
+            className="css-12lxyki-HeaderMedia"
+          >
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt=""
+                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="css-afvmvk-HeaderImageCaption"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="css-1bvtd5i"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+          </figure>
+          <div
+            className="css-165wy3b-Headline"
+          >
+            <h1
+              className="css-acwztd-Headline"
+            >
+              Reclaimed lakes and giant airports: how Mexico City might have looked
+            </h1>
+          </div>
+          <div
+            className="css-s7agzf"
+          >
+            <address>
+              <span
+                className="css-11gwkgb"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="css-15jtyuf"
+              >
+                 Editor of things
+              </span>
+            </address>
+          </div>
+          <div
+            className="css-7m2n2v-EditionsLines"
+          >
+            <div
+              className="css-1xgmaw8-straightLines-fourLines-Lines"
+            />
+          </div>
+          <div
+            className="css-1fihjfe"
+          >
+            <p>
+              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+            </p>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="css-rdfey0-ShareIcon"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="css-yn5fb1-Article"
+    >
+      <section
+        className="css-1rrc8kn-Article"
+      >
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <figure
+          className="css-huy3rj-BodyImage"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow css-1we7mgb-Img"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <div
+          className="css-cq3eyp-containerStyling"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="css-l8n9ox-detailStyling"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="css-dp9r84-atomTitleStyling"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="css-gpo7xk-titleStyling"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="css-1rv27d3-showHideStyling"
+              >
+                <span
+                  className="css-117w3ky-iconSpacing"
+                >
+                  <span
+                    className="css-kd64v9-plusStyling"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="css-1vg8ran-bodyStyling"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="css-dc74hn-footerStyling"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="css-fgqqde-className"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="css-1hq58dr-buttonStyling"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="css-soya5m-buttonStyling-className"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="css-5a9sl9-className"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <aside
+          className="css-c1l0e9-Pullquote"
+        >
+          <blockquote
+            className="css-vhllol-Pullquote"
+          >
+            <p
+              className="css-a5coej-Pullquote"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="css-1znb75"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Article Comment 1`] = `
+<main
+  className="css-2qsm3-Article"
+>
+  <article
+    className="css-2ammhe-Article"
+  >
+    <div
+      className="css-v93u6i-Article"
+    >
+      <section
+        className="css-wzgevt-Article"
+      >
+        <header
+          className="css-1d01hcu-CommentHeader"
+        >
+          <figure
+            aria-labelledby="header-image-caption"
+            className="css-12lxyki-HeaderMedia"
+          >
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt=""
+                className="js-launch-slideshow js-main-image css-xqx25p-Img"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="css-169o3q0-HeaderImageCaption"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="css-6okjyw"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+          </figure>
+          <div
+            className="css-165wy3b-Headline"
+          >
+            <h1
+              className="css-k4j3s4-Headline"
+            >
+              <span
+                className="css-1od8ezt"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+                Reclaimed lakes and giant airports: how Mexico City might have looked
+              </span>
+            </h1>
+          </div>
+          <div
+            className="css-1xck3cj"
+          >
+            <address>
+              <span
+                className="css-1tnqwjd"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="css-15jtyuf"
+              >
+                 Editor of things
+              </span>
+            </address>
+            <div
+              className="css-17kiv7u"
+            >
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="105px"
+                  srcSet="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=32&quality=85&fit=bounds&s=100fc280274e40946afb34d4b561ce9f 32w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e 64w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=128&quality=85&fit=bounds&s=35b6ce614cae19fbdcdefa55a670eda5 128w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=192&quality=85&fit=bounds&s=930a05d87b62a1f613ff76f3ee0c97a0 192w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=256&quality=85&fit=bounds&s=8c44b90de342114bd3bf6145767d4b31 256w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=400&quality=85&fit=bounds&s=8491504dfb944eee7ef173e739cb4f74 400w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=600&quality=85&fit=bounds&s=668fc2d7278f6c4a553f806c9b2d47d3 600w"
+                />
+                <source
+                  sizes="105px"
+                  srcSet="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=32&quality=85&fit=bounds&s=100fc280274e40946afb34d4b561ce9f 32w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e 64w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=128&quality=85&fit=bounds&s=35b6ce614cae19fbdcdefa55a670eda5 128w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=192&quality=85&fit=bounds&s=930a05d87b62a1f613ff76f3ee0c97a0 192w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=256&quality=85&fit=bounds&s=8c44b90de342114bd3bf6145767d4b31 256w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=400&quality=85&fit=bounds&s=8491504dfb944eee7ef173e739cb4f74 400w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=600&quality=85&fit=bounds&s=668fc2d7278f6c4a553f806c9b2d47d3 600w"
+                />
+                <img
+                  alt="image"
+                  className="css-1w5z5b1-Img"
+                  data-ratio={1}
+                  src="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e"
+                />
+              </picture>
+            </div>
+          </div>
+          <div
+            className="css-7m2n2v-EditionsLines"
+          >
+            <div
+              className="css-1xgmaw8-straightLines-fourLines-Lines"
+            />
+          </div>
+          <div
+            className="css-a9bgr4"
+          >
+            <p>
+              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+            </p>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="css-rdfey0-ShareIcon"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="css-yn5fb1-Article"
+    >
+      <section
+        className="css-1rrc8kn-Article"
+      >
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <figure
+          className="css-huy3rj-BodyImage"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow css-198316x-Img"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <div
+          className="css-cq3eyp-containerStyling"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="css-l8n9ox-detailStyling"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="css-3w82vu-atomTitleStyling"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="css-gpo7xk-titleStyling"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="css-1p3af4l-showHideStyling"
+              >
+                <span
+                  className="css-117w3ky-iconSpacing"
+                >
+                  <span
+                    className="css-kd64v9-plusStyling"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="css-5oaelj-bodyStyling"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="css-dc74hn-footerStyling"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="css-fgqqde-className"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="css-con9lg-buttonStyling"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="css-av88v2-buttonStyling-className"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="css-5a9sl9-className"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <aside
+          className="css-1f6ukfo-Pullquote"
+        >
+          <blockquote
+            className="css-vhllol-Pullquote"
+          >
+            <p
+              className="css-cgf9f8-Pullquote"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="css-1znb75"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Article Default 1`] = `
+<main
+  className="css-2qsm3-Article"
+>
+  <article
+    className="css-2ammhe-Article"
+  >
+    <div
+      className="css-16sk62p-Article"
+    >
+      <section
+        className="css-wzgevt-Article"
+      >
+        <header
+          className="css-10xsu7p-StandardHeader"
+        >
+          <figure
+            aria-labelledby="header-image-caption"
+            className="css-12lxyki-HeaderMedia"
+          >
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt=""
+                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="css-169o3q0-HeaderImageCaption"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="css-6okjyw"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+          </figure>
+          <div
+            className="css-165wy3b-Headline"
+          >
+            <h1
+              className="css-13o616v-Headline"
+            >
+              Reclaimed lakes and giant airports: how Mexico City might have looked
+            </h1>
+          </div>
+          <div
+            className="css-h42k03"
+          >
+            <p>
+              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+            </p>
+          </div>
+          <div
+            className="css-7m2n2v-EditionsLines"
+          >
+            <div
+              className="css-1xgmaw8-straightLines-fourLines-Lines"
+            />
+          </div>
+          <div
+            className="css-teh8lu"
+          >
+            <address>
+              <span
+                className="css-s6pm0t"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="css-1yh100x"
+              >
+                 Editor of things
+              </span>
+            </address>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="css-rdfey0-ShareIcon"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="css-yn5fb1-Article"
+    >
+      <section
+        className="css-1rrc8kn-Article"
+      >
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <figure
+          className="css-huy3rj-BodyImage"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow css-1we7mgb-Img"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <div
+          className="css-cq3eyp-containerStyling"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="css-l8n9ox-detailStyling"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="css-3w82vu-atomTitleStyling"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="css-gpo7xk-titleStyling"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="css-1p3af4l-showHideStyling"
+              >
+                <span
+                  className="css-117w3ky-iconSpacing"
+                >
+                  <span
+                    className="css-kd64v9-plusStyling"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="css-5oaelj-bodyStyling"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="css-dc74hn-footerStyling"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="css-fgqqde-className"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="css-con9lg-buttonStyling"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="css-av88v2-buttonStyling-className"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="css-5a9sl9-className"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <aside
+          className="css-1f6ukfo-Pullquote"
+        >
+          <blockquote
+            className="css-vhllol-Pullquote"
+          >
+            <p
+              className="css-cgf9f8-Pullquote"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="css-1znb75"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Article Feature 1`] = `
+<main
+  className="css-2qsm3-Article"
+>
+  <article
+    className="css-2ammhe-Article"
+  >
+    <div
+      className="css-16sk62p-Article"
+    >
+      <section
+        className="css-wzgevt-Article"
+      >
+        <header
+          className="css-10xsu7p-StandardHeader"
+        >
+          <figure
+            aria-labelledby="header-image-caption"
+            className="css-12lxyki-HeaderMedia"
+          >
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt=""
+                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="css-1tza6s1-HeaderImageCaption"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="css-1vqrqak"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+          </figure>
+          <div
+            className="css-165wy3b-Headline"
+          >
+            <h1
+              className="css-3zxxdv-Headline"
+            >
+              Reclaimed lakes and giant airports: how Mexico City might have looked
+            </h1>
+          </div>
+          <div
+            className="css-1rir6qk"
+          >
+            <p>
+              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+            </p>
+          </div>
+          <div
+            className="css-7m2n2v-EditionsLines"
+          >
+            <div
+              className="css-1xgmaw8-straightLines-fourLines-Lines"
+            />
+          </div>
+          <div
+            className="css-t8cjud"
+          >
+            <address>
+              <span
+                className="css-1410z7r"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="css-1yh100x"
+              >
+                 Editor of things
+              </span>
+            </address>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="css-rdfey0-ShareIcon"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="css-yn5fb1-Article"
+    >
+      <section
+        className="css-1rrc8kn-Article"
+      >
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <figure
+          className="css-huy3rj-BodyImage"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow css-1we7mgb-Img"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <div
+          className="css-cq3eyp-containerStyling"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="css-l8n9ox-detailStyling"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="css-lzpv1d-atomTitleStyling"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="css-gpo7xk-titleStyling"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="css-1s5nci7-showHideStyling"
+              >
+                <span
+                  className="css-117w3ky-iconSpacing"
+                >
+                  <span
+                    className="css-kd64v9-plusStyling"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="css-dv25nz-bodyStyling"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="css-dc74hn-footerStyling"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="css-fgqqde-className"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="css-27e8o5-buttonStyling"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="css-dl0cko-buttonStyling-className"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="css-5a9sl9-className"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <aside
+          className="css-llu3t1-Pullquote"
+        >
+          <blockquote
+            className="css-vhllol-Pullquote"
+          >
+            <p
+              className="css-19my7cx-Pullquote"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="css-1znb75"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Article Interview 1`] = `
+<main
+  className="css-2qsm3-Article"
+>
+  <article
+    className="css-2ammhe-Article"
+  >
+    <div
+      className="css-16sk62p-Article"
+    >
+      <section
+        className="css-1dhlyus-Article"
+      >
+        <header>
+          <figure
+            aria-labelledby="header-image-caption"
+            className="css-dej5xk-HeaderMedia"
+          >
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt=""
+                className="js-launch-slideshow js-main-image css-1ly9xbv-Img"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="css-ianha0-HeaderImageCaption"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="css-1vqrqak"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+          </figure>
+          <div
+            className="css-c356nv-InterviewHeader"
+          >
+            <div
+              className="css-165wy3b-Headline"
+            >
+              <div
+                className="css-1duggjj-Headline"
+              />
+              <h1
+                className="css-ghqarw-Headline"
+              >
+                <span
+                  className="css-1hvs9iy"
+                >
+                  Reclaimed lakes and giant airports: how Mexico City might have looked
+                </span>
+              </h1>
+            </div>
+            <div
+              className="css-18316b1"
+            >
+              <p>
+                The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+              </p>
+            </div>
+          </div>
+          <div
+            className="css-ybmkx6-EditionsLines"
+          >
+            <div
+              className="css-1xgmaw8-straightLines-fourLines-Lines"
+            />
+          </div>
+          <div
+            className="css-1r6t5jr"
+          >
+            <address>
+              <span
+                className="css-1410z7r"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="css-1yh100x"
+              >
+                 Editor of things
+              </span>
+            </address>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="css-rdfey0-ShareIcon"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="css-yn5fb1-Article"
+    >
+      <section
+        className="css-1rrc8kn-Article"
+      >
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <figure
+          className="css-huy3rj-BodyImage"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow css-1we7mgb-Img"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <div
+          className="css-cq3eyp-containerStyling"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="css-l8n9ox-detailStyling"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="css-lzpv1d-atomTitleStyling"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="css-gpo7xk-titleStyling"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="css-1s5nci7-showHideStyling"
+              >
+                <span
+                  className="css-117w3ky-iconSpacing"
+                >
+                  <span
+                    className="css-kd64v9-plusStyling"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="css-dv25nz-bodyStyling"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="css-dc74hn-footerStyling"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="css-fgqqde-className"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="css-27e8o5-buttonStyling"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="css-dl0cko-buttonStyling-className"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="css-5a9sl9-className"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <aside
+          className="css-llu3t1-Pullquote"
+        >
+          <blockquote
+            className="css-vhllol-Pullquote"
+          >
+            <p
+              className="css-19my7cx-Pullquote"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="css-1znb75"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Article Media 1`] = `
+<main
+  className="css-2qsm3-Article"
+>
+  <article
+    className="css-58dfiu-Article"
+  >
+    <div
+      className="css-18oto43-Article"
+    >
+      <section
+        className="css-1dhlyus-Article"
+      >
+        <header
+          className="css-70tn5r-GalleryHeader"
+        >
+          <figure
+            aria-labelledby="header-image-caption"
+            className="css-dej5xk-HeaderMedia"
+          >
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt=""
+                className="js-launch-slideshow js-main-image css-vgwzwo-Img"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="css-nr1xa1-HeaderImageCaption"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="css-6okjyw"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+          </figure>
+          <div
+            className="css-cm0bg2-GalleryHeader"
+          >
+            <div
+              className="css-165wy3b-Headline"
+            >
+              <h1
+                className="css-1cwqm68-Headline"
+              >
+                Reclaimed lakes and giant airports: how Mexico City might have looked
+              </h1>
+            </div>
+            <div
+              className="css-y9xf0m-GalleryHeader"
+            >
+              <div
+                className="css-mwiu58"
+              >
+                <p>
+                  The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+                </p>
+              </div>
+              <div
+                className="css-22kpax-EditionsLines"
+              >
+                <div
+                  className="css-1xgmaw8-straightLines-fourLines-Lines"
+                />
+              </div>
+              <div
+                className="css-o0edii"
+              >
+                <address>
+                  <span
+                    className="css-1vsgm6a"
+                  >
+                    Jane Smith
+                  </span>
+                  <span
+                    className="css-1u4yveu"
+                  >
+                     Editor of things
+                  </span>
+                </address>
+                <span
+                  className="js-share-button"
+                  role="button"
+                >
+                  <button
+                    className="css-rdfey0-ShareIcon"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      fill="none"
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <circle
+                        cx="15"
+                        cy="15"
+                        r="14.5"
+                      />
+                      <path
+                        d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="css-1f5frn6-Article"
+    >
+      <section
+        className="css-1rrc8kn-Article"
+      />
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Article Review 1`] = `
+<main
+  className="css-2qsm3-Article"
+>
+  <article
+    className="css-2ammhe-Article"
+  >
+    <div
+      className="css-8rvrj7-Article"
+    >
+      <section
+        className="css-wzgevt-Article"
+      >
+        <header
+          className="css-10xsu7p-StandardHeader"
+        >
+          <figure
+            aria-labelledby="header-image-caption"
+            className="css-12lxyki-HeaderMedia"
+          >
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt=""
+                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="css-mx0oi0-HeaderImageCaption"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="css-pfziyb"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+            <div
+              className="css-qw9jwe-StarRating"
+            >
+              <span
+                className="css-kuz013"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                className="css-kuz013"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                className="css-kuz013"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                className="css-kuz013"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                className="css-w8n5c6-empty"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </div>
+          </figure>
+          <div
+            className="css-165wy3b-Headline"
+          >
+            <h1
+              className="css-1r46rn4-Headline"
+            >
+              Reclaimed lakes and giant airports: how Mexico City might have looked
+            </h1>
+          </div>
+          <div
+            className="css-1193fgv"
+          >
+            <p>
+              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+            </p>
+          </div>
+          <div
+            className="css-7m2n2v-EditionsLines"
+          >
+            <div
+              className="css-1xgmaw8-straightLines-fourLines-Lines"
+            />
+          </div>
+          <div
+            className="css-1acgyo2"
+          >
+            <address>
+              <span
+                className="css-ixhtuz"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="css-1yh100x"
+              >
+                 Editor of things
+              </span>
+            </address>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="css-rdfey0-ShareIcon"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="css-yn5fb1-Article"
+    >
+      <section
+        className="css-1rrc8kn-Article"
+      >
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <figure
+          className="css-huy3rj-BodyImage"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow css-1we7mgb-Img"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <div
+          className="css-cq3eyp-containerStyling"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="css-l8n9ox-detailStyling"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="css-1mdioea-atomTitleStyling"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="css-gpo7xk-titleStyling"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="css-bawg6n-showHideStyling"
+              >
+                <span
+                  className="css-117w3ky-iconSpacing"
+                >
+                  <span
+                    className="css-kd64v9-plusStyling"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="css-1piahod-bodyStyling"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="css-dc74hn-footerStyling"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="css-fgqqde-className"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="css-8jszxu-buttonStyling"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="css-1dn7oml-buttonStyling-className"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="css-5a9sl9-className"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <aside
+          className="css-zws4bj-Pullquote"
+        >
+          <blockquote
+            className="css-vhllol-Pullquote"
+          >
+            <p
+              className="css-1eb8lfx-Pullquote"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="css-1znb75"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Article Showcase 1`] = `
+<main
+  className="css-2qsm3-Article"
+>
+  <article
+    className="css-2ammhe-Article"
+  >
+    <div
+      className="css-16sk62p-Article"
+    >
+      <section
+        className="css-wzgevt-Article"
+      >
+        <header
+          className="css-10xsu7p-StandardHeader"
+        >
+          <figure
+            aria-labelledby="header-image-caption"
+            className="css-12lxyki-HeaderMedia"
+          >
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt=""
+                className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="css-169o3q0-HeaderImageCaption"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="css-6okjyw"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+          </figure>
+          <div
+            className="css-165wy3b-Headline"
+          >
+            <h1
+              className="css-13o616v-Headline"
+            >
+              Reclaimed lakes and giant airports: how Mexico City might have looked
+            </h1>
+          </div>
+          <div
+            className="css-h42k03"
+          >
+            <p>
+              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+            </p>
+          </div>
+          <div
+            className="css-7m2n2v-EditionsLines"
+          >
+            <div
+              className="css-1xgmaw8-straightLines-fourLines-Lines"
+            />
+          </div>
+          <div
+            className="css-teh8lu"
+          >
+            <address>
+              <span
+                className="css-s6pm0t"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="css-1yh100x"
+              >
+                 Editor of things
+              </span>
+            </address>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="css-rdfey0-ShareIcon"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="css-yn5fb1-Article"
+    >
+      <section
+        className="css-1rrc8kn-Article"
+      >
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <figure
+          className="css-huy3rj-BodyImage"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow css-1we7mgb-Img"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <div
+          className="css-cq3eyp-containerStyling"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="css-l8n9ox-detailStyling"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="css-3w82vu-atomTitleStyling"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="css-gpo7xk-titleStyling"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="css-1p3af4l-showHideStyling"
+              >
+                <span
+                  className="css-117w3ky-iconSpacing"
+                >
+                  <span
+                    className="css-kd64v9-plusStyling"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="css-5oaelj-bodyStyling"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="css-dc74hn-footerStyling"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="css-fgqqde-className"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="css-con9lg-buttonStyling"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="css-av88v2-buttonStyling-className"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="css-15k23p-className"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="css-5a9sl9-className"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <aside
+          className="css-1f6ukfo-Pullquote"
+        >
+          <blockquote
+            className="css-vhllol-Pullquote"
+          >
+            <p
+              className="css-cgf9f8-Pullquote"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="css-1znb75"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+        <p
+          className="css-ril8fi-Paragraph"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Avatar Default 1`] = `
+<picture>
+  <source
+    media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+    sizes="105px"
+    srcSet="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=32&quality=85&fit=bounds&s=100fc280274e40946afb34d4b561ce9f 32w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e 64w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=128&quality=85&fit=bounds&s=35b6ce614cae19fbdcdefa55a670eda5 128w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=192&quality=85&fit=bounds&s=930a05d87b62a1f613ff76f3ee0c97a0 192w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=256&quality=85&fit=bounds&s=8c44b90de342114bd3bf6145767d4b31 256w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=400&quality=85&fit=bounds&s=8491504dfb944eee7ef173e739cb4f74 400w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=600&quality=85&fit=bounds&s=668fc2d7278f6c4a553f806c9b2d47d3 600w"
+  />
+  <source
+    sizes="105px"
+    srcSet="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=32&quality=85&fit=bounds&s=100fc280274e40946afb34d4b561ce9f 32w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e 64w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=128&quality=85&fit=bounds&s=35b6ce614cae19fbdcdefa55a670eda5 128w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=192&quality=85&fit=bounds&s=930a05d87b62a1f613ff76f3ee0c97a0 192w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=256&quality=85&fit=bounds&s=8c44b90de342114bd3bf6145767d4b31 256w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=400&quality=85&fit=bounds&s=8491504dfb944eee7ef173e739cb4f74 400w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=600&quality=85&fit=bounds&s=668fc2d7278f6c4a553f806c9b2d47d3 600w"
+  />
+  <img
+    alt="image"
+    className="css-1i77lxz-Img"
+    data-ratio={1}
+    src="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e"
+  />
+</picture>
+`;
+
+exports[`Storyshots Editions/Byline Analysis 1`] = `
+<div
+  className="css-teh8lu"
+>
+  <address>
+    <span
+      className="css-1tnqwjd"
+    >
+      Jane Smith
+    </span>
+    <span
+      className="css-15jtyuf"
+    >
+       Editor of things
+    </span>
+  </address>
+</div>
+`;
+
+exports[`Storyshots Editions/Byline Comment 1`] = `
+<div
+  style={
+    Object {
+      "marginTop": "64px",
+    }
+  }
+>
+  <div
+    className="css-1xck3cj"
+  >
+    <address>
+      <span
+        className="css-1tnqwjd"
+      >
+        Jane Smith
+      </span>
+      <span
+        className="css-15jtyuf"
+      >
+         Editor of things
+      </span>
+    </address>
+    <div
+      className="css-17kiv7u"
+    >
+      <picture>
+        <source
+          media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+          sizes="105px"
+          srcSet="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=32&quality=85&fit=bounds&s=100fc280274e40946afb34d4b561ce9f 32w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e 64w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=128&quality=85&fit=bounds&s=35b6ce614cae19fbdcdefa55a670eda5 128w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=192&quality=85&fit=bounds&s=930a05d87b62a1f613ff76f3ee0c97a0 192w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=256&quality=85&fit=bounds&s=8c44b90de342114bd3bf6145767d4b31 256w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=400&quality=85&fit=bounds&s=8491504dfb944eee7ef173e739cb4f74 400w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=600&quality=85&fit=bounds&s=668fc2d7278f6c4a553f806c9b2d47d3 600w"
+        />
+        <source
+          sizes="105px"
+          srcSet="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=32&quality=85&fit=bounds&s=100fc280274e40946afb34d4b561ce9f 32w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e 64w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=128&quality=85&fit=bounds&s=35b6ce614cae19fbdcdefa55a670eda5 128w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=192&quality=85&fit=bounds&s=930a05d87b62a1f613ff76f3ee0c97a0 192w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=256&quality=85&fit=bounds&s=8c44b90de342114bd3bf6145767d4b31 256w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=400&quality=85&fit=bounds&s=8491504dfb944eee7ef173e739cb4f74 400w, https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=600&quality=85&fit=bounds&s=668fc2d7278f6c4a553f806c9b2d47d3 600w"
+        />
+        <img
+          alt="image"
+          className="css-1w5z5b1-Img"
+          data-ratio={1}
+          src="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e"
+        />
+      </picture>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Editions/Byline Default 1`] = `
+<div
+  className="css-teh8lu"
+>
+  <address>
+    <span
+      className="css-s6pm0t"
+    >
+      Jane Smith
+    </span>
+    <span
+      className="css-1yh100x"
+    >
+       Editor of things
+    </span>
+  </address>
+  <span
+    className="js-share-button"
+    role="button"
+  >
+    <button
+      className="css-rdfey0-ShareIcon"
+      onClick={[Function]}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="15"
+          cy="15"
+          r="14.5"
+        />
+        <path
+          d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+        />
+      </svg>
+    </button>
+  </span>
+</div>
+`;
+
+exports[`Storyshots Editions/Byline Feature 1`] = `
+<div
+  className="css-teh8lu"
+>
+  <address>
+    <span
+      className="css-s6pm0t"
+    >
+      Jane Smith
+    </span>
+    <span
+      className="css-1yh100x"
+    >
+       Editor of things
+    </span>
+  </address>
+  <span
+    className="js-share-button"
+    role="button"
+  >
+    <button
+      className="css-rdfey0-ShareIcon"
+      onClick={[Function]}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="15"
+          cy="15"
+          r="14.5"
+        />
+        <path
+          d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+        />
+      </svg>
+    </button>
+  </span>
+</div>
+`;
+
+exports[`Storyshots Editions/Byline Interview 1`] = `
+<div
+  className="css-8x2t1u"
+>
+  <address>
+    <span
+      className="css-s6pm0t"
+    >
+      Jane Smith
+    </span>
+    <span
+      className="css-1yh100x"
+    >
+       Editor of things
+    </span>
+  </address>
+  <span
+    className="js-share-button"
+    role="button"
+  >
+    <button
+      className="css-rdfey0-ShareIcon"
+      onClick={[Function]}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="15"
+          cy="15"
+          r="14.5"
+        />
+        <path
+          d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+        />
+      </svg>
+    </button>
+  </span>
+</div>
+`;
+
+exports[`Storyshots Editions/Byline Review 1`] = `
+<div
+  className="css-teh8lu"
+>
+  <address>
+    <span
+      className="css-s6pm0t"
+    >
+      Jane Smith
+    </span>
+    <span
+      className="css-1yh100x"
+    >
+       Editor of things
+    </span>
+  </address>
+  <span
+    className="js-share-button"
+    role="button"
+  >
+    <button
+      className="css-rdfey0-ShareIcon"
+      onClick={[Function]}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="15"
+          cy="15"
+          r="14.5"
+        />
+        <path
+          d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+        />
+      </svg>
+    </button>
+  </span>
+</div>
+`;
+
+exports[`Storyshots Editions/Byline Showcase 1`] = `
+<div
+  className="css-58spt4"
+>
+  <address>
+    <span
+      className="css-s6pm0t"
+    >
+      Jane Smith
+    </span>
+    <span
+      className="css-1yh100x"
+    >
+       Editor of things
+    </span>
+  </address>
+  <span
+    className="js-share-button"
+    role="button"
+  >
+    <button
+      className="css-rdfey0-ShareIcon"
+      onClick={[Function]}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="15"
+          cy="15"
+          r="14.5"
+        />
+        <path
+          d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+        />
+      </svg>
+    </button>
+  </span>
+</div>
+`;
+
+exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
+<figure
+  aria-labelledby="header-image-caption"
+  className="css-dej5xk-HeaderMedia"
+>
+  <picture>
+    <source
+      media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+      sizes="100vw"
+      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+    />
+    <source
+      sizes="100vw"
+      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+    />
+    <img
+      alt=""
+      className="js-launch-slideshow js-main-image css-1ly9xbv-Img"
+      data-ratio={0.6}
+      src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+    />
+  </picture>
+  <figcaption
+    className="css-nr1xa1-HeaderImageCaption"
+  >
+    <details>
+      <summary>
+        <span
+          className="css-6okjyw"
+        >
+          <svg
+            viewBox="0 0 30 30"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+              fillRule="evenodd"
+            />
+          </svg>
+          Click to see figure caption
+        </span>
+      </summary>
+      <span
+        id="header-image-caption"
+      >
+        ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+         
+        Photograph: Philip Keith/The Guardian
+      </span>
+    </details>
+  </figcaption>
+</figure>
+`;
+
+exports[`Storyshots Editions/HeaderMedia Image 1`] = `
+<figure
+  aria-labelledby="header-image-caption"
+  className="css-12lxyki-HeaderMedia"
+>
+  <picture>
+    <source
+      media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+      sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+    />
+    <source
+      sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+    />
+    <img
+      alt=""
+      className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+      data-ratio={0.6}
+      src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+    />
+  </picture>
+  <figcaption
+    className="css-169o3q0-HeaderImageCaption"
+  >
+    <details>
+      <summary>
+        <span
+          className="css-6okjyw"
+        >
+          <svg
+            viewBox="0 0 30 30"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+              fillRule="evenodd"
+            />
+          </svg>
+          Click to see figure caption
+        </span>
+      </summary>
+      <span
+        id="header-image-caption"
+      >
+        ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+         
+        Photograph: Philip Keith/The Guardian
+      </span>
+    </details>
+  </figcaption>
+</figure>
+`;
+
+exports[`Storyshots Editions/HeaderMedia Video 1`] = `
+<div
+  className="css-x1sm9l"
+>
+  <iframe
+    allowFullScreen={true}
+    className="css-7y7f6n"
+    frameBorder="0"
+    scrolling="no"
+    src="https://embed.theguardian.com/embed/atom/media/26401ff7-24d0-4ba5-8882-2c32c2b379f0#noadsaf"
+    title="Super Bowl LV: Tom Brady MVP as Buccaneers beat Chiefs 31-9 – video report"
+  />
+</div>
+`;
+
+exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
+<figure
+  aria-labelledby="header-image-caption"
+  className="css-12lxyki-HeaderMedia"
+>
+  <picture>
+    <source
+      media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+      sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+    />
+    <source
+      sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+    />
+    <img
+      alt=""
+      className="js-launch-slideshow js-main-image css-3d4hzy-Img"
+      data-ratio={0.6}
+      src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+    />
+  </picture>
+  <figcaption
+    className="css-mx0oi0-HeaderImageCaption"
+  >
+    <details>
+      <summary>
+        <span
+          className="css-pfziyb"
+        >
+          <svg
+            viewBox="0 0 30 30"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+              fillRule="evenodd"
+            />
+          </svg>
+          Click to see figure caption
+        </span>
+      </summary>
+      <span
+        id="header-image-caption"
+      >
+        ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+         
+        Photograph: Philip Keith/The Guardian
+      </span>
+    </details>
+  </figcaption>
+  <div
+    className="css-qw9jwe-StarRating"
+  >
+    <span
+      className="css-kuz013"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+    <span
+      className="css-kuz013"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+    <span
+      className="css-kuz013"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+    <span
+      className="css-kuz013"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+    <span
+      className="css-w8n5c6-empty"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+  </div>
+</figure>
+`;
+
+exports[`Storyshots Editions/Headline Analysis 1`] = `
+<div
+  className="css-165wy3b-Headline"
+>
+  <h1
+    className="css-1qz0qx9-Headline"
+  >
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </h1>
+</div>
+`;
+
+exports[`Storyshots Editions/Headline Comment 1`] = `
+<div
+  className="css-165wy3b-Headline"
+>
+  <h1
+    className="css-k4j3s4-Headline"
+  >
+    <span
+      className="css-1od8ezt"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+          fillRule="evenodd"
+        />
+      </svg>
+      Reclaimed lakes and giant airports: how Mexico City might have looked
+    </span>
+  </h1>
+</div>
+`;
+
+exports[`Storyshots Editions/Headline Default 1`] = `
+<div
+  className="css-165wy3b-Headline"
+>
+  <h1
+    className="css-13o616v-Headline"
+  >
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </h1>
+</div>
+`;
+
+exports[`Storyshots Editions/Headline Feature 1`] = `
+<div
+  className="css-165wy3b-Headline"
+>
+  <h1
+    className="css-1v4opfu-Headline"
+  >
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </h1>
+</div>
+`;
+
+exports[`Storyshots Editions/Headline Interview 1`] = `
+<div
+  className="css-165wy3b-Headline"
+>
+  <div
+    className="css-1duggjj-Headline"
+  />
+  <h1
+    className="css-ghqarw-Headline"
+  >
+    <span
+      className="css-1hvs9iy"
+    >
+      Reclaimed lakes and giant airports: how Mexico City might have looked
+    </span>
+  </h1>
+</div>
+`;
+
+exports[`Storyshots Editions/Headline Media 1`] = `
+<div
+  className="css-165wy3b-Headline"
+>
+  <h1
+    className="css-1cwqm68-Headline"
+  >
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </h1>
+</div>
+`;
+
+exports[`Storyshots Editions/Headline Review 1`] = `
+<div
+  className="css-165wy3b-Headline"
+>
+  <h1
+    className="css-1r46rn4-Headline"
+  >
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </h1>
+</div>
+`;
+
+exports[`Storyshots Editions/Headline Showcase 1`] = `
+<div
+  className="css-165wy3b-Headline"
+>
+  <h1
+    className="css-1kmuawa-Headline"
+  >
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </h1>
+</div>
+`;
+
+exports[`Storyshots Editions/PullQuote Default 1`] = `
+<aside
+  className="css-1f6ukfo-Pullquote"
+>
+  <blockquote
+    className="css-vhllol-Pullquote"
+  >
+    <p
+      className="css-cgf9f8-Pullquote"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+          fillRule="evenodd"
+        />
+      </svg>
+      The anti-slaughter movement is declining due to increased surveillance and repression that criminalises Tibetan identity
+    </p>
+    <cite
+      className="css-1znb75"
+    >
+      Katia Buffetrille, anthropologist
+    </cite>
+  </blockquote>
+</aside>
+`;
+
+exports[`Storyshots Editions/Series Default 1`] = `
+<nav
+  className="css-zzo0sh"
+>
+  Running
+</nav>
+`;
+
+exports[`Storyshots Editions/Series Immersive 1`] = `
+<nav
+  className="css-103n3es"
+>
+  The long read
+</nav>
+`;
+
+exports[`Storyshots Editions/Series Interview 1`] = `
+<nav
+  className="css-dtesww"
+>
+  Interview
+</nav>
+`;
+
+exports[`Storyshots Editions/ShareIcon Default 1`] = `
+<div
+  className="css-1wlqhgk-Default"
+>
+  <button
+    className="css-rdfey0-ShareIcon"
+    onClick={[Function]}
+  >
+    <svg
+      fill="none"
+      viewBox="0 0 30 30"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="15"
+        cy="15"
+        r="14.5"
+      />
+      <path
+        d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`Storyshots Editions/Standfirst Analysis 1`] = `
+<div
+  className="css-a9bgr4"
+>
+  <p>
+    The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+  </p>
+</div>
+`;
+
+exports[`Storyshots Editions/Standfirst Comment 1`] = `
+<div
+  className="css-a9bgr4"
+>
+  <p>
+    The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+  </p>
+</div>
+`;
+
+exports[`Storyshots Editions/Standfirst Default 1`] = `
+<div
+  className="css-h42k03"
+>
+  <p>
+    The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+  </p>
+</div>
+`;
+
+exports[`Storyshots Editions/Standfirst Media 1`] = `
+<div
+  style={
+    Object {
+      "backgroundColor": "#121212",
+    }
+  }
+>
+  <div
+    className="css-mwiu58"
+  >
+    <p>
+      The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Editions/Standfirst Showcase 1`] = `
+<div
+  className="css-1mgym3w"
+>
+  <p>
+    The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+  </p>
+</div>
+`;
+
+exports[`Storyshots Follow Default 1`] = `
+<button
+  className="js-follow css-ylaspq-Follow"
+  data-display-name="Jane Smith"
+  data-id="profile/janesmith"
+>
+  <span
+    className="js-status"
+  >
+    Follow 
+  </span>
+  Jane Smith
+</button>
+`;
+
+exports[`Storyshots Footer Default 1`] = `
+<div
+  className="css-1tni85m-FooterCcpa"
+>
+  © 
+  2021
+   Guardian News and Media Limited or its affiliated companies. All rights reserved.
+  <br />
+  <a
+    className="css-j4jbe3-FooterCcpa"
+    href="https://www.theguardian.com/help/privacy-policy"
+  >
+    Privacy Policy
+  </a>
+</div>
+`;
+
+exports[`Storyshots Footer With Ccpa 1`] = `
+<div
+  className="css-1tni85m-FooterCcpa"
+>
+  © 
+  2021
+   Guardian News and Media Limited or its affiliated companies. All rights reserved.
+  <br />
+  <a
+    className="css-1telkou"
+    href="https://www.theguardian.com/help/privacy-policy"
+  >
+    California Residents - Do Not Sell
+  </a>
+   · 
+  <a
+    className="css-j4jbe3-FooterCcpa"
+    href="https://www.theguardian.com/help/privacy-policy"
+  >
+    Privacy Policy
+  </a>
+</div>
+`;
+
+exports[`Storyshots Headline Analysis 1`] = `
+<h1
+  className="css-5hyg8b-Headline"
+>
+  <span>
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </span>
+</h1>
+`;
+
+exports[`Storyshots Headline Default 1`] = `
+<h1
+  className="css-swyj2a-Headline"
+>
+  <span>
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </span>
+</h1>
+`;
+
+exports[`Storyshots Headline Feature 1`] = `
+<h1
+  className="css-1wsu5kv-Headline"
+>
+  <span>
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </span>
+</h1>
+`;
+
+exports[`Storyshots Headline Labs 1`] = `
+<h1
+  className="css-10s8ewe-Headline"
+>
+  <span>
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </span>
+</h1>
+`;
+
+exports[`Storyshots Headline Review 1`] = `
+<h1
+  className="css-p4webw-Headline"
+>
+  <span>
+    Reclaimed lakes and giant airports: how Mexico City might have looked
+  </span>
+  <div>
+    <span
+      className="css-ihxckh"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+    <span
+      className="css-ihxckh"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+    <span
+      className="css-ihxckh"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+    <span
+      className="css-hfq1j9-empty"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+    <span
+      className="css-hfq1j9-empty"
+    >
+      <svg
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </span>
+  </div>
+</h1>
+`;
+
+exports[`Storyshots HorizontalRule Default 1`] = `
+<hr
+  className="css-lmf0pc-HorizontalRule"
+/>
+`;
+
+exports[`Storyshots Paragraph Default 1`] = `
+<p
+  className="css-ril8fi-Paragraph"
+>
+  Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have dreamed of water: containing it, draining it and now retaining it.
+</p>
+`;
+
+exports[`Storyshots Paragraph Labs 1`] = `
+<p
+  className="css-ludswr-Paragraph"
+>
+  Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have dreamed of water: containing it, draining it and now retaining it.
+</p>
+`;
+
+exports[`Storyshots Rich Link Default 1`] = `
+<section
+  className="css-ke3kvz-Default"
+>
+  <aside
+    className="js-rich-link css-1xpjeoh-RichLink"
+  >
+    <a
+      href="https://theguardian.com"
+    >
+      <div
+        className="js-image"
+      />
+      <h1>
+        Axolotls in crisis: the fight to save the water monster of Mexico City.
+      </h1>
+      <button>
+        <svg
+          viewBox="0 0 30 30"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clipRule="evenodd"
+            d="M4 15.95h19.125l-7.5 8.975.975.975 10.425-10.45v-1L16.6 4l-.975.975 7.5 8.975H4v2z"
+            fillRule="evenodd"
+          />
+        </svg>
+        Read more
+      </button>
+    </a>
+  </aside>
+</section>
+`;
+
+exports[`Storyshots Shared Tags 1`] = `
+<ul
+  className="css-y50d1d-Tags"
+>
+  <li>
+    <a
+      href="https://mapi.co.uk/tag"
+    >
+      Tag title
+    </a>
+  </li>
+  <li>
+    <a
+      href="https://mapi.co.uk/tag"
+    >
+      Tag title
+    </a>
+  </li>
+  <li>
+    <a
+      href="https://mapi.co.uk/tag"
+    >
+      Tag title
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`Storyshots Standfirst Comment 1`] = `
+<div
+  className="css-qiidkb"
+>
+  <p>
+    The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+  </p>
+</div>
+`;
+
+exports[`Storyshots Standfirst Default 1`] = `
+<div
+  className="css-bb3wik"
+>
+  <p>
+    The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+  </p>
+</div>
+`;
+
+exports[`Storyshots Standfirst Feature 1`] = `
+<div
+  className="css-qiidkb"
+>
+  <p>
+    The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+  </p>
+</div>
+`;
+
+exports[`Storyshots Standfirst Review 1`] = `
+<div
+  className="css-qiidkb"
+>
+  <p>
+    The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+  </p>
+</div>
+`;
+
+exports[`Storyshots Star Rating Default 1`] = `
+<div>
+  <span
+    className="css-ihxckh"
+  >
+    <svg
+      viewBox="0 0 30 30"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+        fillRule="evenodd"
+      />
+    </svg>
+  </span>
+  <span
+    className="css-ihxckh"
+  >
+    <svg
+      viewBox="0 0 30 30"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+        fillRule="evenodd"
+      />
+    </svg>
+  </span>
+  <span
+    className="css-ihxckh"
+  >
+    <svg
+      viewBox="0 0 30 30"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+        fillRule="evenodd"
+      />
+    </svg>
+  </span>
+  <span
+    className="css-hfq1j9-empty"
+  >
+    <svg
+      viewBox="0 0 30 30"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+        fillRule="evenodd"
+      />
+    </svg>
+  </span>
+  <span
+    className="css-hfq1j9-empty"
+  >
+    <svg
+      viewBox="0 0 30 30"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+        fillRule="evenodd"
+      />
+    </svg>
+  </span>
+</div>
+`;
+
+exports[`Storyshots Star Rating Not Review 1`] = `null`;

--- a/src/storyshots.test.ts
+++ b/src/storyshots.test.ts
@@ -1,0 +1,3 @@
+import initStoryshots from '@storybook/addon-storyshots';
+
+initStoryshots();


### PR DESCRIPTION
## Why are you doing this?

Investigating the addition of snapshot testing using the Storybook addon "Storyshots" and Jest.

For anyone who hasn't come across this before there's more info here:
https://www.npmjs.com/package/@storybook/addon-storyshots

The setup is very simple, we've had to update the Storybook config files to use their new conventions but otherwise all this requires is a `storyshots.test.ts` file that initialises the tests .

Each time we run the test script now Jest will create a snapshot for every file that has a `*.stories.tsx` file - giving us a way to monitor for changes in the UI.

Creating the snapshots adds around 2.5 seconds to the time the test script takes to run and currently generates 65 snapshots, all contained within one file.

If a snapshot has been changed Jest will flag it as below:

<img src="https://user-images.githubusercontent.com/77005274/107755421-ad5c0b80-6d1a-11eb-8d7c-c0956307e76c.png" width="300px" />

We can either fix this by updating the snapshot (`npm run test -- -u`) or fix the code so the snapshot doesn't change.

**TL;DR** Storyshot testing adds a snapshot for every component covered by a story. The test script takes a couple of seconds longer to run, but we gain a lot of UI test coverage in return for adding minimal config to the project.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/107755587-eeecb680-6d1a-11eb-8988-61c25a84c49f.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/107755614-f8761e80-6d1a-11eb-86e4-b4df31c6ca05.png" width="300px" /> |
