### PR TITLE
[spike]: demo grid layout for header media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2253,7 +2253,7 @@
       "requires": {
         "@emotion/core": "^10.1.1",
         "@guardian/src-foundations": "^2.7.1",
-        "@guardian/types": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
+        "@guardian/types": "github:guardian/types#semver:1.1.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "typescript": "^4.1.3"

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -324,17 +324,31 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 .emotion-5 {
-  margin: 0;
-  position: relative;
+  grid-column-start: 0;
+  grid-column-end: span 12;
 }
 
-@media (min-width:980px) {
+@media (min-width:740px) {
   .emotion-5 {
-    width: 750px;
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
   }
 }
 
 .emotion-6 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-7 {
   width: 100vw;
   height: calc(100vw * 0.6);
   background-color: #F6F6F6;
@@ -342,51 +356,26 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   display: block;
   display: block;
   width: 100%;
-}
-
-@media (min-width:740px) {
-  .emotion-6 {
-    width: 740px;
-    height: calc(740px * 0.6);
-  }
-}
-
-@media (min-width:1300px) {
-  .emotion-6 {
-    width: 980px;
-    height: calc(980px * 0.6);
-  }
+  height: 100%;
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-6 {
+  .emotion-7 {
     background-color: #333333;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-6 {
-    width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-6 {
-    width: 750px;
-    height: 450px;
-  }
-}
-
-.emotion-7 {
+.emotion-8 {
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   top: 0;
+  width: 100%;
+  height: 100%;
 }
 
-.emotion-7 summary {
+.emotion-8 summary {
   text-align: center;
   background-color: #BB3B80;
   width: 34px;
@@ -398,11 +387,11 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   outline: none;
 }
 
-.emotion-7 summary::-webkit-details-marker {
+.emotion-8 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-7 details[open] {
+.emotion-8 details[open] {
   min-height: 44px;
   max-height: 999px;
   height: 100%;
@@ -420,54 +409,41 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 9rem;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-7 {
-    width: calc(100vw - 3.75rem);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 {
-    width: 750px;
-  }
-}
-
-.emotion-8 {
+.emotion-9 {
   line-height: 32px;
   font-size: 0;
 }
 
-.emotion-8 svg {
+.emotion-9 svg {
   width: 75%;
   height: 75%;
   margin: 12.5%;
 }
 
-.emotion-8 path {
+.emotion-9 path {
   fill: #FEEEF7;
 }
 
-.emotion-9 {
+.emotion-10 {
   position: relative;
 }
 
-.emotion-10 {
+.emotion-11 {
   color: #121212;
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -483,7 +459,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:375px) {
-  .emotion-10 {
+  .emotion-11 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 1.75rem;
     line-height: 1.35;
@@ -492,7 +468,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-10 {
+  .emotion-11 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 2.125rem;
     line-height: 1.35;
@@ -500,7 +476,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   }
 }
 
-.emotion-11 {
+.emotion-12 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -514,7 +490,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   margin: 0;
 }
 
-.emotion-11 svg {
+.emotion-12 svg {
   -webkit-flex: 0 0 1.875rem;
   -ms-flex: 0 0 1.875rem;
   flex: 0 0 1.875rem;
@@ -523,21 +499,21 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   height: 1.875rem;
 }
 
-.emotion-11 svg circle {
+.emotion-12 svg circle {
   stroke: #BB3B80;
 }
 
-.emotion-11 svg path {
+.emotion-12 svg path {
   fill: #BB3B80;
 }
 
 @media (min-width:740px) {
-  .emotion-11 {
+  .emotion-12 {
     padding-bottom: 2.25rem;
   }
 }
 
-.emotion-12 {
+.emotion-13 {
   color: #BB3B80;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -547,7 +523,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-12 {
+  .emotion-13 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 1.75rem;
     line-height: 1.35;
@@ -557,7 +533,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-12 {
+  .emotion-13 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 2.125rem;
     line-height: 1.35;
@@ -566,7 +542,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   }
 }
 
-.emotion-13 {
+.emotion-14 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
   line-height: undefined;
@@ -576,7 +552,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-13 {
+  .emotion-14 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 1.75rem;
     line-height: undefined;
@@ -586,7 +562,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-13 {
+  .emotion-14 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 2.125rem;
     line-height: undefined;
@@ -595,23 +571,11 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   }
 }
 
-.emotion-14 {
+.emotion-15 {
   box-sizing: border-box;
 }
 
-@media (min-width:740px) {
-  .emotion-14 {
-    width: 539px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-14 {
-    width: 558px;
-  }
-}
-
-.emotion-15 {
+.emotion-16 {
   background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
   background-repeat: repeat-x;
   background-position: top;
@@ -619,7 +583,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   height: calc(0.25rem * 3 + 1px);
 }
 
-.emotion-16 {
+.emotion-17 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.15;
@@ -641,29 +605,17 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   color: #767676;
 }
 
-@media (min-width:740px) {
-  .emotion-16 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-16 {
-    width: 545px;
-  }
-}
-
-.emotion-16 p,
-.emotion-16 ul {
+.emotion-17 p,
+.emotion-17 ul {
   padding-top: 0.25rem;
   margin: 0;
 }
 
-.emotion-16 address {
+.emotion-17 address {
   font-style: normal;
 }
 
-.emotion-16 svg {
+.emotion-17 svg {
   -webkit-flex: 0 0 1.875rem;
   -ms-flex: 0 0 1.875rem;
   flex: 0 0 1.875rem;
@@ -673,15 +625,15 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   height: 1.875rem;
 }
 
-.emotion-16 svg circle {
+.emotion-17 svg circle {
   stroke: #BB3B80;
 }
 
-.emotion-16 svg path {
+.emotion-17 svg path {
   fill: #BB3B80;
 }
 
-.emotion-17 {
+.emotion-18 {
   background: none;
   border: none;
   padding: 0;
@@ -689,53 +641,53 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-18 {
+  .emotion-19 {
     width: 526px;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-18 {
+  .emotion-19 {
     width: 545px;
   }
 }
 
 @media (min-width:740px) {
-  .emotion-18 {
+  .emotion-19 {
     padding-right: 0.75rem;
     border-right: 1px solid #DCDCDC;
   }
 }
 
 @media (min-width:740px) {
-  .emotion-18 {
+  .emotion-19 {
     margin-left: 24px;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-18 {
+  .emotion-19 {
     margin-left: 144px;
   }
 }
 
-.emotion-19 {
+.emotion-20 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
 
-.emotion-19 iframe {
+.emotion-20 iframe {
   width: 100%;
   border: none;
 }
 
-.emotion-19 figcaption {
+.emotion-20 figcaption {
   background: #FFFFFF;
   padding-bottom: 0.5rem;
 }
 
 @media (min-width:740px) {
-  .emotion-19 p {
+  .emotion-20 p {
     margin: 0;
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
@@ -743,13 +695,13 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-19 {
+  .emotion-20 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.emotion-20 {
+.emotion-21 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -758,18 +710,18 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.emotion-21 {
+.emotion-22 {
   margin: 1rem 0;
   width: 100%;
 }
 
 @media (min-width:660px) {
-  .emotion-21 {
+  .emotion-22 {
     width: 620px;
   }
 }
 
-.emotion-22 {
+.emotion-23 {
   width: 100%;
   height: calc(100% * 1.25);
   background-color: #F6F6F6;
@@ -778,26 +730,26 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:660px) {
-  .emotion-22 {
+  .emotion-23 {
     width: 620px;
     height: calc(620px * 1.25);
   }
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-22 {
+  .emotion-23 {
     background-color: #333333;
   }
 }
 
-.emotion-25 {
+.emotion-26 {
   display: block;
   position: relative;
   margin-bottom: 0.75rem;
   margin-top: 1rem;
 }
 
-.emotion-26 {
+.emotion-27 {
   margin: 16px 0 36px;
   background: #EDEDED;
   color: #121212;
@@ -807,20 +759,20 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   position: relative;
 }
 
-.emotion-26 summary {
+.emotion-27 summary {
   list-style: none;
   margin: 0 0 16px;
 }
 
-.emotion-26 summary::-webkit-details-marker {
+.emotion-27 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-26 summary:focus {
+.emotion-27 summary:focus {
   outline: none;
 }
 
-.emotion-27 {
+.emotion-28 {
   display: block;
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
@@ -829,7 +781,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   color: #BB3B80;
 }
 
-.emotion-28 {
+.emotion-29 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.15;
@@ -838,7 +790,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   line-height: 22px;
 }
 
-.emotion-29 {
+.emotion-30 {
   background: #121212;
   color: #FFFFFF;
   height: 2rem;
@@ -862,11 +814,11 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   margin: 0;
 }
 
-.emotion-29:hover {
+.emotion-30:hover {
   background: #BB3B80;
 }
 
-.emotion-30 {
+.emotion-31 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -881,7 +833,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   font-weight: 400;
 }
 
-.emotion-31 {
+.emotion-32 {
   margin-right: 12px;
   margin-bottom: 6px;
   width: 33px;
@@ -889,36 +841,36 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   height: 28px;
 }
 
-.emotion-32 {
+.emotion-33 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.emotion-32 p {
+.emotion-33 p {
   margin-bottom: 0.5rem;
 }
 
-.emotion-32 ol {
+.emotion-33 ol {
   list-style: decimal;
   list-style-position: inside;
   margin-bottom: 1rem;
 }
 
-.emotion-32 ul {
+.emotion-33 ul {
   list-style: none;
   margin: 0 0 0.75rem;
   padding: 0;
   margin-bottom: 1rem;
 }
 
-.emotion-32 ul li {
+.emotion-33 ul li {
   margin-bottom: 0.375rem;
   padding-left: 1.25rem;
 }
 
-.emotion-32 ul li:before {
+.emotion-33 ul li:before {
   display: inline-block;
   content: '';
   border-radius: 0.375rem;
@@ -929,15 +881,15 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   margin-left: -1.25rem;
 }
 
-.emotion-32 b {
+.emotion-33 b {
   font-weight: 700;
 }
 
-.emotion-32 i {
+.emotion-33 i {
   font-style: italic;
 }
 
-.emotion-32 a {
+.emotion-33 a {
   color: #7D0068;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -946,11 +898,11 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   transition: border-color 0.15s ease-out;
 }
 
-.emotion-32 a:hover {
+.emotion-33 a:hover {
   border-bottom: solid 0.0625rem #BB3B80;
 }
 
-.emotion-33 {
+.emotion-34 {
   font-size: 13px;
   line-height: 16px;
   display: -webkit-box;
@@ -963,7 +915,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-34 {
+.emotion-35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -978,7 +930,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   font-weight: 400;
 }
 
-.emotion-35 {
+.emotion-36 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1002,20 +954,20 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   height: 28px;
 }
 
-.emotion-35:hover {
+.emotion-36:hover {
   background: #BB3B80;
 }
 
-.emotion-35:focus {
+.emotion-36:focus {
   border: none;
 }
 
-.emotion-36 {
+.emotion-37 {
   width: 16px;
   height: 16px;
 }
 
-.emotion-37 {
+.emotion-38 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1045,15 +997,15 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   -o-transform: rotate(180deg);
 }
 
-.emotion-37:hover {
+.emotion-38:hover {
   background: #BB3B80;
 }
 
-.emotion-37:focus {
+.emotion-38:focus {
   border: none;
 }
 
-.emotion-39 {
+.emotion-40 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.75rem;
   line-height: 1.5;
@@ -1061,7 +1013,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   height: 28px;
 }
 
-.emotion-42 {
+.emotion-43 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -1076,14 +1028,14 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-42 {
+  .emotion-43 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-42:before {
+.emotion-43:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -1095,7 +1047,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-42:after {
+.emotion-43:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -1105,25 +1057,25 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   border-top: 1px solid #BB3B80;
 }
 
-.emotion-43 {
+.emotion-44 {
   margin: 0;
 }
 
-.emotion-44 {
+.emotion-45 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-44 svg {
+.emotion-45 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #BB3B80;
 }
 
-.emotion-45 {
+.emotion-46 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -1146,92 +1098,96 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
         <header
           className="emotion-4"
         >
-          <figure
-            aria-labelledby="header-image-caption"
+          <div
             className="emotion-5"
           >
-            <picture>
-              <source
-                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-              />
-              <source
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-              />
-              <img
-                alt="image"
-                className="js-launch-slideshow js-main-image emotion-6"
-                data-ratio={0.6}
-                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-              />
-            </picture>
-            <figcaption
-              className="emotion-7"
+            <figure
+              aria-labelledby="header-image-caption"
+              className="emotion-6"
             >
-              <details>
-                <summary>
-                  <span
-                    className="emotion-8"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+                />
+                <source
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+                />
+                <img
+                  alt="image"
+                  className="js-launch-slideshow js-main-image emotion-7"
+                  data-ratio={0.6}
+                  src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+                />
+              </picture>
+              <figcaption
+                className="emotion-8"
+              >
+                <details>
+                  <summary>
+                    <span
+                      className="emotion-9"
                     >
-                      <path
-                        clipRule="evenodd"
-                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                    Click to see figure caption
+                      <svg
+                        viewBox="0 0 30 30"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                      Click to see figure caption
+                    </span>
+                  </summary>
+                  <span
+                    id="header-image-caption"
+                  >
+                    ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                     
+                    Photograph: Philip Keith/The Guardian
                   </span>
-                </summary>
-                <span
-                  id="header-image-caption"
-                >
-                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-                   
-                  Photograph: Philip Keith/The Guardian
-                </span>
-              </details>
-            </figcaption>
-          </figure>
+                </details>
+              </figcaption>
+            </figure>
+          </div>
           <div
-            className="emotion-9"
+            className="emotion-10"
           >
             <h1
-              className="emotion-10"
+              className="emotion-11"
             >
               Reclaimed lakes and giant airports: how Mexico City might have looked
             </h1>
           </div>
           <div
-            className="emotion-11"
+            className="emotion-12"
           >
             <address>
               <span
-                className="emotion-12"
+                className="emotion-13"
               >
                 Jane Smith
               </span>
               <span
-                className="emotion-13"
+                className="emotion-14"
               >
                  Editor of things
               </span>
             </address>
           </div>
           <div
-            className="emotion-14"
+            className="emotion-15"
           >
             <div
-              className="emotion-15"
+              className="emotion-16"
             />
           </div>
           <div
-            className="emotion-16"
+            className="emotion-17"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -1241,7 +1197,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               role="button"
             >
               <button
-                className="emotion-17"
+                className="emotion-18"
                 onClick={[Function]}
               >
                 <svg
@@ -1265,16 +1221,16 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
       </section>
     </div>
     <div
-      className="emotion-18"
+      className="emotion-19"
     >
       <section
-        className="emotion-19"
+        className="emotion-20"
       >
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <figure
-          className="emotion-21"
+          className="emotion-22"
         >
           <picture>
             <source
@@ -1288,7 +1244,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow emotion-22"
+              className="js-launch-slideshow emotion-23"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -1297,18 +1253,18 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
           </picture>
         </figure>
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <div
-          className="emotion-25"
+          className="emotion-26"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="emotion-26"
+            className="emotion-27"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -1316,23 +1272,23 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               onClick={[Function]}
             >
               <span
-                className="emotion-27"
+                className="emotion-28"
               >
                 Quick Guide
               </span>
               <h4
-                className="emotion-28"
+                className="emotion-29"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="emotion-29"
+                className="emotion-30"
               >
                 <span
-                  className="emotion-30"
+                  className="emotion-31"
                 >
                   <span
-                    className="emotion-31"
+                    className="emotion-32"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -1351,7 +1307,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
             </summary>
             <div>
               <div
-                className="emotion-32"
+                className="emotion-33"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -1360,24 +1316,24 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               />
             </div>
             <footer
-              className="emotion-33"
+              className="emotion-34"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="emotion-34"
+                  className="emotion-35"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="emotion-35"
+                    className="emotion-36"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="emotion-36"
+                      className="emotion-37"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -1387,12 +1343,12 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="emotion-37"
+                    className="emotion-38"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="emotion-36"
+                      className="emotion-37"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -1404,7 +1360,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-39"
+                className="emotion-40"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -1414,19 +1370,19 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
           </details>
         </div>
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <aside
-          className="emotion-42"
+          className="emotion-43"
         >
           <blockquote
-            className="emotion-43"
+            className="emotion-44"
           >
             <p
-              className="emotion-44"
+              className="emotion-45"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -1441,17 +1397,17 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-45"
+              className="emotion-46"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
       </section>
     </div>
@@ -1521,17 +1477,31 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 .emotion-5 {
-  margin: 0;
-  position: relative;
+  grid-column-start: 0;
+  grid-column-end: span 12;
 }
 
-@media (min-width:980px) {
+@media (min-width:740px) {
   .emotion-5 {
-    width: 750px;
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
   }
 }
 
 .emotion-6 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-7 {
   width: 100vw;
   height: calc(100vw * 0.6);
   background-color: #DCDCDC;
@@ -1539,51 +1509,26 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   display: block;
   display: block;
   width: 100%;
-}
-
-@media (min-width:740px) {
-  .emotion-6 {
-    width: 740px;
-    height: calc(740px * 0.6);
-  }
-}
-
-@media (min-width:1300px) {
-  .emotion-6 {
-    width: 980px;
-    height: calc(980px * 0.6);
-  }
+  height: 100%;
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-6 {
+  .emotion-7 {
     background-color: #333333;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-6 {
-    width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-6 {
-    width: 750px;
-    height: 450px;
-  }
-}
-
-.emotion-7 {
+.emotion-8 {
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   top: 0;
+  width: 100%;
+  height: 100%;
 }
 
-.emotion-7 summary {
+.emotion-8 summary {
   text-align: center;
   background-color: #C70000;
   width: 34px;
@@ -1595,11 +1540,11 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   outline: none;
 }
 
-.emotion-7 summary::-webkit-details-marker {
+.emotion-8 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-7 details[open] {
+.emotion-8 details[open] {
   min-height: 44px;
   max-height: 999px;
   height: 100%;
@@ -1617,54 +1562,41 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 9rem;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-7 {
-    width: calc(100vw - 3.75rem);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 {
-    width: 750px;
-  }
-}
-
-.emotion-8 {
+.emotion-9 {
   line-height: 32px;
   font-size: 0;
 }
 
-.emotion-8 svg {
+.emotion-9 svg {
   width: 75%;
   height: 75%;
   margin: 12.5%;
 }
 
-.emotion-8 path {
+.emotion-9 path {
   fill: #FFF4F2;
 }
 
-.emotion-9 {
+.emotion-10 {
   position: relative;
 }
 
-.emotion-10 {
+.emotion-11 {
   color: #121212;
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -1675,7 +1607,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:375px) {
-  .emotion-10 {
+  .emotion-11 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 1.75rem;
     line-height: 1.35;
@@ -1684,7 +1616,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-10 {
+  .emotion-11 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 2.125rem;
     line-height: 1.35;
@@ -1692,11 +1624,11 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   }
 }
 
-.emotion-11 {
+.emotion-12 {
   margin: 0;
 }
 
-.emotion-11 svg {
+.emotion-12 svg {
   margin-bottom: -0.65rem;
   width: 40px;
   margin-left: -0.3rem;
@@ -1704,13 +1636,13 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-11 svg {
+  .emotion-12 svg {
     margin-bottom: -0.75rem;
     width: 50px;
   }
 }
 
-.emotion-12 {
+.emotion-13 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1725,7 +1657,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   padding-right: 6.5625rem;
 }
 
-.emotion-12 svg {
+.emotion-13 svg {
   -webkit-flex: 0 0 1.875rem;
   -ms-flex: 0 0 1.875rem;
   flex: 0 0 1.875rem;
@@ -1734,21 +1666,21 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   height: 1.875rem;
 }
 
-.emotion-12 svg circle {
+.emotion-13 svg circle {
   stroke: #C70000;
 }
 
-.emotion-12 svg path {
+.emotion-13 svg path {
   fill: #C70000;
 }
 
 @media (min-width:740px) {
-  .emotion-12 {
+  .emotion-13 {
     padding-bottom: 2.25rem;
   }
 }
 
-.emotion-13 {
+.emotion-14 {
   color: #C70000;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -1758,7 +1690,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-13 {
+  .emotion-14 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 1.75rem;
     line-height: 1.35;
@@ -1768,7 +1700,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-13 {
+  .emotion-14 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 2.125rem;
     line-height: 1.35;
@@ -1777,7 +1709,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   }
 }
 
-.emotion-14 {
+.emotion-15 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
   line-height: undefined;
@@ -1787,7 +1719,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-14 {
+  .emotion-15 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 1.75rem;
     line-height: undefined;
@@ -1797,7 +1729,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-14 {
+  .emotion-15 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 2.125rem;
     line-height: undefined;
@@ -1806,13 +1738,13 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   }
 }
 
-.emotion-15 {
+.emotion-16 {
   position: absolute;
   bottom: 0;
   right: 0;
 }
 
-.emotion-16 {
+.emotion-17 {
   width: 105px;
   height: calc(105px * 1);
   background-color: #DCDCDC;
@@ -1822,23 +1754,11 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   width: 125px;
 }
 
-.emotion-17 {
+.emotion-18 {
   box-sizing: border-box;
 }
 
-@media (min-width:740px) {
-  .emotion-17 {
-    width: 539px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-17 {
-    width: 558px;
-  }
-}
-
-.emotion-18 {
+.emotion-19 {
   background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
   background-repeat: repeat-x;
   background-position: top;
@@ -1846,7 +1766,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   height: calc(0.25rem * 3 + 1px);
 }
 
-.emotion-19 {
+.emotion-20 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.15;
@@ -1868,29 +1788,17 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   color: #767676;
 }
 
-@media (min-width:740px) {
-  .emotion-19 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-19 {
-    width: 545px;
-  }
-}
-
-.emotion-19 p,
-.emotion-19 ul {
+.emotion-20 p,
+.emotion-20 ul {
   padding-top: 0.25rem;
   margin: 0;
 }
 
-.emotion-19 address {
+.emotion-20 address {
   font-style: normal;
 }
 
-.emotion-19 svg {
+.emotion-20 svg {
   -webkit-flex: 0 0 1.875rem;
   -ms-flex: 0 0 1.875rem;
   flex: 0 0 1.875rem;
@@ -1900,15 +1808,15 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   height: 1.875rem;
 }
 
-.emotion-19 svg circle {
+.emotion-20 svg circle {
   stroke: #C70000;
 }
 
-.emotion-19 svg path {
+.emotion-20 svg path {
   fill: #C70000;
 }
 
-.emotion-20 {
+.emotion-21 {
   background: none;
   border: none;
   padding: 0;
@@ -1916,53 +1824,53 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-21 {
+  .emotion-22 {
     width: 526px;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-21 {
+  .emotion-22 {
     width: 545px;
   }
 }
 
 @media (min-width:740px) {
-  .emotion-21 {
+  .emotion-22 {
     padding-right: 0.75rem;
     border-right: 1px solid #DCDCDC;
   }
 }
 
 @media (min-width:740px) {
-  .emotion-21 {
+  .emotion-22 {
     margin-left: 24px;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-21 {
+  .emotion-22 {
     margin-left: 144px;
   }
 }
 
-.emotion-22 {
+.emotion-23 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
 
-.emotion-22 iframe {
+.emotion-23 iframe {
   width: 100%;
   border: none;
 }
 
-.emotion-22 figcaption {
+.emotion-23 figcaption {
   background: #FFFFFF;
   padding-bottom: 0.5rem;
 }
 
 @media (min-width:740px) {
-  .emotion-22 p {
+  .emotion-23 p {
     margin: 0;
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
@@ -1970,13 +1878,13 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-22 {
+  .emotion-23 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.emotion-23 {
+.emotion-24 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -1985,18 +1893,18 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.emotion-24 {
+.emotion-25 {
   margin: 1rem 0;
   width: 100%;
 }
 
 @media (min-width:660px) {
-  .emotion-24 {
+  .emotion-25 {
     width: 620px;
   }
 }
 
-.emotion-25 {
+.emotion-26 {
   width: 100%;
   height: calc(100% * 1.25);
   background-color: #DCDCDC;
@@ -2005,26 +1913,26 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:660px) {
-  .emotion-25 {
+  .emotion-26 {
     width: 620px;
     height: calc(620px * 1.25);
   }
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-25 {
+  .emotion-26 {
     background-color: #333333;
   }
 }
 
-.emotion-28 {
+.emotion-29 {
   display: block;
   position: relative;
   margin-bottom: 0.75rem;
   margin-top: 1rem;
 }
 
-.emotion-29 {
+.emotion-30 {
   margin: 16px 0 36px;
   background: #EDEDED;
   color: #121212;
@@ -2034,20 +1942,20 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   position: relative;
 }
 
-.emotion-29 summary {
+.emotion-30 summary {
   list-style: none;
   margin: 0 0 16px;
 }
 
-.emotion-29 summary::-webkit-details-marker {
+.emotion-30 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-29 summary:focus {
+.emotion-30 summary:focus {
   outline: none;
 }
 
-.emotion-30 {
+.emotion-31 {
   display: block;
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
@@ -2056,7 +1964,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   color: #C70000;
 }
 
-.emotion-31 {
+.emotion-32 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.15;
@@ -2065,7 +1973,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   line-height: 22px;
 }
 
-.emotion-32 {
+.emotion-33 {
   background: #121212;
   color: #FFFFFF;
   height: 2rem;
@@ -2089,11 +1997,11 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   margin: 0;
 }
 
-.emotion-32:hover {
+.emotion-33:hover {
   background: #C70000;
 }
 
-.emotion-33 {
+.emotion-34 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2108,7 +2016,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   font-weight: 400;
 }
 
-.emotion-34 {
+.emotion-35 {
   margin-right: 12px;
   margin-bottom: 6px;
   width: 33px;
@@ -2116,36 +2024,36 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   height: 28px;
 }
 
-.emotion-35 {
+.emotion-36 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.emotion-35 p {
+.emotion-36 p {
   margin-bottom: 0.5rem;
 }
 
-.emotion-35 ol {
+.emotion-36 ol {
   list-style: decimal;
   list-style-position: inside;
   margin-bottom: 1rem;
 }
 
-.emotion-35 ul {
+.emotion-36 ul {
   list-style: none;
   margin: 0 0 0.75rem;
   padding: 0;
   margin-bottom: 1rem;
 }
 
-.emotion-35 ul li {
+.emotion-36 ul li {
   margin-bottom: 0.375rem;
   padding-left: 1.25rem;
 }
 
-.emotion-35 ul li:before {
+.emotion-36 ul li:before {
   display: inline-block;
   content: '';
   border-radius: 0.375rem;
@@ -2156,15 +2064,15 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   margin-left: -1.25rem;
 }
 
-.emotion-35 b {
+.emotion-36 b {
   font-weight: 700;
 }
 
-.emotion-35 i {
+.emotion-36 i {
   font-style: italic;
 }
 
-.emotion-35 a {
+.emotion-36 a {
   color: #AB0613;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2173,11 +2081,11 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   transition: border-color 0.15s ease-out;
 }
 
-.emotion-35 a:hover {
+.emotion-36 a:hover {
   border-bottom: solid 0.0625rem #C70000;
 }
 
-.emotion-36 {
+.emotion-37 {
   font-size: 13px;
   line-height: 16px;
   display: -webkit-box;
@@ -2190,7 +2098,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-37 {
+.emotion-38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2205,7 +2113,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   font-weight: 400;
 }
 
-.emotion-38 {
+.emotion-39 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2229,20 +2137,20 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   height: 28px;
 }
 
-.emotion-38:hover {
+.emotion-39:hover {
   background: #C70000;
 }
 
-.emotion-38:focus {
+.emotion-39:focus {
   border: none;
 }
 
-.emotion-39 {
+.emotion-40 {
   width: 16px;
   height: 16px;
 }
 
-.emotion-40 {
+.emotion-41 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2272,15 +2180,15 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   -o-transform: rotate(180deg);
 }
 
-.emotion-40:hover {
+.emotion-41:hover {
   background: #C70000;
 }
 
-.emotion-40:focus {
+.emotion-41:focus {
   border: none;
 }
 
-.emotion-42 {
+.emotion-43 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.75rem;
   line-height: 1.5;
@@ -2288,7 +2196,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   height: 28px;
 }
 
-.emotion-45 {
+.emotion-46 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -2303,14 +2211,14 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-45 {
+  .emotion-46 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-45:before {
+.emotion-46:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -2322,7 +2230,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-45:after {
+.emotion-46:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -2332,25 +2240,25 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   border-top: 1px solid #C70000;
 }
 
-.emotion-46 {
+.emotion-47 {
   margin: 0;
 }
 
-.emotion-47 {
+.emotion-48 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-47 svg {
+.emotion-48 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #C70000;
 }
 
-.emotion-48 {
+.emotion-49 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -2373,66 +2281,70 @@ exports[`Storyshots Editions/Article Comment 1`] = `
         <header
           className="emotion-4"
         >
-          <figure
-            aria-labelledby="header-image-caption"
+          <div
             className="emotion-5"
           >
-            <picture>
-              <source
-                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-              />
-              <source
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-              />
-              <img
-                alt="image"
-                className="js-launch-slideshow js-main-image emotion-6"
-                data-ratio={0.6}
-                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-              />
-            </picture>
-            <figcaption
-              className="emotion-7"
+            <figure
+              aria-labelledby="header-image-caption"
+              className="emotion-6"
             >
-              <details>
-                <summary>
-                  <span
-                    className="emotion-8"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+                />
+                <source
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+                />
+                <img
+                  alt="image"
+                  className="js-launch-slideshow js-main-image emotion-7"
+                  data-ratio={0.6}
+                  src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+                />
+              </picture>
+              <figcaption
+                className="emotion-8"
+              >
+                <details>
+                  <summary>
+                    <span
+                      className="emotion-9"
                     >
-                      <path
-                        clipRule="evenodd"
-                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                    Click to see figure caption
+                      <svg
+                        viewBox="0 0 30 30"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                      Click to see figure caption
+                    </span>
+                  </summary>
+                  <span
+                    id="header-image-caption"
+                  >
+                    ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                     
+                    Photograph: Philip Keith/The Guardian
                   </span>
-                </summary>
-                <span
-                  id="header-image-caption"
-                >
-                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-                   
-                  Photograph: Philip Keith/The Guardian
-                </span>
-              </details>
-            </figcaption>
-          </figure>
+                </details>
+              </figcaption>
+            </figure>
+          </div>
           <div
-            className="emotion-9"
+            className="emotion-10"
           >
             <h1
-              className="emotion-10"
+              className="emotion-11"
             >
               <span
-                className="emotion-11"
+                className="emotion-12"
               >
                 <svg
                   viewBox="0 0 30 30"
@@ -2449,22 +2361,22 @@ exports[`Storyshots Editions/Article Comment 1`] = `
             </h1>
           </div>
           <div
-            className="emotion-12"
+            className="emotion-13"
           >
             <address>
               <span
-                className="emotion-13"
+                className="emotion-14"
               >
                 Jane Smith
               </span>
               <span
-                className="emotion-14"
+                className="emotion-15"
               >
                  Editor of things
               </span>
             </address>
             <div
-              className="emotion-15"
+              className="emotion-16"
             >
               <picture>
                 <source
@@ -2478,7 +2390,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
                 />
                 <img
                   alt="image"
-                  className="emotion-16"
+                  className="emotion-17"
                   data-ratio={1}
                   src="https://i.guim.co.uk/img/uploads/2017/10/06/Emma-Brockes,-L.png?width=64&quality=85&fit=bounds&s=b6b6831a7a599a815002b8a4c041342e"
                 />
@@ -2486,14 +2398,14 @@ exports[`Storyshots Editions/Article Comment 1`] = `
             </div>
           </div>
           <div
-            className="emotion-17"
+            className="emotion-18"
           >
             <div
-              className="emotion-18"
+              className="emotion-19"
             />
           </div>
           <div
-            className="emotion-19"
+            className="emotion-20"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
@@ -2503,7 +2415,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               role="button"
             >
               <button
-                className="emotion-20"
+                className="emotion-21"
                 onClick={[Function]}
               >
                 <svg
@@ -2527,16 +2439,16 @@ exports[`Storyshots Editions/Article Comment 1`] = `
       </section>
     </div>
     <div
-      className="emotion-21"
+      className="emotion-22"
     >
       <section
-        className="emotion-22"
+        className="emotion-23"
       >
         <p
-          className="emotion-23"
+          className="emotion-24"
         />
         <figure
-          className="emotion-24"
+          className="emotion-25"
         >
           <picture>
             <source
@@ -2550,7 +2462,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow emotion-25"
+              className="js-launch-slideshow emotion-26"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -2559,18 +2471,18 @@ exports[`Storyshots Editions/Article Comment 1`] = `
           </picture>
         </figure>
         <p
-          className="emotion-23"
+          className="emotion-24"
         />
         <p
-          className="emotion-23"
+          className="emotion-24"
         />
         <div
-          className="emotion-28"
+          className="emotion-29"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="emotion-29"
+            className="emotion-30"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -2578,23 +2490,23 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               onClick={[Function]}
             >
               <span
-                className="emotion-30"
+                className="emotion-31"
               >
                 Quick Guide
               </span>
               <h4
-                className="emotion-31"
+                className="emotion-32"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="emotion-32"
+                className="emotion-33"
               >
                 <span
-                  className="emotion-33"
+                  className="emotion-34"
                 >
                   <span
-                    className="emotion-34"
+                    className="emotion-35"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -2613,7 +2525,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
             </summary>
             <div>
               <div
-                className="emotion-35"
+                className="emotion-36"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -2622,24 +2534,24 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               />
             </div>
             <footer
-              className="emotion-36"
+              className="emotion-37"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="emotion-37"
+                  className="emotion-38"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="emotion-38"
+                    className="emotion-39"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="emotion-39"
+                      className="emotion-40"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -2649,12 +2561,12 @@ exports[`Storyshots Editions/Article Comment 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="emotion-40"
+                    className="emotion-41"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="emotion-39"
+                      className="emotion-40"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -2666,7 +2578,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-42"
+                className="emotion-43"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -2676,19 +2588,19 @@ exports[`Storyshots Editions/Article Comment 1`] = `
           </details>
         </div>
         <p
-          className="emotion-23"
+          className="emotion-24"
         />
         <p
-          className="emotion-23"
+          className="emotion-24"
         />
         <aside
-          className="emotion-45"
+          className="emotion-46"
         >
           <blockquote
-            className="emotion-46"
+            className="emotion-47"
           >
             <p
-              className="emotion-47"
+              className="emotion-48"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -2703,17 +2615,17 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-48"
+              className="emotion-49"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="emotion-23"
+          className="emotion-24"
         />
         <p
-          className="emotion-23"
+          className="emotion-24"
         />
       </section>
     </div>
@@ -2783,17 +2695,31 @@ exports[`Storyshots Editions/Article Default 1`] = `
 }
 
 .emotion-5 {
-  margin: 0;
-  position: relative;
+  grid-column-start: 0;
+  grid-column-end: span 12;
 }
 
-@media (min-width:980px) {
+@media (min-width:740px) {
   .emotion-5 {
-    width: 750px;
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
   }
 }
 
 .emotion-6 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-7 {
   width: 100vw;
   height: calc(100vw * 0.6);
   background-color: #F6F6F6;
@@ -2801,51 +2727,26 @@ exports[`Storyshots Editions/Article Default 1`] = `
   display: block;
   display: block;
   width: 100%;
-}
-
-@media (min-width:740px) {
-  .emotion-6 {
-    width: 740px;
-    height: calc(740px * 0.6);
-  }
-}
-
-@media (min-width:1300px) {
-  .emotion-6 {
-    width: 980px;
-    height: calc(980px * 0.6);
-  }
+  height: 100%;
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-6 {
+  .emotion-7 {
     background-color: #333333;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-6 {
-    width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-6 {
-    width: 750px;
-    height: 450px;
-  }
-}
-
-.emotion-7 {
+.emotion-8 {
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   top: 0;
+  width: 100%;
+  height: 100%;
 }
 
-.emotion-7 summary {
+.emotion-8 summary {
   text-align: center;
   background-color: #C70000;
   width: 34px;
@@ -2857,11 +2758,11 @@ exports[`Storyshots Editions/Article Default 1`] = `
   outline: none;
 }
 
-.emotion-7 summary::-webkit-details-marker {
+.emotion-8 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-7 details[open] {
+.emotion-8 details[open] {
   min-height: 44px;
   max-height: 999px;
   height: 100%;
@@ -2879,1208 +2780,32 @@ exports[`Storyshots Editions/Article Default 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 9rem;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-7 {
-    width: calc(100vw - 3.75rem);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 {
-    width: 750px;
-  }
-}
-
-.emotion-8 {
+.emotion-9 {
   line-height: 32px;
   font-size: 0;
 }
 
-.emotion-8 svg {
+.emotion-9 svg {
   width: 75%;
   height: 75%;
   margin: 12.5%;
 }
 
-.emotion-8 path {
+.emotion-9 path {
   fill: #FFF4F2;
 }
 
-.emotion-9 {
-  position: relative;
-}
-
-.emotion-10 {
-  color: #121212;
-  box-sizing: border-box;
-  border-top: 1px solid #DCDCDC;
-  padding-bottom: 1rem;
-  padding-right: 0.5rem;
-  margin: 0;
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.5rem;
-  line-height: 1.15;
-  font-weight: 500;
-}
-
-@media (min-width:375px) {
-  .emotion-10 {
-    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-    font-size: 1.75rem;
-    line-height: 1.15;
-    font-weight: 500;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-10 {
-    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-    font-size: 2.125rem;
-    line-height: 1.15;
-    font-weight: 500;
-  }
-}
-
-.emotion-11 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 400;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-bottom: 1rem;
-  color: #121212;
-}
-
-@media (min-width:740px) {
-  .emotion-11 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-11 {
-    width: 545px;
-  }
-}
-
-.emotion-11 p,
-.emotion-11 ul {
-  padding-top: 0.25rem;
-  margin: 0;
-}
-
-.emotion-11 address {
-  font-style: normal;
-}
-
-.emotion-11 svg {
-  -webkit-flex: 0 0 1.875rem;
-  -ms-flex: 0 0 1.875rem;
-  flex: 0 0 1.875rem;
-  margin-top: 0.375rem;
-  padding-left: 0.5rem;
-  width: 1.875rem;
-  height: 1.875rem;
-}
-
-.emotion-11 svg circle {
-  stroke: #C70000;
-}
-
-.emotion-11 svg path {
-  fill: #C70000;
-}
-
-.emotion-12 {
-  box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-12 {
-    width: 539px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-12 {
-    width: 558px;
-  }
-}
-
-.emotion-13 {
-  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
-  background-repeat: repeat-x;
-  background-position: top;
-  background-size: 1px calc(0.25rem * 3 + 1px);
-  height: calc(0.25rem * 3 + 1px);
-}
-
-.emotion-14 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-bottom: 1rem;
-  margin: 0;
-}
-
-.emotion-14 svg {
-  -webkit-flex: 0 0 1.875rem;
-  -ms-flex: 0 0 1.875rem;
-  flex: 0 0 1.875rem;
-  padding-top: 0.375rem;
-  width: 1.875rem;
-  height: 1.875rem;
-}
-
-.emotion-14 svg circle {
-  stroke: #C70000;
-}
-
-.emotion-14 svg path {
-  fill: #C70000;
-}
-
-@media (min-width:740px) {
-  .emotion-14 {
-    padding-bottom: 2.25rem;
-  }
-}
-
-.emotion-15 {
-  color: #C70000;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 700;
-  font-style: normal;
-}
-
-.emotion-16 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  color: #121212;
-}
-
-.emotion-17 {
-  background: none;
-  border: none;
-  padding: 0;
-  height: 2.5rem;
-}
-
-@media (min-width:740px) {
-  .emotion-18 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-18 {
-    width: 545px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-18 {
-    padding-right: 0.75rem;
-    border-right: 1px solid #DCDCDC;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-18 {
-    margin-left: 24px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-18 {
-    margin-left: 144px;
-  }
-}
-
-.emotion-19 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
-.emotion-19 iframe {
-  width: 100%;
-  border: none;
-}
-
-.emotion-19 figcaption {
-  background: #FFFFFF;
-  padding-bottom: 0.5rem;
-}
-
-@media (min-width:740px) {
-  .emotion-19 p {
-    margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-19 {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-.emotion-20 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-  overflow-wrap: break-word;
-  margin: 0 0 0.75rem;
-}
-
-.emotion-21 {
-  margin: 1rem 0;
-  width: 100%;
-}
-
-@media (min-width:660px) {
-  .emotion-21 {
-    width: 620px;
-  }
-}
-
-.emotion-22 {
-  width: 100%;
-  height: calc(100% * 1.25);
-  background-color: #F6F6F6;
-  color: #999999;
-  display: block;
-}
-
-@media (min-width:660px) {
-  .emotion-22 {
-    width: 620px;
-    height: calc(620px * 1.25);
-  }
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-22 {
-    background-color: #333333;
-  }
-}
-
-.emotion-25 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-26 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-26 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-26 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-26 summary:focus {
-  outline: none;
-}
-
-.emotion-27 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #C70000;
-}
-
-.emotion-28 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-29 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-29:hover {
-  background: #C70000;
-}
-
-.emotion-30 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-31 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-32 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-32 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-32 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-32 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-32 b {
-  font-weight: 700;
-}
-
-.emotion-32 i {
-  font-style: italic;
-}
-
-.emotion-32 a {
-  color: #AB0613;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-32 a:hover {
-  border-bottom: solid 0.0625rem #C70000;
-}
-
-.emotion-33 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-35 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-35:hover {
-  background: #C70000;
-}
-
-.emotion-35:focus {
-  border: none;
-}
-
-.emotion-36 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-37 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-37:hover {
-  background: #C70000;
-}
-
-.emotion-37:focus {
-  border: none;
-}
-
-.emotion-39 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-42 {
-  width: 10.875rem;
-  position: relative;
-  box-sizing: border-box;
-  padding: 0 0.5rem 1.5rem 0.5rem;
-  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
-  color: #C70000;
-  border: 1px solid #C70000;
-  border-top: 0.75rem solid #C70000;
-  border-bottom: none;
-  float: left;
-  clear: left;
-}
-
-@media (min-width:980px) {
-  .emotion-42 {
-    float: right;
-    clear: right;
-    margin-right: calc(-10.875rem - 2.5rem);
-  }
-}
-
-.emotion-42:before {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: -1px;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 1px solid #C70000;
-  border-top: none;
-  border-radius: 0 0 100% 0;
-}
-
-.emotion-42:after {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: calc(1.5rem + 1px);
-  width: calc(100% - 1.5rem);
-  height: 1px;
-  border-top: 1px solid #C70000;
-}
-
-.emotion-43 {
-  margin: 0;
-}
-
-.emotion-44 {
-  margin: 0;
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.25rem;
-  line-height: 1.15;
-}
-
-.emotion-44 svg {
-  margin-bottom: -0.6rem;
-  height: 2rem;
-  margin-left: -0.3rem;
-  fill: #C70000;
-}
-
-.emotion-45 {
-  font-style: normal;
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.25rem;
-  line-height: 1.15;
-  font-weight: 700;
-}
-
-<main
-  className="emotion-0"
->
-  <article
-    className="emotion-1"
-  >
-    <div
-      className="emotion-2"
-    >
-      <section
-        className="emotion-3"
-      >
-        <header
-          className="emotion-4"
-        >
-          <figure
-            aria-labelledby="header-image-caption"
-            className="emotion-5"
-          >
-            <picture>
-              <source
-                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-              />
-              <source
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-              />
-              <img
-                alt="image"
-                className="js-launch-slideshow js-main-image emotion-6"
-                data-ratio={0.6}
-                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-              />
-            </picture>
-            <figcaption
-              className="emotion-7"
-            >
-              <details>
-                <summary>
-                  <span
-                    className="emotion-8"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                    Click to see figure caption
-                  </span>
-                </summary>
-                <span
-                  id="header-image-caption"
-                >
-                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-                   
-                  Photograph: Philip Keith/The Guardian
-                </span>
-              </details>
-            </figcaption>
-          </figure>
-          <div
-            className="emotion-9"
-          >
-            <h1
-              className="emotion-10"
-            >
-              Reclaimed lakes and giant airports: how Mexico City might have looked
-            </h1>
-          </div>
-          <div
-            className="emotion-11"
-          >
-            <p>
-              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
-            </p>
-          </div>
-          <div
-            className="emotion-12"
-          >
-            <div
-              className="emotion-13"
-            />
-          </div>
-          <div
-            className="emotion-14"
-          >
-            <address>
-              <span
-                className="emotion-15"
-              >
-                Jane Smith
-              </span>
-              <span
-                className="emotion-16"
-              >
-                 Editor of things
-              </span>
-            </address>
-            <span
-              className="js-share-button"
-              role="button"
-            >
-              <button
-                className="emotion-17"
-                onClick={[Function]}
-              >
-                <svg
-                  fill="none"
-                  viewBox="0 0 30 30"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="15"
-                    cy="15"
-                    r="14.5"
-                  />
-                  <path
-                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
-                  />
-                </svg>
-              </button>
-            </span>
-          </div>
-        </header>
-      </section>
-    </div>
-    <div
-      className="emotion-18"
-    >
-      <section
-        className="emotion-19"
-      >
-        <p
-          className="emotion-20"
-        />
-        <figure
-          className="emotion-21"
-        >
-          <picture>
-            <source
-              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-              sizes="(min-width: 660px) 620px, 100%"
-              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
-            />
-            <source
-              sizes="(min-width: 660px) 620px, 100%"
-              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
-            />
-            <img
-              alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow emotion-22"
-              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
-              data-credit="Photograph: Sam Frost/The Guardian"
-              data-ratio={1.25}
-              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
-            />
-          </picture>
-        </figure>
-        <p
-          className="emotion-20"
-        />
-        <p
-          className="emotion-20"
-        />
-        <div
-          className="emotion-25"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-26"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-27"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-28"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-29"
-              >
-                <span
-                  className="emotion-30"
-                >
-                  <span
-                    className="emotion-31"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-32"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-33"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-34"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-35"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-37"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-39"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
-        <p
-          className="emotion-20"
-        />
-        <p
-          className="emotion-20"
-        />
-        <aside
-          className="emotion-42"
-        >
-          <blockquote
-            className="emotion-43"
-          >
-            <p
-              className="emotion-44"
-            >
-              <svg
-                viewBox="0 0 30 30"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  clipRule="evenodd"
-                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
-                  fillRule="evenodd"
-                />
-              </svg>
-              Why should the crown be allowed to carry on with a feudal system just because they want to?
-            </p>
-            <cite
-              className="emotion-45"
-            >
-              Jane Giddins
-            </cite>
-          </blockquote>
-        </aside>
-        <p
-          className="emotion-20"
-        />
-        <p
-          className="emotion-20"
-        />
-      </section>
-    </div>
-  </article>
-</main>
-`;
-
-exports[`Storyshots Editions/Article Editorial 1`] = `
-.emotion-0 {
-  height: 100%;
-}
-
-.emotion-1 {
-  min-height: 100%;
-  background-color: inherit;
-}
-
-.emotion-2 {
-  background-color: #FFFFFF;
-}
-
-.emotion-3 {
-  border-bottom: 1px solid #DCDCDC;
-}
-
-@media (min-width:740px) {
-  .emotion-3 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-3 {
-    width: 545px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-3 {
-    padding-right: 0.75rem;
-    border-right: 1px solid #DCDCDC;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-3 {
-    margin-left: 24px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-3 {
-    margin-left: 144px;
-  }
-}
-
-.emotion-4 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
-@media (min-width:740px) {
-  .emotion-4 {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-.emotion-5 {
-  margin: 0;
-  position: relative;
-}
-
-@media (min-width:980px) {
-  .emotion-5 {
-    width: 750px;
-  }
-}
-
-.emotion-6 {
-  width: 100vw;
-  height: calc(100vw * 0.6);
-  background-color: #F6F6F6;
-  color: #999999;
-  display: block;
-  display: block;
-  width: 100%;
-}
-
-@media (min-width:740px) {
-  .emotion-6 {
-    width: 740px;
-    height: calc(740px * 0.6);
-  }
-}
-
-@media (min-width:1300px) {
-  .emotion-6 {
-    width: 980px;
-    height: calc(980px * 0.6);
-  }
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-6 {
-    background-color: #333333;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-6 {
-    width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-6 {
-    width: 750px;
-    height: 450px;
-  }
-}
-
-.emotion-7 {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 0;
-}
-
-.emotion-7 summary {
-  text-align: center;
-  background-color: #E05E00;
-  width: 34px;
-  height: 34px;
-  position: absolute;
-  bottom: 0.75rem;
-  right: 0.75rem;
-  border-radius: 100%;
-  outline: none;
-}
-
-.emotion-7 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-7 details[open] {
-  min-height: 44px;
-  max-height: 999px;
-  height: 100%;
-  background-color: rgba(0,0,0,0.8);
-  padding: 0.5rem;
-  overflow: hidden;
-  padding-right: 3rem;
-  z-index: 1;
-  color: #FFFFFF;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-  box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-7 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 details[open] {
-    padding-left: 9rem;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-7 {
-    width: calc(100vw - 3.75rem);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 {
-    width: 750px;
-  }
-}
-
-.emotion-8 {
-  line-height: 32px;
-  font-size: 0;
-}
-
-.emotion-8 svg {
-  width: 75%;
-  height: 75%;
-  margin: 12.5%;
-}
-
-.emotion-8 path {
-  fill: #FEF9F5;
-}
-
-.emotion-9 {
-  box-sizing: border-box;
-  font-family: GT Guardian Titlepiece,Georgia,serif;
-  font-size: 2.625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #E05E00;
-  font-size: 1.0625rem;
-  padding: 0.25rem 0 0.5rem;
-  box-sizing: border-box;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-}
-
-@media (min-width:740px) {
-  .emotion-9 {
-    padding-bottom: 0.75rem;
-  }
-}
-
 .emotion-10 {
   position: relative;
 }
@@ -4090,7 +2815,6 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -4131,18 +2855,6 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   justify-content: space-between;
   padding-bottom: 1rem;
   color: #121212;
-}
-
-@media (min-width:740px) {
-  .emotion-12 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-12 {
-    width: 545px;
-  }
 }
 
 .emotion-12 p,
@@ -4166,27 +2878,15 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-12 svg circle {
-  stroke: #E05E00;
+  stroke: #C70000;
 }
 
 .emotion-12 svg path {
-  fill: #E05E00;
+  fill: #C70000;
 }
 
 .emotion-13 {
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-13 {
-    width: 539px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-13 {
-    width: 558px;
-  }
 }
 
 .emotion-14 {
@@ -4221,11 +2921,11 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-15 svg circle {
-  stroke: #E05E00;
+  stroke: #C70000;
 }
 
 .emotion-15 svg path {
-  fill: #E05E00;
+  fill: #C70000;
 }
 
 @media (min-width:740px) {
@@ -4235,7 +2935,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-16 {
-  color: #E05E00;
+  color: #C70000;
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -4395,7 +3095,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   font-size: 1.0625rem;
   line-height: 1.15;
   font-weight: 700;
-  color: #E05E00;
+  color: #C70000;
 }
 
 .emotion-29 {
@@ -4432,7 +3132,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-30:hover {
-  background: #E05E00;
+  background: #C70000;
 }
 
 .emotion-31 {
@@ -4507,7 +3207,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-33 a {
-  color: #CB4700;
+  color: #AB0613;
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: 0.0625rem solid #DCDCDC;
@@ -4516,7 +3216,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-33 a:hover {
-  border-bottom: solid 0.0625rem #E05E00;
+  border-bottom: solid 0.0625rem #C70000;
 }
 
 .emotion-34 {
@@ -4572,7 +3272,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-36:hover {
-  background: #E05E00;
+  background: #C70000;
 }
 
 .emotion-36:focus {
@@ -4615,7 +3315,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-38:hover {
-  background: #E05E00;
+  background: #C70000;
 }
 
 .emotion-38:focus {
@@ -4636,9 +3336,9 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   box-sizing: border-box;
   padding: 0 0.5rem 1.5rem 0.5rem;
   margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
-  color: #E05E00;
-  border: 1px solid #E05E00;
-  border-top: 0.75rem solid #E05E00;
+  color: #C70000;
+  border: 1px solid #C70000;
+  border-top: 0.75rem solid #C70000;
   border-bottom: none;
   float: left;
   clear: left;
@@ -4659,7 +3359,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   left: -1px;
   width: 1.5rem;
   height: 1.5rem;
-  border: 1px solid #E05E00;
+  border: 1px solid #C70000;
   border-top: none;
   border-radius: 0 0 100% 0;
 }
@@ -4671,7 +3371,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   left: calc(1.5rem + 1px);
   width: calc(100% - 1.5rem);
   height: 1px;
-  border-top: 1px solid #E05E00;
+  border-top: 1px solid #C70000;
 }
 
 .emotion-44 {
@@ -4689,7 +3389,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
-  fill: #E05E00;
+  fill: #C70000;
 }
 
 .emotion-46 {
@@ -4715,63 +3415,62 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
         <header
           className="emotion-4"
         >
-          <figure
-            aria-labelledby="header-image-caption"
+          <div
             className="emotion-5"
           >
-            <picture>
-              <source
-                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-              />
-              <source
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-              />
-              <img
-                alt="image"
-                className="js-launch-slideshow js-main-image emotion-6"
-                data-ratio={0.6}
-                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-              />
-            </picture>
-            <figcaption
-              className="emotion-7"
+            <figure
+              aria-labelledby="header-image-caption"
+              className="emotion-6"
             >
-              <details>
-                <summary>
-                  <span
-                    className="emotion-8"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+                />
+                <source
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+                />
+                <img
+                  alt="image"
+                  className="js-launch-slideshow js-main-image emotion-7"
+                  data-ratio={0.6}
+                  src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+                />
+              </picture>
+              <figcaption
+                className="emotion-8"
+              >
+                <details>
+                  <summary>
+                    <span
+                      className="emotion-9"
                     >
-                      <path
-                        clipRule="evenodd"
-                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                    Click to see figure caption
+                      <svg
+                        viewBox="0 0 30 30"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                      Click to see figure caption
+                    </span>
+                  </summary>
+                  <span
+                    id="header-image-caption"
+                  >
+                    ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                     
+                    Photograph: Philip Keith/The Guardian
                   </span>
-                </summary>
-                <span
-                  id="header-image-caption"
-                >
-                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-                   
-                  Photograph: Philip Keith/The Guardian
-                </span>
-              </details>
-            </figcaption>
-          </figure>
-          <nav
-            className="emotion-9"
-          >
-            View from the Guardian
-          </nav>
+                </details>
+              </figcaption>
+            </figure>
+          </div>
           <div
             className="emotion-10"
           >
@@ -5033,7 +3732,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 </main>
 `;
 
-exports[`Storyshots Editions/Article Feature 1`] = `
+exports[`Storyshots Editions/Article Editorial 1`] = `
 .emotion-0 {
   height: 100%;
 }
@@ -5095,1135 +3794,48 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 }
 
 .emotion-5 {
-  margin: 0;
-  position: relative;
-}
-
-@media (min-width:980px) {
-  .emotion-5 {
-    width: 750px;
-  }
-}
-
-.emotion-6 {
-  width: 100vw;
-  height: calc(100vw * 0.6);
-  background-color: #F6F6F6;
-  color: #999999;
-  display: block;
-  display: block;
-  width: 100%;
+  grid-column-start: 0;
+  grid-column-end: span 12;
 }
 
 @media (min-width:740px) {
-  .emotion-6 {
-    width: 740px;
-    height: calc(740px * 0.6);
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
   }
 }
 
 @media (min-width:1300px) {
-  .emotion-6 {
-    width: 980px;
-    height: calc(980px * 0.6);
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
   }
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-6 {
-    background-color: #333333;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-6 {
-    width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-6 {
-    width: 750px;
-    height: 450px;
-  }
-}
-
-.emotion-7 {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 0;
-}
-
-.emotion-7 summary {
-  text-align: center;
-  background-color: #0084C6;
-  width: 34px;
-  height: 34px;
-  position: absolute;
-  bottom: 0.75rem;
-  right: 0.75rem;
-  border-radius: 100%;
-  outline: none;
-}
-
-.emotion-7 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-7 details[open] {
-  min-height: 44px;
-  max-height: 999px;
-  height: 100%;
-  background-color: rgba(0,0,0,0.8);
-  padding: 0.5rem;
-  overflow: hidden;
-  padding-right: 3rem;
-  z-index: 1;
-  color: #FFFFFF;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-  box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-7 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 details[open] {
-    padding-left: 9rem;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-7 {
-    width: calc(100vw - 3.75rem);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 {
-    width: 750px;
-  }
-}
-
-.emotion-8 {
-  line-height: 32px;
-  font-size: 0;
-}
-
-.emotion-8 svg {
-  width: 75%;
-  height: 75%;
-  margin: 12.5%;
-}
-
-.emotion-8 path {
-  fill: #F1F8FC;
-}
-
-.emotion-9 {
-  position: relative;
-}
-
-.emotion-10 {
-  color: #005689;
-  box-sizing: border-box;
-  border-top: 1px solid #DCDCDC;
-  padding-bottom: 1rem;
-  padding-right: 0.5rem;
-  margin: 0;
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.5rem;
-  line-height: 1.15;
-  font-weight: 500;
-}
-
-@media (min-width:375px) {
-  .emotion-10 {
-    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-    font-size: 1.75rem;
-    line-height: 1.15;
-    font-weight: 500;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-10 {
-    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-    font-size: 2.125rem;
-    line-height: 1.15;
-    font-weight: 500;
-  }
-}
-
-.emotion-11 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 400;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-bottom: 1rem;
-  color: #121212;
-}
-
-@media (min-width:740px) {
-  .emotion-11 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-11 {
-    width: 545px;
-  }
-}
-
-.emotion-11 p,
-.emotion-11 ul {
-  padding-top: 0.25rem;
-  margin: 0;
-}
-
-.emotion-11 address {
-  font-style: normal;
-}
-
-.emotion-11 svg {
-  -webkit-flex: 0 0 1.875rem;
-  -ms-flex: 0 0 1.875rem;
-  flex: 0 0 1.875rem;
-  margin-top: 0.375rem;
-  padding-left: 0.5rem;
-  width: 1.875rem;
-  height: 1.875rem;
-}
-
-.emotion-11 svg circle {
-  stroke: #0084C6;
-}
-
-.emotion-11 svg path {
-  fill: #0084C6;
-}
-
-.emotion-12 {
-  box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-12 {
-    width: 539px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-12 {
-    width: 558px;
-  }
-}
-
-.emotion-13 {
-  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
-  background-repeat: repeat-x;
-  background-position: top;
-  background-size: 1px calc(0.25rem * 3 + 1px);
-  height: calc(0.25rem * 3 + 1px);
-}
-
-.emotion-14 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-bottom: 1rem;
-  margin: 0;
-}
-
-.emotion-14 svg {
-  -webkit-flex: 0 0 1.875rem;
-  -ms-flex: 0 0 1.875rem;
-  flex: 0 0 1.875rem;
-  padding-top: 0.375rem;
-  width: 1.875rem;
-  height: 1.875rem;
-}
-
-.emotion-14 svg circle {
-  stroke: #0084C6;
-}
-
-.emotion-14 svg path {
-  fill: #0084C6;
-}
-
-@media (min-width:740px) {
-  .emotion-14 {
-    padding-bottom: 2.25rem;
-  }
-}
-
-.emotion-15 {
-  color: #0084C6;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 700;
-  font-style: normal;
-}
-
-.emotion-16 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  color: #121212;
-}
-
-.emotion-17 {
-  background: none;
-  border: none;
-  padding: 0;
-  height: 2.5rem;
-}
-
-@media (min-width:740px) {
-  .emotion-18 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-18 {
-    width: 545px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-18 {
-    padding-right: 0.75rem;
-    border-right: 1px solid #DCDCDC;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-18 {
-    margin-left: 24px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-18 {
-    margin-left: 144px;
-  }
-}
-
-.emotion-19 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
-.emotion-19 iframe {
-  width: 100%;
-  border: none;
-}
-
-.emotion-19 figcaption {
-  background: #FFFFFF;
-  padding-bottom: 0.5rem;
-}
-
-@media (min-width:740px) {
-  .emotion-19 p {
-    margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-19 {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-.emotion-20 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-  overflow-wrap: break-word;
-  margin: 0 0 0.75rem;
-}
-
-.emotion-21 {
-  margin: 1rem 0;
-  width: 100%;
-}
-
-@media (min-width:660px) {
-  .emotion-21 {
-    width: 620px;
-  }
-}
-
-.emotion-22 {
-  width: 100%;
-  height: calc(100% * 1.25);
-  background-color: #F6F6F6;
-  color: #999999;
-  display: block;
-}
-
-@media (min-width:660px) {
-  .emotion-22 {
-    width: 620px;
-    height: calc(620px * 1.25);
-  }
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-22 {
-    background-color: #333333;
-  }
-}
-
-.emotion-25 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-26 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-26 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-26 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-26 summary:focus {
-  outline: none;
-}
-
-.emotion-27 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #0084C6;
-}
-
-.emotion-28 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-29 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-29:hover {
-  background: #0084C6;
-}
-
-.emotion-30 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-31 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-32 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-32 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-32 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-32 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-32 b {
-  font-weight: 700;
-}
-
-.emotion-32 i {
-  font-style: italic;
-}
-
-.emotion-32 a {
-  color: #005689;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-32 a:hover {
-  border-bottom: solid 0.0625rem #0084C6;
-}
-
-.emotion-33 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-35 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-35:hover {
-  background: #0084C6;
-}
-
-.emotion-35:focus {
-  border: none;
-}
-
-.emotion-36 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-37 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-37:hover {
-  background: #0084C6;
-}
-
-.emotion-37:focus {
-  border: none;
-}
-
-.emotion-39 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-42 {
-  width: 10.875rem;
-  position: relative;
-  box-sizing: border-box;
-  padding: 0 0.5rem 1.5rem 0.5rem;
-  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
-  color: #0084C6;
-  border: 1px solid #0084C6;
-  border-top: 0.75rem solid #0084C6;
-  border-bottom: none;
-  float: left;
-  clear: left;
-}
-
-@media (min-width:980px) {
-  .emotion-42 {
-    float: right;
-    clear: right;
-    margin-right: calc(-10.875rem - 2.5rem);
-  }
-}
-
-.emotion-42:before {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: -1px;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 1px solid #0084C6;
-  border-top: none;
-  border-radius: 0 0 100% 0;
-}
-
-.emotion-42:after {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: calc(1.5rem + 1px);
-  width: calc(100% - 1.5rem);
-  height: 1px;
-  border-top: 1px solid #0084C6;
-}
-
-.emotion-43 {
-  margin: 0;
-}
-
-.emotion-44 {
-  margin: 0;
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.25rem;
-  line-height: 1.15;
-}
-
-.emotion-44 svg {
-  margin-bottom: -0.6rem;
-  height: 2rem;
-  margin-left: -0.3rem;
-  fill: #0084C6;
-}
-
-.emotion-45 {
-  font-style: normal;
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.25rem;
-  line-height: 1.15;
-  font-weight: 700;
-}
-
-<main
-  className="emotion-0"
->
-  <article
-    className="emotion-1"
-  >
-    <div
-      className="emotion-2"
-    >
-      <section
-        className="emotion-3"
-      >
-        <header
-          className="emotion-4"
-        >
-          <figure
-            aria-labelledby="header-image-caption"
-            className="emotion-5"
-          >
-            <picture>
-              <source
-                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-              />
-              <source
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-              />
-              <img
-                alt="image"
-                className="js-launch-slideshow js-main-image emotion-6"
-                data-ratio={0.6}
-                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-              />
-            </picture>
-            <figcaption
-              className="emotion-7"
-            >
-              <details>
-                <summary>
-                  <span
-                    className="emotion-8"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                    Click to see figure caption
-                  </span>
-                </summary>
-                <span
-                  id="header-image-caption"
-                >
-                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-                   
-                  Photograph: Philip Keith/The Guardian
-                </span>
-              </details>
-            </figcaption>
-          </figure>
-          <div
-            className="emotion-9"
-          >
-            <h1
-              className="emotion-10"
-            >
-              Reclaimed lakes and giant airports: how Mexico City might have looked
-            </h1>
-          </div>
-          <div
-            className="emotion-11"
-          >
-            <p>
-              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
-            </p>
-          </div>
-          <div
-            className="emotion-12"
-          >
-            <div
-              className="emotion-13"
-            />
-          </div>
-          <div
-            className="emotion-14"
-          >
-            <address>
-              <span
-                className="emotion-15"
-              >
-                Jane Smith
-              </span>
-              <span
-                className="emotion-16"
-              >
-                 Editor of things
-              </span>
-            </address>
-            <span
-              className="js-share-button"
-              role="button"
-            >
-              <button
-                className="emotion-17"
-                onClick={[Function]}
-              >
-                <svg
-                  fill="none"
-                  viewBox="0 0 30 30"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="15"
-                    cy="15"
-                    r="14.5"
-                  />
-                  <path
-                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
-                  />
-                </svg>
-              </button>
-            </span>
-          </div>
-        </header>
-      </section>
-    </div>
-    <div
-      className="emotion-18"
-    >
-      <section
-        className="emotion-19"
-      >
-        <p
-          className="emotion-20"
-        />
-        <figure
-          className="emotion-21"
-        >
-          <picture>
-            <source
-              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-              sizes="(min-width: 660px) 620px, 100%"
-              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
-            />
-            <source
-              sizes="(min-width: 660px) 620px, 100%"
-              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
-            />
-            <img
-              alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow emotion-22"
-              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
-              data-credit="Photograph: Sam Frost/The Guardian"
-              data-ratio={1.25}
-              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
-            />
-          </picture>
-        </figure>
-        <p
-          className="emotion-20"
-        />
-        <p
-          className="emotion-20"
-        />
-        <div
-          className="emotion-25"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-26"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-27"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-28"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-29"
-              >
-                <span
-                  className="emotion-30"
-                >
-                  <span
-                    className="emotion-31"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-32"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-33"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-34"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-35"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-37"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-39"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
-        <p
-          className="emotion-20"
-        />
-        <p
-          className="emotion-20"
-        />
-        <aside
-          className="emotion-42"
-        >
-          <blockquote
-            className="emotion-43"
-          >
-            <p
-              className="emotion-44"
-            >
-              <svg
-                viewBox="0 0 30 30"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  clipRule="evenodd"
-                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
-                  fillRule="evenodd"
-                />
-              </svg>
-              Why should the crown be allowed to carry on with a feudal system just because they want to?
-            </p>
-            <cite
-              className="emotion-45"
-            >
-              Jane Giddins
-            </cite>
-          </blockquote>
-        </aside>
-        <p
-          className="emotion-20"
-        />
-        <p
-          className="emotion-20"
-        />
-      </section>
-    </div>
-  </article>
-</main>
-`;
-
-exports[`Storyshots Editions/Article Gallery 1`] = `
-.emotion-0 {
-  height: 100%;
-}
-
-.emotion-1 {
-  min-height: 100%;
-  background-color: #121212;
-}
-
-.emotion-2 {
-  background-color: #121212;
-}
-
-.emotion-4 {
-  border-bottom: 1px solid #FFFFFF;
-}
-
-@media (min-width:740px) {
-  .emotion-4 {
-    border: none;
-  }
-}
-
-.emotion-5 {
-  margin: 0;
-  position: relative;
-  width: 100%;
 }
 
 .emotion-6 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-7 {
   width: 100vw;
   height: calc(100vw * 0.6);
-  background-color: #333333;
+  background-color: #F6F6F6;
   color: #999999;
   display: block;
   display: block;
   width: 100%;
-  height: calc(100vw * 0.6);
+  height: 100%;
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-6 {
+  .emotion-7 {
     background-color: #333333;
   }
 }
 
-.emotion-7 {
+.emotion-8 {
   position: absolute;
   left: 0;
   right: 0;
@@ -6233,9 +3845,9 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
   height: 100%;
 }
 
-.emotion-7 summary {
+.emotion-8 summary {
   text-align: center;
-  background-color: #C70000;
+  background-color: #E05E00;
   width: 34px;
   height: 34px;
   position: absolute;
@@ -6245,11 +3857,11 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
   outline: none;
 }
 
-.emotion-7 summary::-webkit-details-marker {
+.emotion-8 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-7 details[open] {
+.emotion-8 details[open] {
   min-height: 44px;
   max-height: 999px;
   height: 100%;
@@ -6267,964 +3879,75 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 9rem;
   }
 }
 
-.emotion-8 {
+.emotion-9 {
   line-height: 32px;
   font-size: 0;
 }
 
-.emotion-8 svg {
+.emotion-9 svg {
   width: 75%;
   height: 75%;
   margin: 12.5%;
 }
 
-.emotion-8 path {
-  fill: #FFF4F2;
-}
-
-.emotion-9 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
-@media (min-width:740px) {
-  .emotion-9 {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-9 {
-    padding-left: 24px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-9 {
-    padding-left: 144px;
-  }
+.emotion-9 path {
+  fill: #FEF9F5;
 }
 
 .emotion-10 {
-  position: relative;
-}
-
-.emotion-11 {
-  color: #FFFFFF;
   box-sizing: border-box;
-  border-top: 1px solid #DCDCDC;
-  padding-bottom: 1rem;
-  padding-right: 0.5rem;
-  margin: 0;
   font-family: GT Guardian Titlepiece,Georgia,serif;
   font-size: 2.625rem;
   line-height: 1.15;
   font-weight: 700;
-  font-size: 2rem;
-  line-height: 1.2;
-  padding-bottom: 1.5rem;
-  background-color: #121212;
-  border: 0;
-}
-
-@media (min-width:740px) {
-  .emotion-11 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-11 {
-    width: 545px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-12 {
-    border-bottom: 1px solid #FFFFFF;
-    border-right: 1px solid #FFFFFF;
-    box-sizing: border-box;
-    width: 538px;
-  }
-
-  @media (min-width:980px) {
-    .emotion-12 {
-      width: 557px;
-    }
-  }
-}
-
-.emotion-13 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  color: #E05E00;
   font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 400;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-bottom: 1rem;
-  color: #121212;
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.25rem;
-  line-height: 1.15;
-  color: #FFFFFF;
-}
-
-@media (min-width:740px) {
-  .emotion-13 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-13 {
-    width: 545px;
-  }
-}
-
-.emotion-13 p,
-.emotion-13 ul {
-  padding-top: 0.25rem;
-  margin: 0;
-}
-
-.emotion-13 address {
-  font-style: normal;
-}
-
-.emotion-13 svg {
-  -webkit-flex: 0 0 1.875rem;
-  -ms-flex: 0 0 1.875rem;
-  flex: 0 0 1.875rem;
-  margin-top: 0.375rem;
-  padding-left: 0.5rem;
-  width: 1.875rem;
-  height: 1.875rem;
-}
-
-.emotion-13 svg circle {
-  stroke: #C70000;
-}
-
-.emotion-13 svg path {
-  fill: #C70000;
-}
-
-.emotion-14 {
+  padding: 0.25rem 0 0.5rem;
   box-sizing: border-box;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
 }
 
 @media (min-width:740px) {
-  .emotion-14 {
-    width: 539px;
+  .emotion-10 {
+    padding-bottom: 0.75rem;
   }
-}
-
-@media (min-width:980px) {
-  .emotion-14 {
-    width: 558px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-14 {
-    margin-left: 0;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-14 {
-    margin-left: 0;
-  }
-}
-
-.emotion-15 {
-  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
-  background-repeat: repeat-x;
-  background-position: top;
-  background-size: 1px calc(0.25rem * 3 + 1px);
-  height: calc(0.25rem * 3 + 1px);
-}
-
-.emotion-16 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-bottom: 1rem;
-  margin: 0;
-}
-
-.emotion-16 svg {
-  -webkit-flex: 0 0 1.875rem;
-  -ms-flex: 0 0 1.875rem;
-  flex: 0 0 1.875rem;
-  padding-top: 0.375rem;
-  width: 1.875rem;
-  height: 1.875rem;
-}
-
-.emotion-16 svg circle {
-  stroke: #FFFFFF;
-}
-
-.emotion-16 svg path {
-  fill: #FFFFFF;
-}
-
-@media (min-width:740px) {
-  .emotion-16 {
-    padding-bottom: 2.25rem;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-16 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-16 {
-    width: 545px;
-  }
-}
-
-.emotion-17 {
-  color: #FFFFFF;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 700;
-  font-style: normal;
-}
-
-.emotion-18 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  color: #FFFFFF;
-}
-
-.emotion-19 {
-  background: none;
-  border: none;
-  padding: 0;
-  height: 2.5rem;
-}
-
-.emotion-20 {
-  box-sizing: border-box;
-  padding-top: 0.75rem;
-  padding-right: 0;
-  padding-left: 0;
-  border: none;
-}
-
-@media (min-width:740px) {
-  .emotion-20 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-20 {
-    width: 545px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-20 {
-    padding-right: 0.75rem;
-    border-right: 1px solid #DCDCDC;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-20 {
-    margin-left: 24px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-20 {
-    margin-left: 144px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-20 {
-    width: 538px;
-    padding-right: 1rem;
-    border-right: 1px solid #FFFFFF;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-20 {
-    width: 557px;
-  }
-}
-
-.emotion-21 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
-.emotion-21 iframe {
-  width: 100%;
-  border: none;
-}
-
-.emotion-21 figcaption {
-  background: #FFFFFF;
-  padding-bottom: 0.5rem;
-}
-
-@media (min-width:740px) {
-  .emotion-21 p {
-    margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-21 {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-.emotion-22 {
-  margin: 0 0 1.5rem;
-  width: 100%;
-  position: relative;
-}
-
-@media (min-width:740px) {
-  .emotion-22 p {
-    margin: 0;
-    padding: 0;
-  }
-}
-
-.emotion-23 {
-  width: 100%;
-  height: calc(100% * 0.6666081768731357);
-  background-color: #333333;
-  color: #999999;
-  display: block;
-}
-
-@media (min-width:740px) {
-  .emotion-24 {
-    position: absolute;
-    top: -0.25rem;
-    width: 170px;
-    right: calc(-170px - 2rem);
-  }
-}
-
-.emotion-25 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 700;
-  color: #FFFFFF;
-  margin: 0;
-  padding: 0.25rem 0 0;
-}
-
-@media (min-width:740px) {
-  .emotion-25 {
-    padding: 0;
-  }
-
-  .emotion-25 svg {
-    -webkit-transform: translateX(-10%) translateY(-15%) rotateZ(-90deg);
-    -ms-transform: translateX(-10%) translateY(-15%) rotateZ(-90deg);
-    transform: translateX(-10%) translateY(-15%) rotateZ(-90deg);
-  }
-}
-
-.emotion-26 {
-  fill: #C70000;
-  height: 0.6875rem;
-  width: 0.8125rem;
-  padding-right: 0.25rem;
-}
-
-.emotion-27 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.35;
-  font-weight: 400;
-  color: #FFFFFF;
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-29 {
-  width: 100%;
-  height: calc(100% * 0.6666666666666666);
-  background-color: #333333;
-  color: #999999;
-  display: block;
-}
-
-<main
-  className="emotion-0"
->
-  <article
-    className="emotion-1"
-  >
-    <div
-      className="emotion-2"
-    >
-      <section
-        className="emotion-3"
-      >
-        <header
-          className="emotion-4"
-        >
-          <figure
-            aria-labelledby="header-image-caption"
-            className="emotion-5"
-          >
-            <picture>
-              <source
-                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-                sizes="100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-              />
-              <source
-                sizes="100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-              />
-              <img
-                alt="image"
-                className="js-launch-slideshow js-main-image emotion-6"
-                data-ratio={0.6}
-                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-              />
-            </picture>
-            <figcaption
-              className="emotion-7"
-            >
-              <details>
-                <summary>
-                  <span
-                    className="emotion-8"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                    Click to see figure caption
-                  </span>
-                </summary>
-                <span
-                  id="header-image-caption"
-                >
-                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-                   
-                  Photograph: Philip Keith/The Guardian
-                </span>
-              </details>
-            </figcaption>
-          </figure>
-          <div
-            className="emotion-9"
-          >
-            <div
-              className="emotion-10"
-            >
-              <h1
-                className="emotion-11"
-              >
-                Reclaimed lakes and giant airports: how Mexico City might have looked
-              </h1>
-            </div>
-            <div
-              className="emotion-12"
-            >
-              <div
-                className="emotion-13"
-              >
-                <p>
-                  The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
-                </p>
-              </div>
-              <div
-                className="emotion-14"
-              >
-                <div
-                  className="emotion-15"
-                />
-              </div>
-              <div
-                className="emotion-16"
-              >
-                <address>
-                  <span
-                    className="emotion-17"
-                  >
-                    Jane Smith
-                  </span>
-                  <span
-                    className="emotion-18"
-                  >
-                     Editor of things
-                  </span>
-                </address>
-                <span
-                  className="js-share-button"
-                  role="button"
-                >
-                  <button
-                    className="emotion-19"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      fill="none"
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <circle
-                        cx="15"
-                        cy="15"
-                        r="14.5"
-                      />
-                      <path
-                        d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
-                      />
-                    </svg>
-                  </button>
-                </span>
-              </div>
-            </div>
-          </div>
-        </header>
-      </section>
-    </div>
-    <div
-      className="emotion-20"
-    >
-      <section
-        className="emotion-21"
-      >
-        <figure
-          className="editions-gallery-figure emotion-22"
-        >
-          <picture>
-            <source
-              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-              sizes="100%"
-              srcSet="https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=45&fit=bounds&s=253ff45edb114b0605b7bce66b7f78f3 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=45&fit=bounds&s=3be9e2a7e7f1b2ac4efab144d6c07a28 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=45&fit=bounds&s=14c3c8f7d54a8d8794664492efc68641 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=45&fit=bounds&s=2745788813a433224e06421647d60b2c 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=45&fit=bounds&s=dcdc2c3d03aee717124c58914a5c39de 2000w"
-            />
-            <source
-              sizes="100%"
-              srcSet="https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=85&fit=bounds&s=c125868b875fa9ec4a8ce180360836e0 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=85&fit=bounds&s=dde3e8a919521443e8b0f5fba726fb24 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=85&fit=bounds&s=3b57ebd649babc411c89f62a27bd800a 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=85&fit=bounds&s=d0d5bfe2a9ce9000f6d8afc8b864fe92 2000w"
-            />
-            <img
-              alt="Washington, DC, US Subcommittee chair Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol, during a House Judiciary subcommittee on Crime, Terrorism, and Homeland Security hearing"
-              className="js-launch-slideshow emotion-23"
-              data-ratio={0.6666081768731357}
-              src="https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3"
-            />
-          </picture>
-          <div
-            className="editions-gallery-caption emotion-24"
-          >
-            <h2
-              className="emotion-25"
-            >
-              <svg
-                className="emotion-26"
-                viewBox="0 0 13 11"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M6.5 0L13 11H0L6.5 0Z"
-                />
-              </svg>
-              Washington DC, US
-            </h2>
-            <p
-              className="emotion-27"
-            >
-              Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol during a House judiciary subcommittee hearing
-            </p>
-          </div>
-        </figure>
-        <figure
-          className="editions-gallery-figure emotion-22"
-        >
-          <picture>
-            <source
-              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-              sizes="100%"
-              srcSet="https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=45&fit=bounds&s=20c42477022d7ce2b2ac2d0b5cb688de 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=45&fit=bounds&s=dff09e82b640f93f268212b3a0de5b4e 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=45&fit=bounds&s=a4e0cdc7de19d34a17c874c3a81a1ebe 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=45&fit=bounds&s=478eaedffbc1085109b5b4e29f2200b9 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=45&fit=bounds&s=e8e63bb3ec8ead5b6607b25fea2cd528 2000w"
-            />
-            <source
-              sizes="100%"
-              srcSet="https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=85&fit=bounds&s=00a782574440af9727bf87616b94d572 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=85&fit=bounds&s=d4b61df8dc308483ca3b92c7da5de42e 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=85&fit=bounds&s=b9a3f3096a28cadaef022bbbf5322c56 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=85&fit=bounds&s=c476519c6a377a16d963a8cf9888713a 2000w"
-            />
-            <img
-              alt="Prayagraj, India A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers, during Magh Mela festival"
-              className="js-launch-slideshow emotion-29"
-              data-ratio={0.6666666666666666}
-              src="https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063"
-            />
-          </picture>
-          <div
-            className="editions-gallery-caption emotion-24"
-          >
-            <h2
-              className="emotion-25"
-            >
-              <svg
-                className="emotion-26"
-                viewBox="0 0 13 11"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M6.5 0L13 11H0L6.5 0Z"
-                />
-              </svg>
-              Prayagraj, India
-            </h2>
-            <p
-              className="emotion-27"
-            >
-              A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers
-            </p>
-          </div>
-        </figure>
-        <figure
-          className="editions-gallery-figure emotion-22"
-        >
-          <picture>
-            <source
-              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-              sizes="100%"
-              srcSet="https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=45&fit=bounds&s=b6beebe9a75fe6d5ce9475c0d13e429c 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=45&fit=bounds&s=1516f1b11f5a186d13bc2e7dc56eecde 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=45&fit=bounds&s=665b8f94e20042d415967c7a382cd561 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=45&fit=bounds&s=7bb7869708fa9d17b025aa334ba3a564 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=45&fit=bounds&s=3c40f4ca2a68a4393201f94f025eb68a 2000w"
-            />
-            <source
-              sizes="100%"
-              srcSet="https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=85&fit=bounds&s=7231bc978677afa567b999de7645602a 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=85&fit=bounds&s=cdeb3b040ff85ccebaa83f54643c87cb 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=85&fit=bounds&s=61bde3db8713dfa8ab6c9d94d3b53d3e 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=85&fit=bounds&s=fe5d0c455c7a8bf71082086f9b24e934 2000w"
-            />
-            <img
-              alt="Hua Hin, Thailand A bird flies over the abandoned sculpture of a Buddhist monk in Cha-am outside Hua Hin, south of Bangkok"
-              className="js-launch-slideshow emotion-29"
-              data-ratio={0.6666666666666666}
-              src="https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c"
-            />
-          </picture>
-          <div
-            className="editions-gallery-caption emotion-24"
-          >
-            <h2
-              className="emotion-25"
-            >
-              <svg
-                className="emotion-26"
-                viewBox="0 0 13 11"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M6.5 0L13 11H0L6.5 0Z"
-                />
-              </svg>
-              Hua Hin, Thailand
-            </h2>
-            <p
-              className="emotion-27"
-            >
-              A bird flies over the abandoned sculpture of a Buddhist monk south of Bangkok
-            </p>
-          </div>
-        </figure>
-        <figure
-          className="editions-gallery-figure emotion-22"
-        >
-          <picture>
-            <source
-              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-              sizes="100%"
-              srcSet="https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=45&fit=bounds&s=0f3c3dbd3fc24dc38b6a25593933d036 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=45&fit=bounds&s=3eb9e25c8e38ec8ae5e9b0a7e10c6c67 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=45&fit=bounds&s=317b489ad130fde80b1ea52214b0341a 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=45&fit=bounds&s=e0770f452eb0745fa25c47b78cdff4b4 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=45&fit=bounds&s=798fd1d9b81dc6b3fa425022e6201e64 2000w"
-            />
-            <source
-              sizes="100%"
-              srcSet="https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=85&fit=bounds&s=dc30181295bcbe657a051d55966d119a 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=85&fit=bounds&s=59187d1926376734fedf391885c21c75 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=85&fit=bounds&s=31b6374d30517dca65cbb0d7c0454535 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=85&fit=bounds&s=15e40dc6afcdbfefe241ddb4748c8ac5 2000w"
-            />
-            <img
-              alt="Mulhouse, France A polar bear cub makes its first steps outside, in an enclosure at the Zoological and Botanical park in eastern France. The cub was born in November 2020"
-              className="js-launch-slideshow emotion-29"
-              data-ratio={0.6666666666666666}
-              src="https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867"
-            />
-          </picture>
-          <div
-            className="editions-gallery-caption emotion-24"
-          >
-            <h2
-              className="emotion-25"
-            >
-              <svg
-                className="emotion-26"
-                viewBox="0 0 13 11"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M6.5 0L13 11H0L6.5 0Z"
-                />
-              </svg>
-              Mulhouse, France
-            </h2>
-            <p
-              className="emotion-27"
-            >
-              A polar bear cub takes its first steps outside in an enclosure at the zoological and botanical park
-            </p>
-          </div>
-        </figure>
-      </section>
-    </div>
-  </article>
-</main>
-`;
-
-exports[`Storyshots Editions/Article Interview 1`] = `
-.emotion-0 {
-  height: 100%;
-}
-
-.emotion-1 {
-  min-height: 100%;
-  background-color: inherit;
-}
-
-.emotion-2 {
-  background-color: #FFFFFF;
-}
-
-.emotion-4 {
-  margin: 0;
-  position: relative;
-  width: 100%;
-}
-
-.emotion-5 {
-  width: 100vw;
-  height: calc(100vw * 0.6);
-  background-color: #F6F6F6;
-  color: #999999;
-  display: block;
-  display: block;
-  width: 100%;
-  height: calc(100vw * 0.6);
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-5 {
-    background-color: #333333;
-  }
-}
-
-.emotion-6 {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.emotion-6 summary {
-  text-align: center;
-  background-color: #0084C6;
-  width: 34px;
-  height: 34px;
-  position: absolute;
-  bottom: 0.75rem;
-  right: 0.75rem;
-  border-radius: 100%;
-  outline: none;
-}
-
-.emotion-6 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-6 details[open] {
-  min-height: 44px;
-  max-height: 999px;
-  height: 100%;
-  background-color: rgba(0,0,0,0.8);
-  padding: 0.5rem;
-  overflow: hidden;
-  padding-right: 3rem;
-  z-index: 1;
-  color: #FFFFFF;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-  box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-6 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-6 details[open] {
-    padding-left: 9rem;
-  }
-}
-
-.emotion-7 {
-  line-height: 32px;
-  font-size: 0;
-}
-
-.emotion-7 svg {
-  width: 75%;
-  height: 75%;
-  margin: 12.5%;
-}
-
-.emotion-7 path {
-  fill: #F1F8FC;
-}
-
-.emotion-8 {
-  background-color: #FFE500;
-}
-
-@media (min-width:740px) {
-  .emotion-8 {
-    padding-left: 24px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-8 {
-    padding-left: 144px;
-  }
-}
-
-.emotion-9 {
-  position: relative;
-}
-
-.emotion-10 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
 }
 
 .emotion-11 {
+  position: relative;
+}
+
+.emotion-12 {
   color: #121212;
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
   line-height: 1.15;
-  font-weight: 700;
-  margin-left: 0.75rem;
-  border: 0;
-}
-
-@media (min-width:375px) {
-  .emotion-11 {
-    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-    font-size: 1.75rem;
-    line-height: 1.15;
-    font-weight: 700;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-11 {
-    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-    font-size: 2.125rem;
-    line-height: 1.15;
-    font-weight: 700;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-11 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-11 {
-    width: 545px;
-  }
-}
-
-.emotion-12 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.5rem;
-  line-height: 1.35;
   font-weight: 500;
-  font-weight: 400;
-  background-color: #121212;
-  color: #FFFFFF;
-  white-space: pre-wrap;
-  padding-top: 0.0625rem;
-  padding-bottom: 0.25rem;
-  box-shadow: -0.75rem 0 0 #121212,0.75rem 0 0 #121212;
-  display: inline;
 }
 
 @media (min-width:375px) {
   .emotion-12 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 1.75rem;
-    line-height: 1.35;
+    line-height: 1.15;
     font-weight: 500;
-    font-weight: 400;
   }
 }
 
@@ -7232,9 +3955,8 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   .emotion-12 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 2.125rem;
-    line-height: 1.35;
+    line-height: 1.15;
     font-weight: 500;
-    font-weight: 400;
   }
 }
 
@@ -7253,20 +3975,6 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   justify-content: space-between;
   padding-bottom: 1rem;
   color: #121212;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
-@media (min-width:740px) {
-  .emotion-13 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-13 {
-    width: 545px;
-  }
 }
 
 .emotion-13 p,
@@ -7290,52 +3998,15 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 .emotion-13 svg circle {
-  stroke: #0084C6;
+  stroke: #E05E00;
 }
 
 .emotion-13 svg path {
-  fill: #0084C6;
-}
-
-@media (min-width:740px) {
-  .emotion-13 {
-    padding-left: 0;
-    padding-right: 0;
-  }
+  fill: #E05E00;
 }
 
 .emotion-14 {
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-14 {
-    width: 539px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-14 {
-    width: 558px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-14 {
-    margin-left: 24px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-14 {
-    margin-left: 144px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-14 {
-    border-right: 1px solid #DCDCDC;
-  }
 }
 
 .emotion-15 {
@@ -7358,9 +4029,6 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   justify-content: space-between;
   padding-bottom: 1rem;
   margin: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-  border-bottom: 1px solid #DCDCDC;
 }
 
 .emotion-16 svg {
@@ -7373,11 +4041,11 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 .emotion-16 svg circle {
-  stroke: #0084C6;
+  stroke: #E05E00;
 }
 
 .emotion-16 svg path {
-  fill: #0084C6;
+  fill: #E05E00;
 }
 
 @media (min-width:740px) {
@@ -7386,36 +4054,8 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   }
 }
 
-@media (min-width:740px) {
-  .emotion-16 {
-    box-sizing: border-box;
-    margin-left: 1.5rem;
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
-    border-right: 1px solid #DCDCDC;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-16 {
-    margin-left: 144px;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-16 {
-    width: 539px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-16 {
-    width: 558px;
-  }
-}
-
 .emotion-17 {
-  color: #0084C6;
+  color: #E05E00;
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -7575,7 +4215,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   font-size: 1.0625rem;
   line-height: 1.15;
   font-weight: 700;
-  color: #0084C6;
+  color: #E05E00;
 }
 
 .emotion-30 {
@@ -7612,7 +4252,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 .emotion-31:hover {
-  background: #0084C6;
+  background: #E05E00;
 }
 
 .emotion-32 {
@@ -7687,7 +4327,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 .emotion-34 a {
-  color: #005689;
+  color: #CB4700;
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: 0.0625rem solid #DCDCDC;
@@ -7696,7 +4336,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 .emotion-34 a:hover {
-  border-bottom: solid 0.0625rem #0084C6;
+  border-bottom: solid 0.0625rem #E05E00;
 }
 
 .emotion-35 {
@@ -7752,7 +4392,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 .emotion-37:hover {
-  background: #0084C6;
+  background: #E05E00;
 }
 
 .emotion-37:focus {
@@ -7795,7 +4435,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 .emotion-39:hover {
-  background: #0084C6;
+  background: #E05E00;
 }
 
 .emotion-39:focus {
@@ -7816,9 +4456,9 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   box-sizing: border-box;
   padding: 0 0.5rem 1.5rem 0.5rem;
   margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
-  color: #0084C6;
-  border: 1px solid #0084C6;
-  border-top: 0.75rem solid #0084C6;
+  color: #E05E00;
+  border: 1px solid #E05E00;
+  border-top: 0.75rem solid #E05E00;
   border-bottom: none;
   float: left;
   clear: left;
@@ -7839,7 +4479,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   left: -1px;
   width: 1.5rem;
   height: 1.5rem;
-  border: 1px solid #0084C6;
+  border: 1px solid #E05E00;
   border-top: none;
   border-radius: 0 0 100% 0;
 }
@@ -7851,7 +4491,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   left: calc(1.5rem + 1px);
   width: calc(100% - 1.5rem);
   height: 1px;
-  border-top: 1px solid #0084C6;
+  border-top: 1px solid #E05E00;
 }
 
 .emotion-45 {
@@ -7869,7 +4509,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
-  fill: #0084C6;
+  fill: #E05E00;
 }
 
 .emotion-47 {
@@ -7892,85 +4532,85 @@ exports[`Storyshots Editions/Article Interview 1`] = `
       <section
         className="emotion-3"
       >
-        <header>
-          <figure
-            aria-labelledby="header-image-caption"
-            className="emotion-4"
+        <header
+          className="emotion-4"
+        >
+          <div
+            className="emotion-5"
           >
-            <picture>
-              <source
-                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-                sizes="100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-              />
-              <source
-                sizes="100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-              />
-              <img
-                alt="image"
-                className="js-launch-slideshow js-main-image emotion-5"
-                data-ratio={0.6}
-                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-              />
-            </picture>
-            <figcaption
+            <figure
+              aria-labelledby="header-image-caption"
               className="emotion-6"
             >
-              <details>
-                <summary>
-                  <span
-                    className="emotion-7"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                    Click to see figure caption
-                  </span>
-                </summary>
-                <span
-                  id="header-image-caption"
-                >
-                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-                   
-                  Photograph: Philip Keith/The Guardian
-                </span>
-              </details>
-            </figcaption>
-          </figure>
-          <div
-            className="emotion-8"
-          >
-            <div
-              className="emotion-9"
-            >
-              <div
-                className="emotion-10"
-              />
-              <h1
-                className="emotion-11"
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+                />
+                <source
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+                />
+                <img
+                  alt="image"
+                  className="js-launch-slideshow js-main-image emotion-7"
+                  data-ratio={0.6}
+                  src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+                />
+              </picture>
+              <figcaption
+                className="emotion-8"
               >
-                <span
-                  className="emotion-12"
-                >
-                  Reclaimed lakes and giant airports: how Mexico City might have looked
-                </span>
-              </h1>
-            </div>
-            <div
-              className="emotion-13"
+                <details>
+                  <summary>
+                    <span
+                      className="emotion-9"
+                    >
+                      <svg
+                        viewBox="0 0 30 30"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                      Click to see figure caption
+                    </span>
+                  </summary>
+                  <span
+                    id="header-image-caption"
+                  >
+                    ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                     
+                    Photograph: Philip Keith/The Guardian
+                  </span>
+                </details>
+              </figcaption>
+            </figure>
+          </div>
+          <nav
+            className="emotion-10"
+          >
+            View from the Guardian
+          </nav>
+          <div
+            className="emotion-11"
+          >
+            <h1
+              className="emotion-12"
             >
-              <p>
-                The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
-              </p>
-            </div>
+              Reclaimed lakes and giant airports: how Mexico City might have looked
+            </h1>
+          </div>
+          <div
+            className="emotion-13"
+          >
+            <p>
+              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+            </p>
           </div>
           <div
             className="emotion-14"
@@ -8217,6 +4857,3142 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 </main>
 `;
 
+exports[`Storyshots Editions/Article Feature 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FFFFFF;
+}
+
+.emotion-3 {
+  border-bottom: 1px solid #DCDCDC;
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    width: 526px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-3 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-3 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-3 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-4 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-5 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
+  }
+}
+
+.emotion-6 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-7 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-7 {
+    background-color: #333333;
+  }
+}
+
+.emotion-8 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-8 summary {
+  text-align: center;
+  background-color: #0084C6;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-8 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-8 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-8 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-8 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+.emotion-9 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-9 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-9 path {
+  fill: #F1F8FC;
+}
+
+.emotion-10 {
+  position: relative;
+}
+
+.emotion-11 {
+  color: #005689;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (min-width:375px) {
+  .emotion-11 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+.emotion-12 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+.emotion-12 p,
+.emotion-12 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-12 address {
+  font-style: normal;
+}
+
+.emotion-12 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-12 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-12 svg path {
+  fill: #0084C6;
+}
+
+.emotion-13 {
+  box-sizing: border-box;
+}
+
+.emotion-14 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-15 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-15 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-15 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-15 svg path {
+  fill: #0084C6;
+}
+
+@media (min-width:740px) {
+  .emotion-15 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-16 {
+  color: #0084C6;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-17 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-18 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-19 {
+    width: 526px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-19 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-19 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-19 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-19 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-20 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-20 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-20 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-20 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-20 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-21 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-22 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width:660px) {
+  .emotion-22 {
+    width: 620px;
+  }
+}
+
+.emotion-23 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:660px) {
+  .emotion-23 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-23 {
+    background-color: #333333;
+  }
+}
+
+.emotion-26 {
+  display: block;
+  position: relative;
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.emotion-27 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-27 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-27 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-27 summary:focus {
+  outline: none;
+}
+
+.emotion-28 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #0084C6;
+}
+
+.emotion-29 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-30 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0,50%);
+  -ms-transform: translate(0,50%);
+  transform: translate(0,50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-30:hover {
+  background: #0084C6;
+}
+
+.emotion-31 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-32 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-33 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-33 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-33 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-33 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-33 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-33 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-33 b {
+  font-weight: 700;
+}
+
+.emotion-33 i {
+  font-style: italic;
+}
+
+.emotion-33 a {
+  color: #005689;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-33 a:hover {
+  border-bottom: solid 0.0625rem #0084C6;
+}
+
+.emotion-34 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.emotion-35 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-36 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-36:hover {
+  background: #0084C6;
+}
+
+.emotion-36:focus {
+  border: none;
+}
+
+.emotion-37 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-38 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-38:hover {
+  background: #0084C6;
+}
+
+.emotion-38:focus {
+  border: none;
+}
+
+.emotion-40 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-43 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #0084C6;
+  border: 1px solid #0084C6;
+  border-top: 0.75rem solid #0084C6;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:980px) {
+  .emotion-43 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-43:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #0084C6;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-43:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #0084C6;
+}
+
+.emotion-44 {
+  margin: 0;
+}
+
+.emotion-45 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-45 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #0084C6;
+}
+
+.emotion-46 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
+<main
+  className="emotion-0"
+>
+  <article
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <section
+        className="emotion-3"
+      >
+        <header
+          className="emotion-4"
+        >
+          <div
+            className="emotion-5"
+          >
+            <figure
+              aria-labelledby="header-image-caption"
+              className="emotion-6"
+            >
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+                />
+                <source
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+                />
+                <img
+                  alt="image"
+                  className="js-launch-slideshow js-main-image emotion-7"
+                  data-ratio={0.6}
+                  src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+                />
+              </picture>
+              <figcaption
+                className="emotion-8"
+              >
+                <details>
+                  <summary>
+                    <span
+                      className="emotion-9"
+                    >
+                      <svg
+                        viewBox="0 0 30 30"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                      Click to see figure caption
+                    </span>
+                  </summary>
+                  <span
+                    id="header-image-caption"
+                  >
+                    ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                     
+                    Photograph: Philip Keith/The Guardian
+                  </span>
+                </details>
+              </figcaption>
+            </figure>
+          </div>
+          <div
+            className="emotion-10"
+          >
+            <h1
+              className="emotion-11"
+            >
+              Reclaimed lakes and giant airports: how Mexico City might have looked
+            </h1>
+          </div>
+          <div
+            className="emotion-12"
+          >
+            <p>
+              The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+            </p>
+          </div>
+          <div
+            className="emotion-13"
+          >
+            <div
+              className="emotion-14"
+            />
+          </div>
+          <div
+            className="emotion-15"
+          >
+            <address>
+              <span
+                className="emotion-16"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="emotion-17"
+              >
+                 Editor of things
+              </span>
+            </address>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="emotion-18"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="emotion-19"
+    >
+      <section
+        className="emotion-20"
+      >
+        <p
+          className="emotion-21"
+        />
+        <figure
+          className="emotion-22"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow emotion-23"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="emotion-21"
+        />
+        <p
+          className="emotion-21"
+        />
+        <div
+          className="emotion-26"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="emotion-27"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="emotion-28"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="emotion-29"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="emotion-30"
+              >
+                <span
+                  className="emotion-31"
+                >
+                  <span
+                    className="emotion-32"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="emotion-33"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="emotion-34"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="emotion-35"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="emotion-36"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="emotion-37"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="emotion-38"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="emotion-37"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="emotion-40"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="emotion-21"
+        />
+        <p
+          className="emotion-21"
+        />
+        <aside
+          className="emotion-43"
+        >
+          <blockquote
+            className="emotion-44"
+          >
+            <p
+              className="emotion-45"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="emotion-46"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="emotion-21"
+        />
+        <p
+          className="emotion-21"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Article Gallery 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: #121212;
+}
+
+.emotion-2 {
+  background-color: #121212;
+}
+
+.emotion-4 {
+  border-bottom: 1px solid #FFFFFF;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    border: none;
+  }
+}
+
+.emotion-5 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+.emotion-6 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-7 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #333333;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-7 {
+    background-color: #333333;
+  }
+}
+
+.emotion-8 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-8 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-8 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-8 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-8 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-8 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+.emotion-9 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-9 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-9 path {
+  fill: #FFF4F2;
+}
+
+.emotion-10 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-10 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-10 {
+    padding-left: 24px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-10 {
+    padding-left: 144px;
+  }
+}
+
+.emotion-11 {
+  position: relative;
+}
+
+.emotion-12 {
+  color: #FFFFFF;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-family: GT Guardian Titlepiece,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  font-size: 2rem;
+  line-height: 1.2;
+  padding-bottom: 1.5rem;
+  background-color: #121212;
+  border: 0;
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    width: 526px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-12 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-13 {
+    border-bottom: 1px solid #FFFFFF;
+    border-right: 1px solid #FFFFFF;
+    box-sizing: border-box;
+    width: 538px;
+  }
+
+  @media (min-width:980px) {
+    .emotion-13 {
+      width: 557px;
+    }
+  }
+}
+
+.emotion-14 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  color: #FFFFFF;
+}
+
+.emotion-14 p,
+.emotion-14 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-14 address {
+  font-style: normal;
+}
+
+.emotion-14 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-14 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-14 svg path {
+  fill: #C70000;
+}
+
+.emotion-15 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-15 {
+    margin-left: 0;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-15 {
+    margin-left: 0;
+  }
+}
+
+.emotion-16 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-17 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-17 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-17 svg circle {
+  stroke: #FFFFFF;
+}
+
+.emotion-17 svg path {
+  fill: #FFFFFF;
+}
+
+@media (min-width:740px) {
+  .emotion-17 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-17 {
+    width: 526px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-17 {
+    width: 545px;
+  }
+}
+
+.emotion-18 {
+  color: #FFFFFF;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-19 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #FFFFFF;
+}
+
+.emotion-20 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+.emotion-21 {
+  box-sizing: border-box;
+  padding-top: 0.75rem;
+  padding-right: 0;
+  padding-left: 0;
+  border: none;
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    width: 526px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-21 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-21 {
+    margin-left: 144px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    width: 538px;
+    padding-right: 1rem;
+    border-right: 1px solid #FFFFFF;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-21 {
+    width: 557px;
+  }
+}
+
+.emotion-22 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-22 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-22 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-22 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-22 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-23 {
+  margin: 0 0 1.5rem;
+  width: 100%;
+  position: relative;
+}
+
+@media (min-width:740px) {
+  .emotion-23 p {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.emotion-24 {
+  width: 100%;
+  height: calc(100% * 0.6666081768731357);
+  background-color: #333333;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:740px) {
+  .emotion-25 {
+    position: absolute;
+    top: -0.25rem;
+    width: 170px;
+    right: calc(-170px - 2rem);
+  }
+}
+
+.emotion-26 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 700;
+  color: #FFFFFF;
+  margin: 0;
+  padding: 0.25rem 0 0;
+}
+
+@media (min-width:740px) {
+  .emotion-26 {
+    padding: 0;
+  }
+
+  .emotion-26 svg {
+    -webkit-transform: translateX(-10%) translateY(-15%) rotateZ(-90deg);
+    -ms-transform: translateX(-10%) translateY(-15%) rotateZ(-90deg);
+    transform: translateX(-10%) translateY(-15%) rotateZ(-90deg);
+  }
+}
+
+.emotion-27 {
+  fill: #C70000;
+  height: 0.6875rem;
+  width: 0.8125rem;
+  padding-right: 0.25rem;
+}
+
+.emotion-28 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.35;
+  font-weight: 400;
+  color: #FFFFFF;
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-30 {
+  width: 100%;
+  height: calc(100% * 0.6666666666666666);
+  background-color: #333333;
+  color: #999999;
+  display: block;
+}
+
+<main
+  className="emotion-0"
+>
+  <article
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <section
+        className="emotion-3"
+      >
+        <header
+          className="emotion-4"
+        >
+          <div
+            className="emotion-5"
+          >
+            <figure
+              aria-labelledby="header-image-caption"
+              className="emotion-6"
+            >
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+                />
+                <source
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+                />
+                <img
+                  alt="image"
+                  className="js-launch-slideshow js-main-image emotion-7"
+                  data-ratio={0.6}
+                  src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+                />
+              </picture>
+              <figcaption
+                className="emotion-8"
+              >
+                <details>
+                  <summary>
+                    <span
+                      className="emotion-9"
+                    >
+                      <svg
+                        viewBox="0 0 30 30"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                      Click to see figure caption
+                    </span>
+                  </summary>
+                  <span
+                    id="header-image-caption"
+                  >
+                    ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                     
+                    Photograph: Philip Keith/The Guardian
+                  </span>
+                </details>
+              </figcaption>
+            </figure>
+          </div>
+          <div
+            className="emotion-10"
+          >
+            <div
+              className="emotion-11"
+            >
+              <h1
+                className="emotion-12"
+              >
+                Reclaimed lakes and giant airports: how Mexico City might have looked
+              </h1>
+            </div>
+            <div
+              className="emotion-13"
+            >
+              <div
+                className="emotion-14"
+              >
+                <p>
+                  The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+                </p>
+              </div>
+              <div
+                className="emotion-15"
+              >
+                <div
+                  className="emotion-16"
+                />
+              </div>
+              <div
+                className="emotion-17"
+              >
+                <address>
+                  <span
+                    className="emotion-18"
+                  >
+                    Jane Smith
+                  </span>
+                  <span
+                    className="emotion-19"
+                  >
+                     Editor of things
+                  </span>
+                </address>
+                <span
+                  className="js-share-button"
+                  role="button"
+                >
+                  <button
+                    className="emotion-20"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      fill="none"
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <circle
+                        cx="15"
+                        cy="15"
+                        r="14.5"
+                      />
+                      <path
+                        d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="emotion-21"
+    >
+      <section
+        className="emotion-22"
+      >
+        <figure
+          className="editions-gallery-figure emotion-23"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="100%"
+              srcSet="https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=45&fit=bounds&s=253ff45edb114b0605b7bce66b7f78f3 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=45&fit=bounds&s=3be9e2a7e7f1b2ac4efab144d6c07a28 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=45&fit=bounds&s=14c3c8f7d54a8d8794664492efc68641 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=45&fit=bounds&s=2745788813a433224e06421647d60b2c 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=45&fit=bounds&s=dcdc2c3d03aee717124c58914a5c39de 2000w"
+            />
+            <source
+              sizes="100%"
+              srcSet="https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=85&fit=bounds&s=c125868b875fa9ec4a8ce180360836e0 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=85&fit=bounds&s=dde3e8a919521443e8b0f5fba726fb24 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=85&fit=bounds&s=3b57ebd649babc411c89f62a27bd800a 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=85&fit=bounds&s=d0d5bfe2a9ce9000f6d8afc8b864fe92 2000w"
+            />
+            <img
+              alt="Washington, DC, US Subcommittee chair Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol, during a House Judiciary subcommittee on Crime, Terrorism, and Homeland Security hearing"
+              className="js-launch-slideshow emotion-24"
+              data-ratio={0.6666081768731357}
+              src="https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3"
+            />
+          </picture>
+          <div
+            className="editions-gallery-caption emotion-25"
+          >
+            <h2
+              className="emotion-26"
+            >
+              <svg
+                className="emotion-27"
+                viewBox="0 0 13 11"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.5 0L13 11H0L6.5 0Z"
+                />
+              </svg>
+              Washington DC, US
+            </h2>
+            <p
+              className="emotion-28"
+            >
+              Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol during a House judiciary subcommittee hearing
+            </p>
+          </div>
+        </figure>
+        <figure
+          className="editions-gallery-figure emotion-23"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="100%"
+              srcSet="https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=45&fit=bounds&s=20c42477022d7ce2b2ac2d0b5cb688de 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=45&fit=bounds&s=dff09e82b640f93f268212b3a0de5b4e 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=45&fit=bounds&s=a4e0cdc7de19d34a17c874c3a81a1ebe 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=45&fit=bounds&s=478eaedffbc1085109b5b4e29f2200b9 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=45&fit=bounds&s=e8e63bb3ec8ead5b6607b25fea2cd528 2000w"
+            />
+            <source
+              sizes="100%"
+              srcSet="https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=85&fit=bounds&s=00a782574440af9727bf87616b94d572 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=85&fit=bounds&s=d4b61df8dc308483ca3b92c7da5de42e 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=85&fit=bounds&s=b9a3f3096a28cadaef022bbbf5322c56 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=85&fit=bounds&s=c476519c6a377a16d963a8cf9888713a 2000w"
+            />
+            <img
+              alt="Prayagraj, India A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers, during Magh Mela festival"
+              className="js-launch-slideshow emotion-30"
+              data-ratio={0.6666666666666666}
+              src="https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063"
+            />
+          </picture>
+          <div
+            className="editions-gallery-caption emotion-25"
+          >
+            <h2
+              className="emotion-26"
+            >
+              <svg
+                className="emotion-27"
+                viewBox="0 0 13 11"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.5 0L13 11H0L6.5 0Z"
+                />
+              </svg>
+              Prayagraj, India
+            </h2>
+            <p
+              className="emotion-28"
+            >
+              A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers
+            </p>
+          </div>
+        </figure>
+        <figure
+          className="editions-gallery-figure emotion-23"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="100%"
+              srcSet="https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=45&fit=bounds&s=b6beebe9a75fe6d5ce9475c0d13e429c 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=45&fit=bounds&s=1516f1b11f5a186d13bc2e7dc56eecde 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=45&fit=bounds&s=665b8f94e20042d415967c7a382cd561 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=45&fit=bounds&s=7bb7869708fa9d17b025aa334ba3a564 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=45&fit=bounds&s=3c40f4ca2a68a4393201f94f025eb68a 2000w"
+            />
+            <source
+              sizes="100%"
+              srcSet="https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=85&fit=bounds&s=7231bc978677afa567b999de7645602a 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=85&fit=bounds&s=cdeb3b040ff85ccebaa83f54643c87cb 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=85&fit=bounds&s=61bde3db8713dfa8ab6c9d94d3b53d3e 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=85&fit=bounds&s=fe5d0c455c7a8bf71082086f9b24e934 2000w"
+            />
+            <img
+              alt="Hua Hin, Thailand A bird flies over the abandoned sculpture of a Buddhist monk in Cha-am outside Hua Hin, south of Bangkok"
+              className="js-launch-slideshow emotion-30"
+              data-ratio={0.6666666666666666}
+              src="https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c"
+            />
+          </picture>
+          <div
+            className="editions-gallery-caption emotion-25"
+          >
+            <h2
+              className="emotion-26"
+            >
+              <svg
+                className="emotion-27"
+                viewBox="0 0 13 11"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.5 0L13 11H0L6.5 0Z"
+                />
+              </svg>
+              Hua Hin, Thailand
+            </h2>
+            <p
+              className="emotion-28"
+            >
+              A bird flies over the abandoned sculpture of a Buddhist monk south of Bangkok
+            </p>
+          </div>
+        </figure>
+        <figure
+          className="editions-gallery-figure emotion-23"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="100%"
+              srcSet="https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=45&fit=bounds&s=0f3c3dbd3fc24dc38b6a25593933d036 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=45&fit=bounds&s=3eb9e25c8e38ec8ae5e9b0a7e10c6c67 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=45&fit=bounds&s=317b489ad130fde80b1ea52214b0341a 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=45&fit=bounds&s=e0770f452eb0745fa25c47b78cdff4b4 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=45&fit=bounds&s=798fd1d9b81dc6b3fa425022e6201e64 2000w"
+            />
+            <source
+              sizes="100%"
+              srcSet="https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=85&fit=bounds&s=dc30181295bcbe657a051d55966d119a 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=85&fit=bounds&s=59187d1926376734fedf391885c21c75 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=85&fit=bounds&s=31b6374d30517dca65cbb0d7c0454535 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=85&fit=bounds&s=15e40dc6afcdbfefe241ddb4748c8ac5 2000w"
+            />
+            <img
+              alt="Mulhouse, France A polar bear cub makes its first steps outside, in an enclosure at the Zoological and Botanical park in eastern France. The cub was born in November 2020"
+              className="js-launch-slideshow emotion-30"
+              data-ratio={0.6666666666666666}
+              src="https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867"
+            />
+          </picture>
+          <div
+            className="editions-gallery-caption emotion-25"
+          >
+            <h2
+              className="emotion-26"
+            >
+              <svg
+                className="emotion-27"
+                viewBox="0 0 13 11"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.5 0L13 11H0L6.5 0Z"
+                />
+              </svg>
+              Mulhouse, France
+            </h2>
+            <p
+              className="emotion-28"
+            >
+              A polar bear cub takes its first steps outside in an enclosure at the zoological and botanical park
+            </p>
+          </div>
+        </figure>
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
+exports[`Storyshots Editions/Article Interview 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FFFFFF;
+}
+
+.emotion-4 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-4 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-4 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-6 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-6 {
+    background-color: #333333;
+  }
+}
+
+.emotion-7 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-7 summary {
+  text-align: center;
+  background-color: #0084C6;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-7 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-7 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-7 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-7 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+.emotion-8 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-8 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-8 path {
+  fill: #F1F8FC;
+}
+
+.emotion-9 {
+  background-color: #FFE500;
+}
+
+@media (min-width:740px) {
+  .emotion-9 {
+    padding-left: 24px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-9 {
+    padding-left: 144px;
+  }
+}
+
+.emotion-10 {
+  position: relative;
+}
+
+.emotion-11 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+
+.emotion-12 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 700;
+  margin-left: 0.75rem;
+  border: 0;
+}
+
+@media (min-width:375px) {
+  .emotion-12 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 700;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-12 {
+    width: 526px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-12 {
+    width: 545px;
+  }
+}
+
+.emotion-13 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.35;
+  font-weight: 500;
+  font-weight: 400;
+  background-color: #121212;
+  color: #FFFFFF;
+  white-space: pre-wrap;
+  padding-top: 0.0625rem;
+  padding-bottom: 0.25rem;
+  box-shadow: -0.75rem 0 0 #121212,0.75rem 0 0 #121212;
+  display: inline;
+}
+
+@media (min-width:375px) {
+  .emotion-13 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.35;
+    font-weight: 500;
+    font-weight: 400;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-13 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.35;
+    font-weight: 500;
+    font-weight: 400;
+  }
+}
+
+.emotion-14 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-14 p,
+.emotion-14 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-14 address {
+  font-style: normal;
+}
+
+.emotion-14 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-14 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-14 svg path {
+  fill: #0084C6;
+}
+
+@media (min-width:740px) {
+  .emotion-14 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-15 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-15 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-15 {
+    margin-left: 144px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-15 {
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+.emotion-16 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-17 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-bottom: 1px solid #DCDCDC;
+}
+
+.emotion-17 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-17 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-17 svg path {
+  fill: #0084C6;
+}
+
+@media (min-width:740px) {
+  .emotion-17 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-17 {
+    box-sizing: border-box;
+    margin-left: 1.5rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-17 {
+    margin-left: 144px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-17 {
+    width: 539px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-17 {
+    width: 558px;
+  }
+}
+
+.emotion-18 {
+  color: #0084C6;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-19 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-20 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    width: 526px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-21 {
+    width: 545px;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-21 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-21 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-22 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-22 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-22 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width:740px) {
+  .emotion-22 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-22 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-23 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-24 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width:660px) {
+  .emotion-24 {
+    width: 620px;
+  }
+}
+
+.emotion-25 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width:660px) {
+  .emotion-25 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-25 {
+    background-color: #333333;
+  }
+}
+
+.emotion-28 {
+  display: block;
+  position: relative;
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.emotion-29 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-29 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-29 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-29 summary:focus {
+  outline: none;
+}
+
+.emotion-30 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #0084C6;
+}
+
+.emotion-31 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-32 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0,50%);
+  -ms-transform: translate(0,50%);
+  transform: translate(0,50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-32:hover {
+  background: #0084C6;
+}
+
+.emotion-33 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-34 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-35 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-35 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-35 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-35 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-35 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-35 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-35 b {
+  font-weight: 700;
+}
+
+.emotion-35 i {
+  font-style: italic;
+}
+
+.emotion-35 a {
+  color: #005689;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-35 a:hover {
+  border-bottom: solid 0.0625rem #0084C6;
+}
+
+.emotion-36 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.emotion-37 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-38 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-38:hover {
+  background: #0084C6;
+}
+
+.emotion-38:focus {
+  border: none;
+}
+
+.emotion-39 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-40 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-40:hover {
+  background: #0084C6;
+}
+
+.emotion-40:focus {
+  border: none;
+}
+
+.emotion-42 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-45 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #0084C6;
+  border: 1px solid #0084C6;
+  border-top: 0.75rem solid #0084C6;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width:980px) {
+  .emotion-45 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-45:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #0084C6;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-45:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #0084C6;
+}
+
+.emotion-46 {
+  margin: 0;
+}
+
+.emotion-47 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-47 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #0084C6;
+}
+
+.emotion-48 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
+<main
+  className="emotion-0"
+>
+  <article
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <section
+        className="emotion-3"
+      >
+        <header>
+          <div
+            className="emotion-4"
+          >
+            <figure
+              aria-labelledby="header-image-caption"
+              className="emotion-5"
+            >
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+                />
+                <source
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+                />
+                <img
+                  alt="image"
+                  className="js-launch-slideshow js-main-image emotion-6"
+                  data-ratio={0.6}
+                  src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+                />
+              </picture>
+              <figcaption
+                className="emotion-7"
+              >
+                <details>
+                  <summary>
+                    <span
+                      className="emotion-8"
+                    >
+                      <svg
+                        viewBox="0 0 30 30"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                      Click to see figure caption
+                    </span>
+                  </summary>
+                  <span
+                    id="header-image-caption"
+                  >
+                    ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                     
+                    Photograph: Philip Keith/The Guardian
+                  </span>
+                </details>
+              </figcaption>
+            </figure>
+          </div>
+          <div
+            className="emotion-9"
+          >
+            <div
+              className="emotion-10"
+            >
+              <div
+                className="emotion-11"
+              />
+              <h1
+                className="emotion-12"
+              >
+                <span
+                  className="emotion-13"
+                >
+                  Reclaimed lakes and giant airports: how Mexico City might have looked
+                </span>
+              </h1>
+            </div>
+            <div
+              className="emotion-14"
+            >
+              <p>
+                The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+              </p>
+            </div>
+          </div>
+          <div
+            className="emotion-15"
+          >
+            <div
+              className="emotion-16"
+            />
+          </div>
+          <div
+            className="emotion-17"
+          >
+            <address>
+              <span
+                className="emotion-18"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="emotion-19"
+              >
+                 Editor of things
+              </span>
+            </address>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="emotion-20"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="emotion-21"
+    >
+      <section
+        className="emotion-22"
+      >
+        <p
+          className="emotion-23"
+        />
+        <figure
+          className="emotion-24"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow emotion-25"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="emotion-23"
+        />
+        <p
+          className="emotion-23"
+        />
+        <div
+          className="emotion-28"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="emotion-29"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="emotion-30"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="emotion-31"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="emotion-32"
+              >
+                <span
+                  className="emotion-33"
+                >
+                  <span
+                    className="emotion-34"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="emotion-35"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="emotion-36"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="emotion-37"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="emotion-38"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="emotion-39"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="emotion-40"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="emotion-39"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="emotion-42"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="emotion-23"
+        />
+        <p
+          className="emotion-23"
+        />
+        <aside
+          className="emotion-45"
+        >
+          <blockquote
+            className="emotion-46"
+          >
+            <p
+              className="emotion-47"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="emotion-48"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="emotion-23"
+        />
+        <p
+          className="emotion-23"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
 exports[`Storyshots Editions/Article Review 1`] = `
 .emotion-0 {
   height: 100%;
@@ -8279,17 +8055,31 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 .emotion-5 {
-  margin: 0;
-  position: relative;
+  grid-column-start: 0;
+  grid-column-end: span 12;
 }
 
-@media (min-width:980px) {
+@media (min-width:740px) {
   .emotion-5 {
-    width: 750px;
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-5 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
   }
 }
 
 .emotion-6 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-7 {
   width: 100vw;
   height: calc(100vw * 0.6);
   background-color: #F6F6F6;
@@ -8297,51 +8087,26 @@ exports[`Storyshots Editions/Article Review 1`] = `
   display: block;
   display: block;
   width: 100%;
-}
-
-@media (min-width:740px) {
-  .emotion-6 {
-    width: 740px;
-    height: calc(740px * 0.6);
-  }
-}
-
-@media (min-width:1300px) {
-  .emotion-6 {
-    width: 980px;
-    height: calc(980px * 0.6);
-  }
+  height: 100%;
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-6 {
+  .emotion-7 {
     background-color: #333333;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-6 {
-    width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-6 {
-    width: 750px;
-    height: 450px;
-  }
-}
-
-.emotion-7 {
+.emotion-8 {
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   top: 0;
+  width: 100%;
+  height: 100%;
 }
 
-.emotion-7 summary {
+.emotion-8 summary {
   text-align: center;
   background-color: #A1845C;
   width: 34px;
@@ -8353,11 +8118,11 @@ exports[`Storyshots Editions/Article Review 1`] = `
   outline: none;
 }
 
-.emotion-7 summary::-webkit-details-marker {
+.emotion-8 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-7 details[open] {
+.emotion-8 details[open] {
   min-height: 44px;
   max-height: 999px;
   height: 100%;
@@ -8375,90 +8140,77 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-7 details[open] {
+  .emotion-8 details[open] {
     padding-left: 9rem;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-7 {
-    width: calc(100vw - 3.75rem);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 {
-    width: 750px;
-  }
-}
-
-.emotion-8 {
+.emotion-9 {
   line-height: 32px;
   font-size: 0;
 }
 
-.emotion-8 svg {
+.emotion-9 svg {
   width: 75%;
   height: 75%;
   margin: 12.5%;
 }
 
-.emotion-8 path {
+.emotion-9 path {
   fill: #FBF6EF;
 }
 
-.emotion-9 {
+.emotion-10 {
   position: absolute;
   left: 0;
   bottom: 0;
 }
 
-.emotion-10 {
+.emotion-11 {
   background-color: #FFE500;
   display: inline-block;
 }
 
-.emotion-10:nth-of-type(5) {
+.emotion-11:nth-of-type(5) {
   padding-right: 2px;
 }
 
-.emotion-10 svg {
+.emotion-11 svg {
   margin: 0 -0.125rem;
   height: 1.75rem;
 }
 
-.emotion-14 {
+.emotion-15 {
   background-color: #FFE500;
   display: inline-block;
   fill: transparent;
   stroke: #121212;
 }
 
-.emotion-14:nth-of-type(5) {
+.emotion-15:nth-of-type(5) {
   padding-right: 2px;
 }
 
-.emotion-14 svg {
+.emotion-15 svg {
   margin: 0 -0.125rem;
   height: 1.75rem;
 }
 
-.emotion-15 {
+.emotion-16 {
   position: relative;
 }
 
-.emotion-16 {
+.emotion-17 {
   color: #6B5840;
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -8467,7 +8219,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 @media (min-width:375px) {
-  .emotion-16 {
+  .emotion-17 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 1.75rem;
     line-height: 1.15;
@@ -8476,7 +8228,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-16 {
+  .emotion-17 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
     font-size: 2.125rem;
     line-height: 1.15;
@@ -8484,7 +8236,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   }
 }
 
-.emotion-17 {
+.emotion-18 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.15;
@@ -8501,29 +8253,17 @@ exports[`Storyshots Editions/Article Review 1`] = `
   color: #121212;
 }
 
-@media (min-width:740px) {
-  .emotion-17 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-17 {
-    width: 545px;
-  }
-}
-
-.emotion-17 p,
-.emotion-17 ul {
+.emotion-18 p,
+.emotion-18 ul {
   padding-top: 0.25rem;
   margin: 0;
 }
 
-.emotion-17 address {
+.emotion-18 address {
   font-style: normal;
 }
 
-.emotion-17 svg {
+.emotion-18 svg {
   -webkit-flex: 0 0 1.875rem;
   -ms-flex: 0 0 1.875rem;
   flex: 0 0 1.875rem;
@@ -8533,31 +8273,19 @@ exports[`Storyshots Editions/Article Review 1`] = `
   height: 1.875rem;
 }
 
-.emotion-17 svg circle {
+.emotion-18 svg circle {
   stroke: #A1845C;
 }
 
-.emotion-17 svg path {
+.emotion-18 svg path {
   fill: #A1845C;
 }
 
-.emotion-18 {
+.emotion-19 {
   box-sizing: border-box;
 }
 
-@media (min-width:740px) {
-  .emotion-18 {
-    width: 539px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-18 {
-    width: 558px;
-  }
-}
-
-.emotion-19 {
+.emotion-20 {
   background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
   background-repeat: repeat-x;
   background-position: top;
@@ -8565,7 +8293,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   height: calc(0.25rem * 3 + 1px);
 }
 
-.emotion-20 {
+.emotion-21 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8579,7 +8307,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   margin: 0;
 }
 
-.emotion-20 svg {
+.emotion-21 svg {
   -webkit-flex: 0 0 1.875rem;
   -ms-flex: 0 0 1.875rem;
   flex: 0 0 1.875rem;
@@ -8588,21 +8316,21 @@ exports[`Storyshots Editions/Article Review 1`] = `
   height: 1.875rem;
 }
 
-.emotion-20 svg circle {
+.emotion-21 svg circle {
   stroke: #A1845C;
 }
 
-.emotion-20 svg path {
+.emotion-21 svg path {
   fill: #A1845C;
 }
 
 @media (min-width:740px) {
-  .emotion-20 {
+  .emotion-21 {
     padding-bottom: 2.25rem;
   }
 }
 
-.emotion-21 {
+.emotion-22 {
   color: #A1845C;
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
@@ -8611,14 +8339,14 @@ exports[`Storyshots Editions/Article Review 1`] = `
   font-style: normal;
 }
 
-.emotion-22 {
+.emotion-23 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
   color: #121212;
 }
 
-.emotion-23 {
+.emotion-24 {
   background: none;
   border: none;
   padding: 0;
@@ -8626,53 +8354,53 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-24 {
+  .emotion-25 {
     width: 526px;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-24 {
+  .emotion-25 {
     width: 545px;
   }
 }
 
 @media (min-width:740px) {
-  .emotion-24 {
+  .emotion-25 {
     padding-right: 0.75rem;
     border-right: 1px solid #DCDCDC;
   }
 }
 
 @media (min-width:740px) {
-  .emotion-24 {
+  .emotion-25 {
     margin-left: 24px;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-24 {
+  .emotion-25 {
     margin-left: 144px;
   }
 }
 
-.emotion-25 {
+.emotion-26 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
 
-.emotion-25 iframe {
+.emotion-26 iframe {
   width: 100%;
   border: none;
 }
 
-.emotion-25 figcaption {
+.emotion-26 figcaption {
   background: #FFFFFF;
   padding-bottom: 0.5rem;
 }
 
 @media (min-width:740px) {
-  .emotion-25 p {
+  .emotion-26 p {
     margin: 0;
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
@@ -8680,13 +8408,13 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-25 {
+  .emotion-26 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.emotion-26 {
+.emotion-27 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -8695,18 +8423,18 @@ exports[`Storyshots Editions/Article Review 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.emotion-27 {
+.emotion-28 {
   margin: 1rem 0;
   width: 100%;
 }
 
 @media (min-width:660px) {
-  .emotion-27 {
+  .emotion-28 {
     width: 620px;
   }
 }
 
-.emotion-28 {
+.emotion-29 {
   width: 100%;
   height: calc(100% * 1.25);
   background-color: #F6F6F6;
@@ -8715,26 +8443,26 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 @media (min-width:660px) {
-  .emotion-28 {
+  .emotion-29 {
     width: 620px;
     height: calc(620px * 1.25);
   }
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-28 {
+  .emotion-29 {
     background-color: #333333;
   }
 }
 
-.emotion-31 {
+.emotion-32 {
   display: block;
   position: relative;
   margin-bottom: 0.75rem;
   margin-top: 1rem;
 }
 
-.emotion-32 {
+.emotion-33 {
   margin: 16px 0 36px;
   background: #EDEDED;
   color: #121212;
@@ -8744,20 +8472,20 @@ exports[`Storyshots Editions/Article Review 1`] = `
   position: relative;
 }
 
-.emotion-32 summary {
+.emotion-33 summary {
   list-style: none;
   margin: 0 0 16px;
 }
 
-.emotion-32 summary::-webkit-details-marker {
+.emotion-33 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-32 summary:focus {
+.emotion-33 summary:focus {
   outline: none;
 }
 
-.emotion-33 {
+.emotion-34 {
   display: block;
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
@@ -8766,7 +8494,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   color: #A1845C;
 }
 
-.emotion-34 {
+.emotion-35 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.15;
@@ -8775,7 +8503,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   line-height: 22px;
 }
 
-.emotion-35 {
+.emotion-36 {
   background: #121212;
   color: #FFFFFF;
   height: 2rem;
@@ -8799,11 +8527,11 @@ exports[`Storyshots Editions/Article Review 1`] = `
   margin: 0;
 }
 
-.emotion-35:hover {
+.emotion-36:hover {
   background: #A1845C;
 }
 
-.emotion-36 {
+.emotion-37 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8818,7 +8546,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   font-weight: 400;
 }
 
-.emotion-37 {
+.emotion-38 {
   margin-right: 12px;
   margin-bottom: 6px;
   width: 33px;
@@ -8826,36 +8554,36 @@ exports[`Storyshots Editions/Article Review 1`] = `
   height: 28px;
 }
 
-.emotion-38 {
+.emotion-39 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.emotion-38 p {
+.emotion-39 p {
   margin-bottom: 0.5rem;
 }
 
-.emotion-38 ol {
+.emotion-39 ol {
   list-style: decimal;
   list-style-position: inside;
   margin-bottom: 1rem;
 }
 
-.emotion-38 ul {
+.emotion-39 ul {
   list-style: none;
   margin: 0 0 0.75rem;
   padding: 0;
   margin-bottom: 1rem;
 }
 
-.emotion-38 ul li {
+.emotion-39 ul li {
   margin-bottom: 0.375rem;
   padding-left: 1.25rem;
 }
 
-.emotion-38 ul li:before {
+.emotion-39 ul li:before {
   display: inline-block;
   content: '';
   border-radius: 0.375rem;
@@ -8866,15 +8594,15 @@ exports[`Storyshots Editions/Article Review 1`] = `
   margin-left: -1.25rem;
 }
 
-.emotion-38 b {
+.emotion-39 b {
   font-weight: 700;
 }
 
-.emotion-38 i {
+.emotion-39 i {
   font-style: italic;
 }
 
-.emotion-38 a {
+.emotion-39 a {
   color: #6B5840;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8883,11 +8611,11 @@ exports[`Storyshots Editions/Article Review 1`] = `
   transition: border-color 0.15s ease-out;
 }
 
-.emotion-38 a:hover {
+.emotion-39 a:hover {
   border-bottom: solid 0.0625rem #A1845C;
 }
 
-.emotion-39 {
+.emotion-40 {
   font-size: 13px;
   line-height: 16px;
   display: -webkit-box;
@@ -8900,7 +8628,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-40 {
+.emotion-41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8915,7 +8643,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   font-weight: 400;
 }
 
-.emotion-41 {
+.emotion-42 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8939,20 +8667,20 @@ exports[`Storyshots Editions/Article Review 1`] = `
   height: 28px;
 }
 
-.emotion-41:hover {
+.emotion-42:hover {
   background: #A1845C;
 }
 
-.emotion-41:focus {
+.emotion-42:focus {
   border: none;
 }
 
-.emotion-42 {
+.emotion-43 {
   width: 16px;
   height: 16px;
 }
 
-.emotion-43 {
+.emotion-44 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8982,15 +8710,15 @@ exports[`Storyshots Editions/Article Review 1`] = `
   -o-transform: rotate(180deg);
 }
 
-.emotion-43:hover {
+.emotion-44:hover {
   background: #A1845C;
 }
 
-.emotion-43:focus {
+.emotion-44:focus {
   border: none;
 }
 
-.emotion-45 {
+.emotion-46 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.75rem;
   line-height: 1.5;
@@ -8998,7 +8726,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   height: 28px;
 }
 
-.emotion-48 {
+.emotion-49 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -9013,14 +8741,14 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-48 {
+  .emotion-49 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-48:before {
+.emotion-49:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -9032,7 +8760,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-48:after {
+.emotion-49:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -9042,25 +8770,25 @@ exports[`Storyshots Editions/Article Review 1`] = `
   border-top: 1px solid #A1845C;
 }
 
-.emotion-49 {
+.emotion-50 {
   margin: 0;
 }
 
-.emotion-50 {
+.emotion-51 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-50 svg {
+.emotion-51 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #A1845C;
 }
 
-.emotion-51 {
+.emotion-52 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -9083,166 +8811,170 @@ exports[`Storyshots Editions/Article Review 1`] = `
         <header
           className="emotion-4"
         >
-          <figure
-            aria-labelledby="header-image-caption"
+          <div
             className="emotion-5"
           >
-            <picture>
-              <source
-                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-              />
-              <source
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-              />
-              <img
-                alt="image"
-                className="js-launch-slideshow js-main-image emotion-6"
-                data-ratio={0.6}
-                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-              />
-            </picture>
-            <figcaption
-              className="emotion-7"
+            <figure
+              aria-labelledby="header-image-caption"
+              className="emotion-6"
             >
-              <details>
-                <summary>
-                  <span
-                    className="emotion-8"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+                />
+                <source
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+                />
+                <img
+                  alt="image"
+                  className="js-launch-slideshow js-main-image emotion-7"
+                  data-ratio={0.6}
+                  src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+                />
+              </picture>
+              <figcaption
+                className="emotion-8"
+              >
+                <details>
+                  <summary>
+                    <span
+                      className="emotion-9"
                     >
-                      <path
-                        clipRule="evenodd"
-                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                    Click to see figure caption
+                      <svg
+                        viewBox="0 0 30 30"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                      Click to see figure caption
+                    </span>
+                  </summary>
+                  <span
+                    id="header-image-caption"
+                  >
+                    ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                     
+                    Photograph: Philip Keith/The Guardian
                   </span>
-                </summary>
+                </details>
+              </figcaption>
+              <div
+                className="emotion-10"
+              >
                 <span
-                  id="header-image-caption"
+                  className="emotion-11"
                 >
-                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-                   
-                  Photograph: Philip Keith/The Guardian
+                  <svg
+                    viewBox="0 0 30 30"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clipRule="evenodd"
+                      d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
                 </span>
-              </details>
-            </figcaption>
-            <div
-              className="emotion-9"
-            >
-              <span
-                className="emotion-10"
-              >
-                <svg
-                  viewBox="0 0 30 30"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  className="emotion-11"
                 >
-                  <path
-                    clipRule="evenodd"
-                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                className="emotion-10"
-              >
-                <svg
-                  viewBox="0 0 30 30"
-                  xmlns="http://www.w3.org/2000/svg"
+                  <svg
+                    viewBox="0 0 30 30"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clipRule="evenodd"
+                      d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="emotion-11"
                 >
-                  <path
-                    clipRule="evenodd"
-                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                className="emotion-10"
-              >
-                <svg
-                  viewBox="0 0 30 30"
-                  xmlns="http://www.w3.org/2000/svg"
+                  <svg
+                    viewBox="0 0 30 30"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clipRule="evenodd"
+                      d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="emotion-11"
                 >
-                  <path
-                    clipRule="evenodd"
-                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                className="emotion-10"
-              >
-                <svg
-                  viewBox="0 0 30 30"
-                  xmlns="http://www.w3.org/2000/svg"
+                  <svg
+                    viewBox="0 0 30 30"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clipRule="evenodd"
+                      d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="emotion-15"
                 >
-                  <path
-                    clipRule="evenodd"
-                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                className="emotion-14"
-              >
-                <svg
-                  viewBox="0 0 30 30"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clipRule="evenodd"
-                    d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-            </div>
-          </figure>
+                  <svg
+                    viewBox="0 0 30 30"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clipRule="evenodd"
+                      d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </figure>
+          </div>
           <div
-            className="emotion-15"
+            className="emotion-16"
           >
             <h1
-              className="emotion-16"
+              className="emotion-17"
             >
               Reclaimed lakes and giant airports: how Mexico City might have looked
             </h1>
           </div>
           <div
-            className="emotion-17"
+            className="emotion-18"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
             </p>
           </div>
           <div
-            className="emotion-18"
+            className="emotion-19"
           >
             <div
-              className="emotion-19"
+              className="emotion-20"
             />
           </div>
           <div
-            className="emotion-20"
+            className="emotion-21"
           >
             <address>
               <span
-                className="emotion-21"
+                className="emotion-22"
               >
                 Jane Smith
               </span>
               <span
-                className="emotion-22"
+                className="emotion-23"
               >
                  Editor of things
               </span>
@@ -9252,7 +8984,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
               role="button"
             >
               <button
-                className="emotion-23"
+                className="emotion-24"
                 onClick={[Function]}
               >
                 <svg
@@ -9276,16 +9008,16 @@ exports[`Storyshots Editions/Article Review 1`] = `
       </section>
     </div>
     <div
-      className="emotion-24"
+      className="emotion-25"
     >
       <section
-        className="emotion-25"
+        className="emotion-26"
       >
         <p
-          className="emotion-26"
+          className="emotion-27"
         />
         <figure
-          className="emotion-27"
+          className="emotion-28"
         >
           <picture>
             <source
@@ -9299,7 +9031,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow emotion-28"
+              className="js-launch-slideshow emotion-29"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -9308,18 +9040,18 @@ exports[`Storyshots Editions/Article Review 1`] = `
           </picture>
         </figure>
         <p
-          className="emotion-26"
+          className="emotion-27"
         />
         <p
-          className="emotion-26"
+          className="emotion-27"
         />
         <div
-          className="emotion-31"
+          className="emotion-32"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="emotion-32"
+            className="emotion-33"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -9327,23 +9059,23 @@ exports[`Storyshots Editions/Article Review 1`] = `
               onClick={[Function]}
             >
               <span
-                className="emotion-33"
+                className="emotion-34"
               >
                 Quick Guide
               </span>
               <h4
-                className="emotion-34"
+                className="emotion-35"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="emotion-35"
+                className="emotion-36"
               >
                 <span
-                  className="emotion-36"
+                  className="emotion-37"
                 >
                   <span
-                    className="emotion-37"
+                    className="emotion-38"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -9362,7 +9094,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
             </summary>
             <div>
               <div
-                className="emotion-38"
+                className="emotion-39"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -9371,24 +9103,24 @@ exports[`Storyshots Editions/Article Review 1`] = `
               />
             </div>
             <footer
-              className="emotion-39"
+              className="emotion-40"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="emotion-40"
+                  className="emotion-41"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="emotion-41"
+                    className="emotion-42"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="emotion-42"
+                      className="emotion-43"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -9398,12 +9130,12 @@ exports[`Storyshots Editions/Article Review 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="emotion-43"
+                    className="emotion-44"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="emotion-42"
+                      className="emotion-43"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -9415,7 +9147,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-45"
+                className="emotion-46"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -9425,19 +9157,19 @@ exports[`Storyshots Editions/Article Review 1`] = `
           </details>
         </div>
         <p
-          className="emotion-26"
+          className="emotion-27"
         />
         <p
-          className="emotion-26"
+          className="emotion-27"
         />
         <aside
-          className="emotion-48"
+          className="emotion-49"
         >
           <blockquote
-            className="emotion-49"
+            className="emotion-50"
           >
             <p
-              className="emotion-50"
+              className="emotion-51"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -9452,17 +9184,17 @@ exports[`Storyshots Editions/Article Review 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-51"
+              className="emotion-52"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="emotion-26"
+          className="emotion-27"
         />
         <p
-          className="emotion-26"
+          className="emotion-27"
         />
       </section>
     </div>
@@ -9540,7 +9272,6 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -9567,17 +9298,31 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 .emotion-7 {
-  margin: 0;
-  position: relative;
+  grid-column-start: 0;
+  grid-column-end: span 12;
 }
 
-@media (min-width:980px) {
+@media (min-width:740px) {
   .emotion-7 {
-    width: 750px;
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
   }
 }
 
 .emotion-8 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-9 {
   width: 100vw;
   height: calc(100vw * 0.6);
   background-color: #F6F6F6;
@@ -9585,51 +9330,26 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   display: block;
   display: block;
   width: 100%;
-}
-
-@media (min-width:740px) {
-  .emotion-8 {
-    width: 740px;
-    height: calc(740px * 0.6);
-  }
-}
-
-@media (min-width:1300px) {
-  .emotion-8 {
-    width: 980px;
-    height: calc(980px * 0.6);
-  }
+  height: 100%;
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-8 {
+  .emotion-9 {
     background-color: #333333;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-8 {
-    width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-8 {
-    width: 750px;
-    height: 450px;
-  }
-}
-
-.emotion-9 {
+.emotion-10 {
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   top: 0;
+  width: 100%;
+  height: 100%;
 }
 
-.emotion-9 summary {
+.emotion-10 summary {
   text-align: center;
   background-color: #C70000;
   width: 34px;
@@ -9641,11 +9361,11 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   outline: none;
 }
 
-.emotion-9 summary::-webkit-details-marker {
+.emotion-10 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-9 details[open] {
+.emotion-10 details[open] {
   min-height: 44px;
   max-height: 999px;
   height: 100%;
@@ -9663,45 +9383,33 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-9 details[open] {
+  .emotion-10 details[open] {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-9 details[open] {
+  .emotion-10 details[open] {
     padding-left: 9rem;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-9 {
-    width: calc(100vw - 3.75rem);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-9 {
-    width: 750px;
-  }
-}
-
-.emotion-10 {
+.emotion-11 {
   line-height: 32px;
   font-size: 0;
 }
 
-.emotion-10 svg {
+.emotion-11 svg {
   width: 75%;
   height: 75%;
   margin: 12.5%;
 }
 
-.emotion-10 path {
+.emotion-11 path {
   fill: #FFF4F2;
 }
 
-.emotion-11 {
+.emotion-12 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.15;
@@ -9723,29 +9431,17 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   color: #333333;
 }
 
-@media (min-width:740px) {
-  .emotion-11 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-11 {
-    width: 545px;
-  }
-}
-
-.emotion-11 p,
-.emotion-11 ul {
+.emotion-12 p,
+.emotion-12 ul {
   padding-top: 0.25rem;
   margin: 0;
 }
 
-.emotion-11 address {
+.emotion-12 address {
   font-style: normal;
 }
 
-.emotion-11 svg {
+.emotion-12 svg {
   -webkit-flex: 0 0 1.875rem;
   -ms-flex: 0 0 1.875rem;
   flex: 0 0 1.875rem;
@@ -9755,31 +9451,19 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   height: 1.875rem;
 }
 
-.emotion-11 svg circle {
+.emotion-12 svg circle {
   stroke: #C70000;
 }
 
-.emotion-11 svg path {
+.emotion-12 svg path {
   fill: #C70000;
 }
 
-.emotion-12 {
+.emotion-13 {
   box-sizing: border-box;
 }
 
-@media (min-width:740px) {
-  .emotion-12 {
-    width: 539px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-12 {
-    width: 558px;
-  }
-}
-
-.emotion-13 {
+.emotion-14 {
   background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
   background-repeat: repeat-x;
   background-position: top;
@@ -9787,7 +9471,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   height: calc(0.25rem * 3 + 1px);
 }
 
-.emotion-14 {
+.emotion-15 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -9802,7 +9486,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   padding-bottom: 1.5rem;
 }
 
-.emotion-14 svg {
+.emotion-15 svg {
   -webkit-flex: 0 0 1.875rem;
   -ms-flex: 0 0 1.875rem;
   flex: 0 0 1.875rem;
@@ -9811,21 +9495,21 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   height: 1.875rem;
 }
 
-.emotion-14 svg circle {
+.emotion-15 svg circle {
   stroke: #C70000;
 }
 
-.emotion-14 svg path {
+.emotion-15 svg path {
   fill: #C70000;
 }
 
 @media (min-width:740px) {
-  .emotion-14 {
+  .emotion-15 {
     padding-bottom: 2.25rem;
   }
 }
 
-.emotion-15 {
+.emotion-16 {
   color: #C70000;
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
@@ -9834,14 +9518,14 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   font-style: normal;
 }
 
-.emotion-16 {
+.emotion-17 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
   color: #121212;
 }
 
-.emotion-17 {
+.emotion-18 {
   background: none;
   border: none;
   padding: 0;
@@ -9849,53 +9533,53 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-18 {
+  .emotion-19 {
     width: 526px;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-18 {
+  .emotion-19 {
     width: 545px;
   }
 }
 
 @media (min-width:740px) {
-  .emotion-18 {
+  .emotion-19 {
     padding-right: 0.75rem;
     border-right: 1px solid #DCDCDC;
   }
 }
 
 @media (min-width:740px) {
-  .emotion-18 {
+  .emotion-19 {
     margin-left: 24px;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-18 {
+  .emotion-19 {
     margin-left: 144px;
   }
 }
 
-.emotion-19 {
+.emotion-20 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
 
-.emotion-19 iframe {
+.emotion-20 iframe {
   width: 100%;
   border: none;
 }
 
-.emotion-19 figcaption {
+.emotion-20 figcaption {
   background: #FFFFFF;
   padding-bottom: 0.5rem;
 }
 
 @media (min-width:740px) {
-  .emotion-19 p {
+  .emotion-20 p {
     margin: 0;
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
@@ -9903,13 +9587,13 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-19 {
+  .emotion-20 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.emotion-20 {
+.emotion-21 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -9918,18 +9602,18 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   margin: 0 0 0.75rem;
 }
 
-.emotion-21 {
+.emotion-22 {
   margin: 1rem 0;
   width: 100%;
 }
 
 @media (min-width:660px) {
-  .emotion-21 {
+  .emotion-22 {
     width: 620px;
   }
 }
 
-.emotion-22 {
+.emotion-23 {
   width: 100%;
   height: calc(100% * 1.25);
   background-color: #F6F6F6;
@@ -9938,26 +9622,26 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 @media (min-width:660px) {
-  .emotion-22 {
+  .emotion-23 {
     width: 620px;
     height: calc(620px * 1.25);
   }
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-22 {
+  .emotion-23 {
     background-color: #333333;
   }
 }
 
-.emotion-25 {
+.emotion-26 {
   display: block;
   position: relative;
   margin-bottom: 0.75rem;
   margin-top: 1rem;
 }
 
-.emotion-26 {
+.emotion-27 {
   margin: 16px 0 36px;
   background: #EDEDED;
   color: #121212;
@@ -9967,20 +9651,20 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   position: relative;
 }
 
-.emotion-26 summary {
+.emotion-27 summary {
   list-style: none;
   margin: 0 0 16px;
 }
 
-.emotion-26 summary::-webkit-details-marker {
+.emotion-27 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-26 summary:focus {
+.emotion-27 summary:focus {
   outline: none;
 }
 
-.emotion-27 {
+.emotion-28 {
   display: block;
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
@@ -9989,7 +9673,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   color: #C70000;
 }
 
-.emotion-28 {
+.emotion-29 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.15;
@@ -9998,7 +9682,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   line-height: 22px;
 }
 
-.emotion-29 {
+.emotion-30 {
   background: #121212;
   color: #FFFFFF;
   height: 2rem;
@@ -10022,11 +9706,11 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   margin: 0;
 }
 
-.emotion-29:hover {
+.emotion-30:hover {
   background: #C70000;
 }
 
-.emotion-30 {
+.emotion-31 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -10041,7 +9725,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   font-weight: 400;
 }
 
-.emotion-31 {
+.emotion-32 {
   margin-right: 12px;
   margin-bottom: 6px;
   width: 33px;
@@ -10049,36 +9733,36 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   height: 28px;
 }
 
-.emotion-32 {
+.emotion-33 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.emotion-32 p {
+.emotion-33 p {
   margin-bottom: 0.5rem;
 }
 
-.emotion-32 ol {
+.emotion-33 ol {
   list-style: decimal;
   list-style-position: inside;
   margin-bottom: 1rem;
 }
 
-.emotion-32 ul {
+.emotion-33 ul {
   list-style: none;
   margin: 0 0 0.75rem;
   padding: 0;
   margin-bottom: 1rem;
 }
 
-.emotion-32 ul li {
+.emotion-33 ul li {
   margin-bottom: 0.375rem;
   padding-left: 1.25rem;
 }
 
-.emotion-32 ul li:before {
+.emotion-33 ul li:before {
   display: inline-block;
   content: '';
   border-radius: 0.375rem;
@@ -10089,15 +9773,15 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   margin-left: -1.25rem;
 }
 
-.emotion-32 b {
+.emotion-33 b {
   font-weight: 700;
 }
 
-.emotion-32 i {
+.emotion-33 i {
   font-style: italic;
 }
 
-.emotion-32 a {
+.emotion-33 a {
   color: #AB0613;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -10106,11 +9790,11 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   transition: border-color 0.15s ease-out;
 }
 
-.emotion-32 a:hover {
+.emotion-33 a:hover {
   border-bottom: solid 0.0625rem #C70000;
 }
 
-.emotion-33 {
+.emotion-34 {
   font-size: 13px;
   line-height: 16px;
   display: -webkit-box;
@@ -10123,7 +9807,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-34 {
+.emotion-35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10138,7 +9822,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   font-weight: 400;
 }
 
-.emotion-35 {
+.emotion-36 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -10162,20 +9846,20 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   height: 28px;
 }
 
-.emotion-35:hover {
+.emotion-36:hover {
   background: #C70000;
 }
 
-.emotion-35:focus {
+.emotion-36:focus {
   border: none;
 }
 
-.emotion-36 {
+.emotion-37 {
   width: 16px;
   height: 16px;
 }
 
-.emotion-37 {
+.emotion-38 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -10205,15 +9889,15 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   -o-transform: rotate(180deg);
 }
 
-.emotion-37:hover {
+.emotion-38:hover {
   background: #C70000;
 }
 
-.emotion-37:focus {
+.emotion-38:focus {
   border: none;
 }
 
-.emotion-39 {
+.emotion-40 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.75rem;
   line-height: 1.5;
@@ -10221,7 +9905,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   height: 28px;
 }
 
-.emotion-42 {
+.emotion-43 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -10236,14 +9920,14 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-42 {
+  .emotion-43 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-42:before {
+.emotion-43:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -10255,7 +9939,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-42:after {
+.emotion-43:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -10265,25 +9949,25 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   border-top: 1px solid #C70000;
 }
 
-.emotion-43 {
+.emotion-44 {
   margin: 0;
 }
 
-.emotion-44 {
+.emotion-45 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-44 svg {
+.emotion-45 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #C70000;
 }
 
-.emotion-45 {
+.emotion-46 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -10315,83 +9999,87 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               Reclaimed lakes and giant airports: how Mexico City might have looked
             </h1>
           </div>
-          <figure
-            aria-labelledby="header-image-caption"
+          <div
             className="emotion-7"
           >
-            <picture>
-              <source
-                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-              />
-              <source
-                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-              />
-              <img
-                alt="image"
-                className="js-launch-slideshow js-main-image emotion-8"
-                data-ratio={0.6}
-                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-              />
-            </picture>
-            <figcaption
-              className="emotion-9"
+            <figure
+              aria-labelledby="header-image-caption"
+              className="emotion-8"
             >
-              <details>
-                <summary>
-                  <span
-                    className="emotion-10"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
+              <picture>
+                <source
+                  media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+                />
+                <source
+                  sizes="100vw"
+                  srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+                />
+                <img
+                  alt="image"
+                  className="js-launch-slideshow js-main-image emotion-9"
+                  data-ratio={0.6}
+                  src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+                />
+              </picture>
+              <figcaption
+                className="emotion-10"
+              >
+                <details>
+                  <summary>
+                    <span
+                      className="emotion-11"
                     >
-                      <path
-                        clipRule="evenodd"
-                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                    Click to see figure caption
+                      <svg
+                        viewBox="0 0 30 30"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clipRule="evenodd"
+                          d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                      Click to see figure caption
+                    </span>
+                  </summary>
+                  <span
+                    id="header-image-caption"
+                  >
+                    ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                     
+                    Photograph: Philip Keith/The Guardian
                   </span>
-                </summary>
-                <span
-                  id="header-image-caption"
-                >
-                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-                   
-                  Photograph: Philip Keith/The Guardian
-                </span>
-              </details>
-            </figcaption>
-          </figure>
+                </details>
+              </figcaption>
+            </figure>
+          </div>
           <div
-            className="emotion-11"
+            className="emotion-12"
           >
             <p>
               The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
             </p>
           </div>
           <div
-            className="emotion-12"
+            className="emotion-13"
           >
             <div
-              className="emotion-13"
+              className="emotion-14"
             />
           </div>
           <div
-            className="emotion-14"
+            className="emotion-15"
           >
             <address>
               <span
-                className="emotion-15"
+                className="emotion-16"
               >
                 Jane Smith
               </span>
               <span
-                className="emotion-16"
+                className="emotion-17"
               >
                  Editor of things
               </span>
@@ -10401,7 +10089,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               role="button"
             >
               <button
-                className="emotion-17"
+                className="emotion-18"
                 onClick={[Function]}
               >
                 <svg
@@ -10425,16 +10113,16 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
       </section>
     </div>
     <div
-      className="emotion-18"
+      className="emotion-19"
     >
       <section
-        className="emotion-19"
+        className="emotion-20"
       >
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <figure
-          className="emotion-21"
+          className="emotion-22"
         >
           <picture>
             <source
@@ -10448,7 +10136,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
             />
             <img
               alt="Jane Giddins outside her home in Newton St Loe"
-              className="js-launch-slideshow emotion-22"
+              className="js-launch-slideshow emotion-23"
               data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
               data-credit="Photograph: Sam Frost/The Guardian"
               data-ratio={1.25}
@@ -10457,18 +10145,18 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
           </picture>
         </figure>
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <div
-          className="emotion-25"
+          className="emotion-26"
           data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
           data-atom-type="guide"
         >
           <details
-            className="emotion-26"
+            className="emotion-27"
             data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
             data-snippet-type="guide"
           >
@@ -10476,23 +10164,23 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               onClick={[Function]}
             >
               <span
-                className="emotion-27"
+                className="emotion-28"
               >
                 Quick Guide
               </span>
               <h4
-                className="emotion-28"
+                className="emotion-29"
               >
                 What is Queen's consent?
               </h4>
               <span
-                className="emotion-29"
+                className="emotion-30"
               >
                 <span
-                  className="emotion-30"
+                  className="emotion-31"
                 >
                   <span
-                    className="emotion-31"
+                    className="emotion-32"
                   >
                     <svg
                       viewBox="0 0 30 30"
@@ -10511,7 +10199,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
             </summary>
             <div>
               <div
-                className="emotion-32"
+                className="emotion-33"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
@@ -10520,24 +10208,24 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               />
             </div>
             <footer
-              className="emotion-33"
+              className="emotion-34"
             >
               <div
                 hidden={false}
               >
                 <div
-                  className="emotion-34"
+                  className="emotion-35"
                 >
                   <div>
                     Was this helpful?
                   </div>
                   <button
-                    className="emotion-35"
+                    className="emotion-36"
                     data-testid="like"
                     onClick={[Function]}
                   >
                     <svg
-                      className="emotion-36"
+                      className="emotion-37"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -10547,12 +10235,12 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
                     </svg>
                   </button>
                   <button
-                    className="emotion-37"
+                    className="emotion-38"
                     data-testid="dislike"
                     onClick={[Function]}
                   >
                     <svg
-                      className="emotion-36"
+                      className="emotion-37"
                       viewBox="0 0 40 40"
                     >
                       <path
@@ -10564,7 +10252,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-39"
+                className="emotion-40"
                 data-testid="feedback"
                 hidden={true}
               >
@@ -10574,19 +10262,19 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
           </details>
         </div>
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <aside
-          className="emotion-42"
+          className="emotion-43"
         >
           <blockquote
-            className="emotion-43"
+            className="emotion-44"
           >
             <p
-              className="emotion-44"
+              className="emotion-45"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -10601,17 +10289,17 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-45"
+              className="emotion-46"
             >
               Jane Giddins
             </cite>
           </blockquote>
         </aside>
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
         <p
-          className="emotion-20"
+          className="emotion-21"
         />
       </section>
     </div>
@@ -11569,219 +11257,90 @@ exports[`Storyshots Editions/GalleryImage Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
+exports[`Storyshots Editions/Grid Article 1`] = `
 .emotion-0 {
-  margin: 0;
-  position: relative;
-  width: 100%;
-}
-
-.emotion-1 {
-  width: 100vw;
-  height: calc(100vw * 0.6);
-  background-color: #F6F6F6;
-  color: #999999;
-  display: block;
-  display: block;
-  width: 100%;
-  height: calc(100vw * 0.6);
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-1 {
-    background-color: #333333;
-  }
-}
-
-.emotion-2 {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.emotion-2 summary {
-  text-align: center;
-  background-color: #C70000;
-  width: 34px;
-  height: 34px;
-  position: absolute;
-  bottom: 0.75rem;
-  right: 0.75rem;
-  border-radius: 100%;
-  outline: none;
-}
-
-.emotion-2 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-2 details[open] {
-  min-height: 44px;
-  max-height: 999px;
-  height: 100%;
-  background-color: rgba(0,0,0,0.8);
-  padding: 0.5rem;
-  overflow: hidden;
-  padding-right: 3rem;
-  z-index: 1;
-  color: #FFFFFF;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
+  max-width: 100%;
   box-sizing: border-box;
 }
 
-@media (min-width:740px) {
-  .emotion-2 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-2 details[open] {
-    padding-left: 9rem;
-  }
-}
-
-.emotion-3 {
-  line-height: 32px;
-  font-size: 0;
-}
-
-.emotion-3 svg {
-  width: 75%;
-  height: 75%;
-  margin: 12.5%;
-}
-
-.emotion-3 path {
-  fill: #FFF4F2;
-}
-
-<figure
-  aria-labelledby="header-image-caption"
-  className="emotion-0"
->
-  <picture>
-    <source
-      media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-      sizes="100vw"
-      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-    />
-    <source
-      sizes="100vw"
-      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-    />
-    <img
-      alt="image"
-      className="js-launch-slideshow js-main-image emotion-1"
-      data-ratio={0.6}
-      src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-    />
-  </picture>
-  <figcaption
-    className="emotion-2"
-  >
-    <details>
-      <summary>
-        <span
-          className="emotion-3"
-        >
-          <svg
-            viewBox="0 0 30 30"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clipRule="evenodd"
-              d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-              fillRule="evenodd"
-            />
-          </svg>
-          Click to see figure caption
-        </span>
-      </summary>
-      <span
-        id="header-image-caption"
-      >
-        ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-         
-        Photograph: Philip Keith/The Guardian
-      </span>
-    </details>
-  </figcaption>
-</figure>
-`;
-
-exports[`Storyshots Editions/HeaderMedia Image 1`] = `
-.emotion-0 {
-  margin: 0;
-  position: relative;
-}
-
-@media (min-width:980px) {
+@media (min-width:1300px) {
   .emotion-0 {
-    width: 750px;
+    margin-left: 9rem;
   }
 }
 
 .emotion-1 {
-  width: 100vw;
-  height: calc(100vw * 0.6);
-  background-color: #F6F6F6;
-  color: #999999;
-  display: block;
-  display: block;
-  width: 100%;
+  display: grid;
+  grid-column-gap: 16px;
+  grid-template-columns: repeat(12,1fr);
 }
 
 @media (min-width:740px) {
   .emotion-1 {
-    width: 740px;
-    height: calc(740px * 0.6);
+    grid-template-columns: repeat(12,1fr);
   }
 }
 
 @media (min-width:1300px) {
   .emotion-1 {
-    width: 980px;
-    height: calc(980px * 0.6);
-  }
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-1 {
-    background-color: #333333;
-  }
-}
-
-@media (min-width:740px) {
-  .emotion-1 {
-    width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-1 {
-    width: 750px;
-    height: 450px;
+    grid-column-gap: 24px;
+    grid-template-columns: repeat(12,1fr);
   }
 }
 
 .emotion-2 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
+  }
+}
+
+.emotion-3 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-4 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-4 {
+    background-color: #333333;
+  }
+}
+
+.emotion-5 {
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   top: 0;
+  width: 100%;
+  height: 100%;
 }
 
-.emotion-2 summary {
+.emotion-5 summary {
   text-align: center;
   background-color: #C70000;
   width: 34px;
@@ -11793,11 +11352,11 @@ exports[`Storyshots Editions/HeaderMedia Image 1`] = `
   outline: none;
 }
 
-.emotion-2 summary::-webkit-details-marker {
+.emotion-5 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-2 details[open] {
+.emotion-5 details[open] {
   min-height: 44px;
   max-height: 999px;
   height: 100%;
@@ -11815,106 +11374,1610 @@ exports[`Storyshots Editions/HeaderMedia Image 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-2 details[open] {
+  .emotion-5 details[open] {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-2 details[open] {
+  .emotion-5 details[open] {
     padding-left: 9rem;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-2 {
-    width: calc(100vw - 3.75rem);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-2 {
-    width: 750px;
-  }
-}
-
-.emotion-3 {
+.emotion-6 {
   line-height: 32px;
   font-size: 0;
 }
 
-.emotion-3 svg {
+.emotion-6 svg {
   width: 75%;
   height: 75%;
   margin: 12.5%;
 }
 
-.emotion-3 path {
+.emotion-6 path {
   fill: #FFF4F2;
 }
 
-<figure
-  aria-labelledby="header-image-caption"
+.emotion-7 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    grid-column-start: 0;
+    grid-column-end: span 8;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 {
+    grid-column-start: 0;
+    grid-column-end: span 8;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    border-right: 1px solid #DCDCDC;
+    padding-right: 0.75rem;
+  }
+}
+
+.emotion-8 {
+  position: relative;
+}
+
+.emotion-9 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (min-width:375px) {
+  .emotion-9 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-9 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+.emotion-10 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+.emotion-10 p,
+.emotion-10 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-10 address {
+  font-style: normal;
+}
+
+.emotion-10 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-10 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-10 svg path {
+  fill: #C70000;
+}
+
+.emotion-11 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    margin-right: -0.75rem;
+  }
+}
+
+.emotion-12 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-13 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-13 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-13 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-13 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-13 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-14 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-15 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-16 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+<div
   className="emotion-0"
 >
-  <picture>
-    <source
-      media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-      sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-    />
-    <source
-      sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-    />
-    <img
-      alt="image"
-      className="js-launch-slideshow js-main-image emotion-1"
-      data-ratio={0.6}
-      src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-    />
-  </picture>
-  <figcaption
-    className="emotion-2"
+  <div
+    className="emotion-1"
   >
-    <details>
-      <summary>
-        <span
-          className="emotion-3"
-        >
-          <svg
-            viewBox="0 0 30 30"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clipRule="evenodd"
-              d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-              fillRule="evenodd"
-            />
-          </svg>
-          Click to see figure caption
-        </span>
-      </summary>
-      <span
-        id="header-image-caption"
+    <div
+      className="emotion-2"
+    >
+      <figure
+        aria-labelledby="header-image-caption"
+        className="emotion-3"
       >
-        ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-         
-        Photograph: Philip Keith/The Guardian
-      </span>
-    </details>
-  </figcaption>
-</figure>
+        <picture>
+          <source
+            media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+          />
+          <source
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+          />
+          <img
+            alt="image"
+            className="js-launch-slideshow js-main-image emotion-4"
+            data-ratio={0.6}
+            src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+          />
+        </picture>
+        <figcaption
+          className="emotion-5"
+        >
+          <details>
+            <summary>
+              <span
+                className="emotion-6"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+                Click to see figure caption
+              </span>
+            </summary>
+            <span
+              id="header-image-caption"
+            >
+              ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+               
+              Photograph: Philip Keith/The Guardian
+            </span>
+          </details>
+        </figcaption>
+      </figure>
+    </div>
+    <div
+      className="emotion-7"
+    >
+      <div
+        className="emotion-8"
+      >
+        <h1
+          className="emotion-9"
+        >
+          Reclaimed lakes and giant airports: how Mexico City might have looked
+        </h1>
+      </div>
+      <div
+        className="emotion-10"
+      >
+        <p>
+          The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+        </p>
+      </div>
+      <div
+        className="emotion-11"
+      >
+        <div
+          className="emotion-12"
+        />
+      </div>
+      <div
+        className="emotion-13"
+      >
+        <address>
+          <span
+            className="emotion-14"
+          >
+            Jane Smith
+          </span>
+          <span
+            className="emotion-15"
+          >
+             Editor of things
+          </span>
+        </address>
+        <span
+          className="js-share-button"
+          role="button"
+        >
+          <button
+            className="emotion-16"
+            onClick={[Function]}
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 30 30"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="15"
+                cy="15"
+                r="14.5"
+              />
+              <path
+                d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+              />
+            </svg>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
-exports[`Storyshots Editions/HeaderMedia Video 1`] = `
+exports[`Storyshots Editions/Grid Article With Video 1`] = `
 .emotion-0 {
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin-left: 9rem;
+  }
+}
+
+.emotion-1 {
+  display: grid;
+  grid-column-gap: 16px;
+  grid-template-columns: repeat(12,1fr);
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    grid-column-gap: 24px;
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+.emotion-2 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 8;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 8;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    border-right: 1px solid #DCDCDC;
+    padding-right: 0.75rem;
+  }
+}
+
+.emotion-3 {
   width: 100%;
   position: relative;
   padding-bottom: 56.25%;
 }
 
+.emotion-4 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-6 {
+  position: relative;
+}
+
+.emotion-7 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (min-width:375px) {
+  .emotion-7 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+.emotion-8 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+.emotion-8 p,
+.emotion-8 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-8 address {
+  font-style: normal;
+}
+
+.emotion-8 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-8 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-8 svg path {
+  fill: #C70000;
+}
+
+.emotion-9 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-9 {
+    margin-right: -0.75rem;
+  }
+}
+
+.emotion-10 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-11 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-11 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-11 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-11 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-12 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-13 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-14 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+<div
+  className="emotion-0"
+>
+  <div
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <div
+        className="emotion-3"
+      >
+        <iframe
+          allowFullScreen={true}
+          className="emotion-4"
+          frameBorder="0"
+          scrolling="no"
+          src="https://embed.theguardian.com/embed/atom/media/26401ff7-24d0-4ba5-8882-2c32c2b379f0#noadsaf"
+          title="Super Bowl LV: Tom Brady MVP as Buccaneers beat Chiefs 31-9 – video report"
+        />
+      </div>
+    </div>
+    <div
+      className="emotion-2"
+    >
+      <div
+        className="emotion-6"
+      >
+        <h1
+          className="emotion-7"
+        >
+          Reclaimed lakes and giant airports: how Mexico City might have looked
+        </h1>
+      </div>
+      <div
+        className="emotion-8"
+      >
+        <p>
+          The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+        </p>
+      </div>
+      <div
+        className="emotion-9"
+      >
+        <div
+          className="emotion-10"
+        />
+      </div>
+      <div
+        className="emotion-11"
+      >
+        <address>
+          <span
+            className="emotion-12"
+          >
+            Jane Smith
+          </span>
+          <span
+            className="emotion-13"
+          >
+             Editor of things
+          </span>
+        </address>
+        <span
+          className="js-share-button"
+          role="button"
+        >
+          <button
+            className="emotion-14"
+            onClick={[Function]}
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 30 30"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="15"
+                cy="15"
+                r="14.5"
+              />
+              <path
+                d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+              />
+            </svg>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Editions/Grid Full Width 1`] = `
+.emotion-0 {
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin-left: 9rem;
+  }
+}
+
 .emotion-1 {
+  display: grid;
+  grid-column-gap: 16px;
+  grid-template-columns: repeat(12,1fr);
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    grid-column-gap: 24px;
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+.emotion-2 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+.emotion-3 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-4 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-4 {
+    background-color: #333333;
+  }
+}
+
+.emotion-5 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-5 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-5 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-5 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-5 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-5 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+.emotion-6 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-6 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-6 path {
+  fill: #FFF4F2;
+}
+
+.emotion-7 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    grid-column-start: 0;
+    grid-column-end: span 8;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-7 {
+    grid-column-start: 0;
+    grid-column-end: span 8;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-7 {
+    border-right: 1px solid #DCDCDC;
+    padding-right: 0.75rem;
+  }
+}
+
+.emotion-8 {
+  position: relative;
+}
+
+.emotion-9 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (min-width:375px) {
+  .emotion-9 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-9 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+.emotion-10 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+.emotion-10 p,
+.emotion-10 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-10 address {
+  font-style: normal;
+}
+
+.emotion-10 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-10 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-10 svg path {
+  fill: #C70000;
+}
+
+.emotion-11 {
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-11 {
+    margin-right: -0.75rem;
+  }
+}
+
+.emotion-12 {
+  background-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 0.25rem );
+  background-repeat: repeat-x;
+  background-position: top;
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-13 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-13 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-13 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-13 svg path {
+  fill: #C70000;
+}
+
+@media (min-width:740px) {
+  .emotion-13 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-14 {
+  color: #C70000;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-15 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-16 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+<div
+  className="emotion-0"
+>
+  <div
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <figure
+        aria-labelledby="header-image-caption"
+        className="emotion-3"
+      >
+        <picture>
+          <source
+            media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+          />
+          <source
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+          />
+          <img
+            alt="image"
+            className="js-launch-slideshow js-main-image emotion-4"
+            data-ratio={0.6}
+            src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+          />
+        </picture>
+        <figcaption
+          className="emotion-5"
+        >
+          <details>
+            <summary>
+              <span
+                className="emotion-6"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+                Click to see figure caption
+              </span>
+            </summary>
+            <span
+              id="header-image-caption"
+            >
+              ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+               
+              Photograph: Philip Keith/The Guardian
+            </span>
+          </details>
+        </figcaption>
+      </figure>
+    </div>
+    <div
+      className="emotion-7"
+    >
+      <div
+        className="emotion-8"
+      >
+        <h1
+          className="emotion-9"
+        >
+          Reclaimed lakes and giant airports: how Mexico City might have looked
+        </h1>
+      </div>
+      <div
+        className="emotion-10"
+      >
+        <p>
+          The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+        </p>
+      </div>
+      <div
+        className="emotion-11"
+      >
+        <div
+          className="emotion-12"
+        />
+      </div>
+      <div
+        className="emotion-13"
+      >
+        <address>
+          <span
+            className="emotion-14"
+          >
+            Jane Smith
+          </span>
+          <span
+            className="emotion-15"
+          >
+             Editor of things
+          </span>
+        </address>
+        <span
+          className="js-share-button"
+          role="button"
+        >
+          <button
+            className="emotion-16"
+            onClick={[Function]}
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 30 30"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="15"
+                cy="15"
+                r="14.5"
+              />
+              <path
+                d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+              />
+            </svg>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
+.emotion-0 {
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin-left: 9rem;
+  }
+}
+
+.emotion-1 {
+  display: grid;
+  grid-column-gap: 16px;
+  grid-template-columns: repeat(12,1fr);
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    grid-column-gap: 24px;
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+.emotion-2 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+.emotion-3 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-4 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-4 {
+    background-color: #333333;
+  }
+}
+
+.emotion-5 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-5 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-5 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-5 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-5 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-5 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+.emotion-6 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-6 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-6 path {
+  fill: #FFF4F2;
+}
+
+<div
+  className="emotion-0"
+>
+  <div
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <figure
+        aria-labelledby="header-image-caption"
+        className="emotion-3"
+      >
+        <picture>
+          <source
+            media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+          />
+          <source
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+          />
+          <img
+            alt="image"
+            className="js-launch-slideshow js-main-image emotion-4"
+            data-ratio={0.6}
+            src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+          />
+        </picture>
+        <figcaption
+          className="emotion-5"
+        >
+          <details>
+            <summary>
+              <span
+                className="emotion-6"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+                Click to see figure caption
+              </span>
+            </summary>
+            <span
+              id="header-image-caption"
+            >
+              ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+               
+              Photograph: Philip Keith/The Guardian
+            </span>
+          </details>
+        </figcaption>
+      </figure>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Editions/HeaderMedia Image 1`] = `
+.emotion-0 {
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin-left: 9rem;
+  }
+}
+
+.emotion-1 {
+  display: grid;
+  grid-column-gap: 16px;
+  grid-template-columns: repeat(12,1fr);
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    grid-column-gap: 24px;
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+.emotion-2 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
+  }
+}
+
+.emotion-3 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-4 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-4 {
+    background-color: #333333;
+  }
+}
+
+.emotion-5 {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.emotion-5 summary {
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-5 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-5 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0,0,0,0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-5 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-5 details[open] {
+    padding-left: 9rem;
+  }
+}
+
+.emotion-6 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-6 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-6 path {
+  fill: #FFF4F2;
+}
+
+<div
+  className="emotion-0"
+>
+  <div
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <figure
+        aria-labelledby="header-image-caption"
+        className="emotion-3"
+      >
+        <picture>
+          <source
+            media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+          />
+          <source
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+          />
+          <img
+            alt="image"
+            className="js-launch-slideshow js-main-image emotion-4"
+            data-ratio={0.6}
+            src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+          />
+        </picture>
+        <figcaption
+          className="emotion-5"
+        >
+          <details>
+            <summary>
+              <span
+                className="emotion-6"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+                Click to see figure caption
+              </span>
+            </summary>
+            <span
+              id="header-image-caption"
+            >
+              ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+               
+              Photograph: Philip Keith/The Guardian
+            </span>
+          </details>
+        </figcaption>
+      </figure>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Editions/HeaderMedia Video 1`] = `
+.emotion-0 {
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width:1300px) {
+  .emotion-0 {
+    margin-left: 9rem;
+  }
+}
+
+.emotion-1 {
+  display: grid;
+  grid-column-gap: 16px;
+  grid-template-columns: repeat(12,1fr);
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    grid-column-gap: 24px;
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+.emotion-2 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 8;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 8;
+  }
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    border-right: 1px solid #DCDCDC;
+    padding-right: 0.75rem;
+  }
+}
+
+.emotion-3 {
+  width: 100%;
+  position: relative;
+  padding-bottom: 56.25%;
+}
+
+.emotion-4 {
   position: absolute;
   top: 0;
   left: 0;
@@ -11925,30 +12988,86 @@ exports[`Storyshots Editions/HeaderMedia Video 1`] = `
 <div
   className="emotion-0"
 >
-  <iframe
-    allowFullScreen={true}
+  <div
     className="emotion-1"
-    frameBorder="0"
-    scrolling="no"
-    src="https://embed.theguardian.com/embed/atom/media/26401ff7-24d0-4ba5-8882-2c32c2b379f0#noadsaf"
-    title="Super Bowl LV: Tom Brady MVP as Buccaneers beat Chiefs 31-9 – video report"
-  />
+  >
+    <div
+      className="emotion-2"
+    >
+      <div
+        className="emotion-3"
+      >
+        <iframe
+          allowFullScreen={true}
+          className="emotion-4"
+          frameBorder="0"
+          scrolling="no"
+          src="https://embed.theguardian.com/embed/atom/media/26401ff7-24d0-4ba5-8882-2c32c2b379f0#noadsaf"
+          title="Super Bowl LV: Tom Brady MVP as Buccaneers beat Chiefs 31-9 – video report"
+        />
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
 .emotion-0 {
-  margin: 0;
-  position: relative;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
-@media (min-width:980px) {
+@media (min-width:1300px) {
   .emotion-0 {
-    width: 750px;
+    margin-left: 9rem;
   }
 }
 
 .emotion-1 {
+  display: grid;
+  grid-column-gap: 16px;
+  grid-template-columns: repeat(12,1fr);
+}
+
+@media (min-width:740px) {
+  .emotion-1 {
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-1 {
+    grid-column-gap: 24px;
+    grid-template-columns: repeat(12,1fr);
+  }
+}
+
+.emotion-2 {
+  grid-column-start: 0;
+  grid-column-end: span 12;
+}
+
+@media (min-width:740px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 12;
+  }
+}
+
+@media (min-width:1300px) {
+  .emotion-2 {
+    grid-column-start: 0;
+    grid-column-end: span 10;
+  }
+}
+
+.emotion-3 {
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.emotion-4 {
   width: 100vw;
   height: calc(100vw * 0.6);
   background-color: #F6F6F6;
@@ -11956,51 +13075,26 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
   display: block;
   display: block;
   width: 100%;
-}
-
-@media (min-width:740px) {
-  .emotion-1 {
-    width: 740px;
-    height: calc(740px * 0.6);
-  }
-}
-
-@media (min-width:1300px) {
-  .emotion-1 {
-    width: 980px;
-    height: calc(980px * 0.6);
-  }
+  height: 100%;
 }
 
 @media (prefers-color-scheme:dark) {
-  .emotion-1 {
+  .emotion-4 {
     background-color: #333333;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-1 {
-    width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-1 {
-    width: 750px;
-    height: 450px;
-  }
-}
-
-.emotion-2 {
+.emotion-5 {
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   top: 0;
+  width: 100%;
+  height: 100%;
 }
 
-.emotion-2 summary {
+.emotion-5 summary {
   text-align: center;
   background-color: #A1845C;
   width: 34px;
@@ -12012,11 +13106,11 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
   outline: none;
 }
 
-.emotion-2 summary::-webkit-details-marker {
+.emotion-5 summary::-webkit-details-marker {
   display: none;
 }
 
-.emotion-2 details[open] {
+.emotion-5 details[open] {
   min-height: 44px;
   max-height: 999px;
   height: 100%;
@@ -12034,206 +13128,206 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
 }
 
 @media (min-width:740px) {
-  .emotion-2 details[open] {
+  .emotion-5 details[open] {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:980px) {
-  .emotion-2 details[open] {
+  .emotion-5 details[open] {
     padding-left: 9rem;
   }
 }
 
-@media (min-width:740px) {
-  .emotion-2 {
-    width: calc(100vw - 3.75rem);
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-2 {
-    width: 750px;
-  }
-}
-
-.emotion-3 {
+.emotion-6 {
   line-height: 32px;
   font-size: 0;
 }
 
-.emotion-3 svg {
+.emotion-6 svg {
   width: 75%;
   height: 75%;
   margin: 12.5%;
 }
 
-.emotion-3 path {
+.emotion-6 path {
   fill: #FBF6EF;
 }
 
-.emotion-4 {
+.emotion-7 {
   position: absolute;
   left: 0;
   bottom: 0;
 }
 
-.emotion-5 {
+.emotion-8 {
   background-color: #FFE500;
   display: inline-block;
 }
 
-.emotion-5:nth-of-type(5) {
+.emotion-8:nth-of-type(5) {
   padding-right: 2px;
 }
 
-.emotion-5 svg {
+.emotion-8 svg {
   margin: 0 -0.125rem;
   height: 1.75rem;
 }
 
-.emotion-9 {
+.emotion-12 {
   background-color: #FFE500;
   display: inline-block;
   fill: transparent;
   stroke: #121212;
 }
 
-.emotion-9:nth-of-type(5) {
+.emotion-12:nth-of-type(5) {
   padding-right: 2px;
 }
 
-.emotion-9 svg {
+.emotion-12 svg {
   margin: 0 -0.125rem;
   height: 1.75rem;
 }
 
-<figure
-  aria-labelledby="header-image-caption"
+<div
   className="emotion-0"
 >
-  <picture>
-    <source
-      media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
-      sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
-    />
-    <source
-      sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
-      srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
-    />
-    <img
-      alt="image"
-      className="js-launch-slideshow js-main-image emotion-1"
-      data-ratio={0.6}
-      src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
-    />
-  </picture>
-  <figcaption
-    className="emotion-2"
-  >
-    <details>
-      <summary>
-        <span
-          className="emotion-3"
-        >
-          <svg
-            viewBox="0 0 30 30"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clipRule="evenodd"
-              d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
-              fillRule="evenodd"
-            />
-          </svg>
-          Click to see figure caption
-        </span>
-      </summary>
-      <span
-        id="header-image-caption"
-      >
-        ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
-         
-        Photograph: Philip Keith/The Guardian
-      </span>
-    </details>
-  </figcaption>
   <div
-    className="emotion-4"
+    className="emotion-1"
   >
-    <span
-      className="emotion-5"
+    <div
+      className="emotion-2"
     >
-      <svg
-        viewBox="0 0 30 30"
-        xmlns="http://www.w3.org/2000/svg"
+      <figure
+        aria-labelledby="header-image-caption"
+        className="emotion-3"
       >
-        <path
-          clipRule="evenodd"
-          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-          fillRule="evenodd"
-        />
-      </svg>
-    </span>
-    <span
-      className="emotion-5"
-    >
-      <svg
-        viewBox="0 0 30 30"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clipRule="evenodd"
-          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-          fillRule="evenodd"
-        />
-      </svg>
-    </span>
-    <span
-      className="emotion-5"
-    >
-      <svg
-        viewBox="0 0 30 30"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clipRule="evenodd"
-          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-          fillRule="evenodd"
-        />
-      </svg>
-    </span>
-    <span
-      className="emotion-5"
-    >
-      <svg
-        viewBox="0 0 30 30"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clipRule="evenodd"
-          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-          fillRule="evenodd"
-        />
-      </svg>
-    </span>
-    <span
-      className="emotion-9"
-    >
-      <svg
-        viewBox="0 0 30 30"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clipRule="evenodd"
-          d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
-          fillRule="evenodd"
-        />
-      </svg>
-    </span>
+        <picture>
+          <source
+            media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+          />
+          <source
+            sizes="100vw"
+            srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+          />
+          <img
+            alt="image"
+            className="js-launch-slideshow js-main-image emotion-4"
+            data-ratio={0.6}
+            src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+          />
+        </picture>
+        <figcaption
+          className="emotion-5"
+        >
+          <details>
+            <summary>
+              <span
+                className="emotion-6"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+                Click to see figure caption
+              </span>
+            </summary>
+            <span
+              id="header-image-caption"
+            >
+              ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+               
+              Photograph: Philip Keith/The Guardian
+            </span>
+          </details>
+        </figcaption>
+        <div
+          className="emotion-7"
+        >
+          <span
+            className="emotion-8"
+          >
+            <svg
+              viewBox="0 0 30 30"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clipRule="evenodd"
+                d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            className="emotion-8"
+          >
+            <svg
+              viewBox="0 0 30 30"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clipRule="evenodd"
+                d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            className="emotion-8"
+          >
+            <svg
+              viewBox="0 0 30 30"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clipRule="evenodd"
+                d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            className="emotion-8"
+          >
+            <svg
+              viewBox="0 0 30 30"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clipRule="evenodd"
+                d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            className="emotion-12"
+          >
+            <svg
+              viewBox="0 0 30 30"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clipRule="evenodd"
+                d="M22.4499 23.5499L20.1249 16.45L26.1499 12.025L25.8499 11.075H18.4L16.1 4H15.05L12.775 11.075H5.3L5 12.025L11.025 16.45L8.74999 23.5499L9.52498 24.1499L15.575 19.7249L21.6249 24.1499L22.4499 23.5499Z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </span>
+        </div>
+      </figure>
+    </div>
   </div>
-</figure>
+</div>
 `;
 
 exports[`Storyshots Editions/Headline Analysis 1`] = `
@@ -12246,7 +13340,6 @@ exports[`Storyshots Editions/Headline Analysis 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -12300,7 +13393,6 @@ exports[`Storyshots Editions/Headline Comment 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -12381,7 +13473,6 @@ exports[`Storyshots Editions/Headline Default 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -12428,7 +13519,6 @@ exports[`Storyshots Editions/Headline Feature 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -12482,7 +13572,6 @@ exports[`Storyshots Editions/Headline Interview 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -12585,7 +13674,6 @@ exports[`Storyshots Editions/Headline Media 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GT Guardian Titlepiece,Georgia,serif;
   font-size: 2.625rem;
@@ -12631,7 +13719,6 @@ exports[`Storyshots Editions/Headline Review 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -12678,7 +13765,6 @@ exports[`Storyshots Editions/Headline Showcase 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -12990,18 +14076,6 @@ exports[`Storyshots Editions/Standfirst Analysis 1`] = `
   color: #767676;
 }
 
-@media (min-width:740px) {
-  .emotion-0 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-0 {
-    width: 545px;
-  }
-}
-
 .emotion-0 p,
 .emotion-0 ul {
   padding-top: 0.25rem;
@@ -13062,18 +14136,6 @@ exports[`Storyshots Editions/Standfirst Comment 1`] = `
   color: #767676;
 }
 
-@media (min-width:740px) {
-  .emotion-0 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-0 {
-    width: 545px;
-  }
-}
-
 .emotion-0 p,
 .emotion-0 ul {
   padding-top: 0.25rem;
@@ -13127,18 +14189,6 @@ exports[`Storyshots Editions/Standfirst Default 1`] = `
   justify-content: space-between;
   padding-bottom: 1rem;
   color: #121212;
-}
-
-@media (min-width:740px) {
-  .emotion-0 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-0 {
-    width: 545px;
-  }
 }
 
 .emotion-0 p,
@@ -13198,18 +14248,6 @@ exports[`Storyshots Editions/Standfirst Media 1`] = `
   font-size: 1.25rem;
   line-height: 1.15;
   color: #FFFFFF;
-}
-
-@media (min-width:740px) {
-  .emotion-0 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-0 {
-    width: 545px;
-  }
 }
 
 .emotion-0 p,
@@ -13278,18 +14316,6 @@ exports[`Storyshots Editions/Standfirst Showcase 1`] = `
   line-height: 1.15;
   font-weight: 500;
   color: #333333;
-}
-
-@media (min-width:740px) {
-  .emotion-0 {
-    width: 526px;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-0 {
-    width: 545px;
-  }
 }
 
 .emotion-0 p,

--- a/src/components/editions/grid/Column.tsx
+++ b/src/components/editions/grid/Column.tsx
@@ -1,0 +1,42 @@
+import type { SerializedStyles } from '@emotion/core';
+import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import type { FC } from 'react';
+
+interface Props {
+	smStart?: number;
+	mdStart?: number;
+	lgStart?: number;
+	smSpan?: number;
+	mdSpan?: number;
+	lgSpan?: number;
+	className?: SerializedStyles;
+}
+
+export const Column: FC<Props> = ({
+	children,
+	smStart = 0,
+	mdStart = 0,
+	lgStart = 0,
+	smSpan = 12,
+	mdSpan = 12,
+	lgSpan = 12,
+	className,
+}) => {
+	const styles = css`
+		grid-column-start: ${smStart};
+		grid-column-end: span ${smSpan};
+
+		${from.tablet} {
+			grid-column-start: ${mdStart};
+			grid-column-end: span ${mdSpan};
+		}
+
+		${from.wide} {
+			grid-column-start: ${lgStart};
+			grid-column-end: span ${lgSpan};
+		}
+	`;
+
+	return <div css={[styles, className]}>{children}</div>;
+};

--- a/src/components/editions/grid/Container.tsx
+++ b/src/components/editions/grid/Container.tsx
@@ -1,0 +1,18 @@
+import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import type { FC } from 'react';
+
+const Container: FC = ({ children }) => {
+	const styles = css`
+		max-width: 100%;
+		box-sizing: border-box;
+
+		${from.wide} {
+			margin-left: 9rem;
+		}
+	`;
+
+	return <div css={styles}>{children}</div>;
+};
+
+export default Container;

--- a/src/components/editions/grid/Grid.stories.tsx
+++ b/src/components/editions/grid/Grid.stories.tsx
@@ -1,0 +1,93 @@
+import { css } from '@emotion/core';
+import { border, remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import Byline from 'components/editions/byline';
+import HeaderMedia from 'components/editions/headerMedia';
+import Headline from 'components/editions/headline';
+import Standfirst from 'components/editions/standfirst';
+import type { FC } from 'react';
+import { interview, article as item } from '../../../fixtures/item';
+import Lines from '../lines';
+import { Column } from './Column';
+import Container from './Container';
+import Grid from './Grid';
+
+const video = {
+	kind: 0,
+	value: {
+		kind: 1,
+		video: {
+			posterUrl:
+				'https://media.guim.co.uk/032aa99755664104fbfc4cbe45cfae0243dce462/0_0_3972_2234/master/3972.jpg',
+			videoId: 'wD_bWOEuuoc',
+			duration: 59,
+			atomId: '26401ff7-24d0-4ba5-8882-2c32c2b379f0',
+			title:
+				'Super Bowl LV: Tom Brady MVP as Buccaneers beat Chiefs 31-9 – video report',
+		},
+	},
+};
+
+const borderStyles = css`
+	${from.tablet} {
+		border-right: 1px solid ${border.secondary};
+		padding-right: ${remSpace[3]};
+	}
+`;
+
+const lineStyles = css`
+	${from.tablet} {
+		margin-right: -${remSpace[3]};
+	}
+`;
+
+const Article: FC = () => (
+	<Container>
+		<Grid smCols={12} mdCols={12} lgCols={12}>
+			<HeaderMedia item={{ ...item }} />
+			<Column smSpan={12} mdSpan={8} lgSpan={8} className={borderStyles}>
+				<Headline item={item} />
+				<Standfirst item={item} />
+				<Lines className={lineStyles} />
+				<Byline item={item} />
+			</Column>
+		</Grid>
+	</Container>
+);
+
+const FullWidth: FC = () => (
+	<Container>
+		<Grid smCols={12} mdCols={12} lgCols={12}>
+			<HeaderMedia item={{ ...interview }} />
+			<Column smSpan={12} mdSpan={8} lgSpan={8} className={borderStyles}>
+				<Headline item={item} />
+				<Standfirst item={item} />
+				<Lines className={lineStyles} />
+				<Byline item={item} />
+			</Column>
+		</Grid>
+	</Container>
+);
+
+const ArticleWithVideo: FC = () => (
+	<Container>
+		<Grid smCols={12} mdCols={12} lgCols={12}>
+			<HeaderMedia item={{ ...item, mainMedia: video }} />
+			<Column smSpan={12} mdSpan={8} lgSpan={8} className={borderStyles}>
+				<Headline item={item} />
+				<Standfirst item={item} />
+				<Lines className={lineStyles} />
+				<Byline item={item} />
+			</Column>
+		</Grid>
+	</Container>
+);
+
+// ----- Exports ----- //
+
+export default {
+	component: Column,
+	title: 'Editions/Grid',
+};
+
+export { Article, ArticleWithVideo, FullWidth };

--- a/src/components/editions/grid/Grid.tsx
+++ b/src/components/editions/grid/Grid.tsx
@@ -1,0 +1,35 @@
+import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import type { FC } from 'react';
+
+interface Props {
+	smCols?: number;
+	mdCols?: number;
+	lgCols?: number;
+}
+
+const Grid: FC<Props> = ({
+	children,
+	smCols = 12,
+	mdCols = 12,
+	lgCols = 12,
+}) => {
+	const styles = css`
+		display: grid;
+		grid-column-gap: 16px;
+		grid-template-columns: repeat(${smCols}, 1fr);
+
+		${from.tablet} {
+			grid-template-columns: repeat(${mdCols}, 1fr);
+		}
+
+		${from.wide} {
+			grid-column-gap: 24px;
+			grid-template-columns: repeat(${lgCols}, 1fr);
+		}
+	`;
+
+	return <div css={[styles]}>{children}</div>;
+};
+
+export default Grid;

--- a/src/components/editions/headerMedia/headerMedia.stories.tsx
+++ b/src/components/editions/headerMedia/headerMedia.stories.tsx
@@ -2,8 +2,10 @@
 
 import { Display, Pillar } from '@guardian/types';
 import { article, review } from 'fixtures/item';
-import type { ReactElement } from 'react';
+import type { FC, ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
+import Container from '../grid/Container';
+import Grid from '../grid/Grid';
 import HeaderMedia from './index';
 
 // ----- Setup ------ //
@@ -24,44 +26,58 @@ const video = {
 	},
 };
 
+const GridWrapper: FC = ({ children }) => (
+	<Container>
+		<Grid>{children}</Grid>
+	</Container>
+);
+
 // ----- Stories ----- //
 
 const Image = (): ReactElement => (
-	<HeaderMedia
-		item={{
-			...article,
-			theme: selectPillar(Pillar.News),
-		}}
-	/>
+	<GridWrapper>
+		<HeaderMedia
+			item={{
+				...article,
+				theme: selectPillar(Pillar.News),
+			}}
+		/>
+	</GridWrapper>
 );
 
 const FullScreen = (): ReactElement => (
-	<HeaderMedia
-		item={{
-			...article,
-			display: Display.Immersive,
-			theme: selectPillar(Pillar.News),
-		}}
-	/>
+	<GridWrapper>
+		<HeaderMedia
+			item={{
+				...article,
+				display: Display.Immersive,
+				theme: selectPillar(Pillar.News),
+			}}
+		/>
+	</GridWrapper>
 );
 
 const WithStarRating = (): ReactElement => (
-	<HeaderMedia
-		item={{
-			...review,
-			theme: selectPillar(Pillar.Culture),
-		}}
-	/>
+	<GridWrapper>
+		<HeaderMedia
+			item={{
+				...review,
+				theme: selectPillar(Pillar.Culture),
+			}}
+		/>
+	</GridWrapper>
 );
 
 const Video = (): ReactElement => (
-	<HeaderMedia
-		item={{
-			...article,
-			mainMedia: video,
-			theme: selectPillar(Pillar.News),
-		}}
-	/>
+	<GridWrapper>
+		<HeaderMedia
+			item={{
+				...article,
+				mainMedia: video,
+				theme: selectPillar(Pillar.News),
+			}}
+		/>
+	</GridWrapper>
 );
 
 // ----- Exports ----- //

--- a/src/components/editions/headerMedia/index.tsx
+++ b/src/components/editions/headerMedia/index.tsx
@@ -4,6 +4,7 @@ import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import type { Sizes } from '@guardian/image-rendering';
 import { Img } from '@guardian/image-rendering';
+import { border, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';
 import { Design, Display, none, some } from '@guardian/types';
@@ -12,45 +13,26 @@ import HeaderImageCaption, {
 } from 'components/editions/headerImageCaption';
 import StarRating from 'components/editions/starRating';
 import { MainMediaKind } from 'headerMedia';
-import type { Image } from 'image';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
-import { wideImageWidth } from '../styles';
+import { Column } from '../grid/Column';
 
 // ----- Styles ----- //
-
-const styles = css`
-	margin: 0;
-	position: relative;
-
-	${from.desktop} {
-		width: ${wideImageWidth}px;
-	}
-`;
-
-const fullWidthStyles = css`
-	margin: 0;
-	position: relative;
-	width: 100%;
-`;
-
-const captionStyles = css`
-	${from.tablet} {
-		width: calc(100vw - 3.75rem);
-	}
-
-	${from.desktop} {
-		width: ${wideImageWidth}px;
-	}
-`;
 
 const videoWrapperStyles = css`
 	width: 100%;
 	position: relative;
 	padding-bottom: 56.25%;
+`;
+
+const videoColumnStyles = css`
+	${from.tablet} {
+		border-right: 1px solid ${border.secondary};
+		padding-right: ${remSpace[3]};
+	}
 `;
 
 const videoStyles = css`
@@ -61,37 +43,28 @@ const videoStyles = css`
 	height: 100%;
 `;
 
-const fullWidthCaptionStyles = css`
+const styles = css`
+	margin: 0;
+	position: relative;
+	width: 100%;
+`;
+
+const fullWidthStyles = css`
+	margin: 0;
+	position: relative;
+	width: 100%;
+`;
+
+const captionStyles = css`
 	width: 100%;
 	height: 100%;
 `;
 
-const getImageStyle = (
-	{ width, height }: Image,
-	format: Format,
-): SerializedStyles => {
-	if (isFullWidthImage(format)) {
-		return css`
-			display: block;
-			width: 100%;
-			height: calc(100vw * ${height / width});
-		`;
-	}
-	return css`
-		display: block;
-		width: 100%;
-
-		${from.tablet} {
-			width: calc(100vw - 3.75rem);
-			height: calc((100vw - 3.75rem) * height / width);
-		}
-
-		${from.desktop} {
-			width: ${wideImageWidth}px;
-			height: ${(wideImageWidth * height) / width}px;
-		}
-	`;
-};
+const imageStyle: SerializedStyles = css`
+	display: block;
+	width: 100%;
+	height: 100%;
+`;
 
 const isFullWidthImage = (format: Format): boolean =>
 	format.display === Display.Immersive ||
@@ -102,31 +75,41 @@ const getStyles = (format: Format): SerializedStyles => {
 	return isFullWidthImage(format) ? fullWidthStyles : styles;
 };
 
-const getCaptionStyles = (format: Format): SerializedStyles => {
-	return isFullWidthImage(format) ? fullWidthCaptionStyles : captionStyles;
-};
-
-const getImageSizes = (format: Format): Sizes => {
-	return isFullWidthImage(format) ? fullWidthSizes : sizes;
-};
-
 // ----- Component ----- //
 
 interface Props {
 	item: Item;
 }
 
+interface ColProps {
+	smSpan: number;
+	mdSpan: number;
+	lgSpan: number;
+}
+
 const sizes: Sizes = {
-	mediaQueries: [
-		{ breakpoint: 'tablet', size: '740px' },
-		{ breakpoint: 'wide', size: '980px' },
-	],
+	mediaQueries: [],
 	default: '100vw',
 };
 
-const fullWidthSizes: Sizes = {
-	mediaQueries: [],
-	default: '100vw',
+const imageColProps = (format: Format): ColProps | void => {
+	if (!isFullWidthImage(format)) {
+		return {
+			smSpan: 12,
+			mdSpan: 12,
+			lgSpan: 10,
+		};
+	}
+};
+
+const videoColProps = (format: Format): ColProps | void => {
+	if (!isFullWidthImage(format)) {
+		return {
+			smSpan: 12,
+			mdSpan: 8,
+			lgSpan: 8,
+		};
+	}
 };
 
 const HeaderMedia: FC<Props> = ({ item }) => {
@@ -144,44 +127,54 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 			} = media;
 
 			return (
-				<figure css={[getStyles(format)]} aria-labelledby={captionId}>
-					<Img
-						image={image}
-						sizes={getImageSizes(format)}
-						format={item}
-						className={some(getImageStyle(image, format))}
-						supportsDarkMode
-						lightbox={some({
-							className: 'js-launch-slideshow js-main-image',
-							caption: none,
-							credit: none,
-						})}
-					/>
-					<HeaderImageCaption
-						caption={nativeCaption}
-						credit={credit}
-						styles={getCaptionStyles(format)}
-						iconColor={iconColor}
-						iconBackgroundColor={iconBackgroundColor}
-					/>
-					<StarRating item={item} />
-				</figure>
+				<Column {...imageColProps(format)}>
+					<figure
+						css={[getStyles(format)]}
+						aria-labelledby={captionId}
+					>
+						<Img
+							image={image}
+							sizes={sizes}
+							format={item}
+							className={some(imageStyle)}
+							supportsDarkMode
+							lightbox={some({
+								className: 'js-launch-slideshow js-main-image',
+								caption: none,
+								credit: none,
+							})}
+						/>
+						<HeaderImageCaption
+							caption={nativeCaption}
+							credit={credit}
+							styles={captionStyles}
+							iconColor={iconColor}
+							iconBackgroundColor={iconBackgroundColor}
+						/>
+						<StarRating item={item} />
+					</figure>
+				</Column>
 			);
 		} else {
 			const {
 				video: { title, atomId },
 			} = media;
 			return (
-				<div css={videoWrapperStyles}>
-					<iframe
-						title={title}
-						css={videoStyles}
-						frameBorder="0"
-						scrolling="no"
-						allowFullScreen
-						src={`https://embed.theguardian.com/embed/atom/media/${atomId}#noadsaf`}
-					></iframe>
-				</div>
+				<Column
+					{...videoColProps(format)}
+					className={videoColumnStyles}
+				>
+					<div css={videoWrapperStyles}>
+						<iframe
+							title={title}
+							css={videoStyles}
+							frameBorder="0"
+							scrolling="no"
+							allowFullScreen
+							src={`https://embed.theguardian.com/embed/atom/media/${atomId}#noadsaf`}
+						></iframe>
+					</div>
+				</Column>
 			);
 		}
 	});

--- a/src/components/editions/headline/index.tsx
+++ b/src/components/editions/headline/index.tsx
@@ -122,7 +122,6 @@ const getSharedStyles = (format: Format): SerializedStyles => css`
 	box-sizing: border-box;
 	border-top: 1px solid ${border.secondary};
 	padding-bottom: ${remSpace[4]};
-	padding-right: ${remSpace[2]};
 	margin: 0;
 `;
 

--- a/src/components/editions/lines.tsx
+++ b/src/components/editions/lines.tsx
@@ -3,14 +3,11 @@ import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { Lines } from '@guardian/src-ed-lines';
 import type { FC } from 'react';
-import { borderWidthStyles } from './styles';
 
 // ----- Component ----- //
 
 const styles = css`
 	box-sizing: border-box;
-
-	${borderWidthStyles}
 `;
 
 interface Props {

--- a/src/components/editions/standfirst/index.tsx
+++ b/src/components/editions/standfirst/index.tsx
@@ -12,7 +12,7 @@ import type { FC } from 'react';
 import { renderStandfirstText } from 'renderer';
 import { getThemeStyles } from 'themeStyles';
 import ShareIcon from '../shareIcon';
-import { articleWidthStyles, sidePadding } from '../styles';
+import { sidePadding } from '../styles';
 
 // ----- Template Format Specific Styles ----- //
 
@@ -47,8 +47,6 @@ const styles = (kickerColor: string): SerializedStyles => css`
 	justify-content: space-between;
 	padding-bottom: ${remSpace[4]};
 	color: ${text.primary};
-
-	${articleWidthStyles}
 
 	p,
 	ul {


### PR DESCRIPTION
## Why are you doing this?

Spike to look at using a CSS-Grid based approach for Editions Rendering.

Currently in AR we are using fixed widths based on the Figma designs control our layout.

This comes with a number of issues:
- Our designs not based on any kind of grid, merely where the designers see fit to place things.
- Our layouts are not dynamic, we can update the values by breakpoint but not in between breakpoints
- Rather than having a small number of components that handle layout values, we have a large number of width values buried within each component
- Often we end up setting a width on an individual sub-component 

While by no means a definitive solution, what this spike hopes to demonstrate is how with a few simple grid layout components we can have dynamic layers that improve consistency across our components while reducing the amount of code we use to control widths.

By controlling the number columns our layout components sit across - and allowing our subcomponents with to be entirely controlled by the layout components - we reach an elegant solution to many of the above problems.

![Screenshot 2021-02-18 at 17 05 32](https://user-images.githubusercontent.com/77005274/108393675-c9284b80-720b-11eb-94c2-7f2ca31712d9.png)

Its worth mentioning that in order for this to work properly we would need:
- Designers to use grids (although this can be approximated)
- A reasonable size refactor of existing Editions components to remove the hardcode width values 

This PR exists only as a demo of an idea and a starting point for discussion. I think we could and should be using grid based layouts where ever possible as the advantages are huge - let's find a way to make that happen.

** Its worth mentioning too that while I was finishing this off eariler @SiAdcock shared his latest Source Layout components which look fantastic and would probably do a very similar job - my next task is to look at those. **

## Changes

- Create grid components
- Refactor `HeaderMedia` component to fill container width as an example of how Grid can assist our layouts
- Remove `magic number` widths where possible

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/108384124-5c5c8380-7202-11eb-8afc-775e706380af.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/108384164-68484580-7202-11eb-8df2-723661e911f8.png" width="300px" /> | 
