### PR TITLE
LIVE-1689: Lib.ts tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25769,6 +25769,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.1.tgz",
+      "integrity": "sha512-IEmN/ZfmMw6G1hgZpVd0LuZXOQDisrMOZrzYd5x3RAK4bMPlJohKUZWZ9t/QsTvH0dV9TbPDcc2OSuIDcihnHA==",
+      "dev": true
+    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "webpack-dev-server": "^3.11.1",
     "webpack-manifest-plugin": "^3.0.0",
     "webpack-node-externals": "^2.5.2",
+    "whatwg-fetch": "^3.6.1",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.0"
   }

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { identity } from './lib';
+import { identity, isElement } from './lib';
 
 // ----- Tests ----- //
 
@@ -9,5 +9,29 @@ describe('identity', () => {
 		expect(identity(2)).toBe(2);
 		expect(identity('hello world')).toBe('hello world');
 		expect(identity({ foo: 'bar' })).toEqual({ foo: 'bar' });
+	});
+});
+
+describe('isElement', () => {
+	it('returns true for element nodes', () => {
+		['div', 'p', 'img'].forEach((descriptor) => {
+			const el = document.createElement(descriptor);
+			expect(isElement(el)).toBe(true);
+		});
+	});
+
+	it('returns false for text nodes', () => {
+		const textNode = document.createTextNode('Some text');
+		expect(isElement(textNode)).toBe(false);
+	});
+
+	it('returns false for document fragments', () => {
+		const frag = document.createDocumentFragment();
+		expect(isElement(frag)).toBe(false);
+	});
+
+	it('returns false for attribute nodes', () => {
+		const attributeNode = document.createAttribute('test-attrib');
+		expect(isElement(attributeNode)).toBe(false);
 	});
 });

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { identity, isElement, toArray, memoise } from './lib';
+import { identity, isElement, toArray, memoise, errorToString } from './lib';
 
 // ----- Tests ----- //
 
@@ -68,5 +68,30 @@ describe('memoise', () => {
 		fn();
 		fn();
 		expect(mockFn).toBeCalledTimes(1);
+	});
+});
+
+describe('errorToString', () => {
+	const message = 'An error message';
+	const fallback = 'A fallback message';
+
+	it('returns the Error message string', () => {
+		const err = new Error(message);
+		expect(errorToString(err, fallback)).toBe(`Error: ${message}`);
+	});
+
+	it(`returns the object's toString`, () => {
+		const o1 = new Object();
+		const o2 = { toString: () => message };
+		expect(errorToString(o1, fallback)).toBe('[object Object]');
+		expect(errorToString(o2, fallback)).toBe(message);
+	});
+
+	it('returns a fallback when no error or object provided', () => {
+		expect(errorToString('1', fallback)).toBe(fallback);
+		expect(errorToString(1, fallback)).toBe(fallback);
+		expect(errorToString(null, fallback)).toBe(fallback);
+		expect(errorToString(undefined, fallback)).toBe(fallback);
+		expect(errorToString([], fallback)).toBe(fallback);
 	});
 });

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,6 +1,13 @@
 // ----- Imports ----- //
 
-import { identity, isElement, toArray, memoise, errorToString } from './lib';
+import {
+	identity,
+	isElement,
+	toArray,
+	memoise,
+	errorToString,
+	isObject,
+} from './lib';
 
 // ----- Tests ----- //
 
@@ -94,4 +101,39 @@ describe('errorToString', () => {
 		expect(errorToString(undefined, fallback)).toBe(fallback);
 		expect(errorToString([], fallback)).toBe(fallback);
 	});
+});
+
+describe('isObject', () => {
+	const nonObjects = [
+		null,
+		undefined,
+		false,
+		0,
+		NaN,
+		'',
+		true,
+		1,
+		'a',
+		Symbol('a'),
+	];
+
+	test.each(nonObjects)('returns false for %p', (...[nonObject]) =>
+		expect(isObject(nonObject)).toBe(false),
+	);
+
+	const objects = [
+		[1, 2, 3],
+		Object(false),
+		new Date(),
+		new Error(),
+		{ a: 1 },
+		Object(0),
+		/x/,
+		Object('a'),
+		document.body,
+	];
+
+	test.each(objects)(`returns true for '%p'}`, (...[obj]) =>
+		expect(isObject(obj)).toBe(true),
+	);
 });

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { identity, isElement } from './lib';
+import { identity, isElement, toArray } from './lib';
 
 // ----- Tests ----- //
 
@@ -33,5 +33,15 @@ describe('isElement', () => {
 	it('returns false for attribute nodes', () => {
 		const attributeNode = document.createAttribute('test-attrib');
 		expect(isElement(attributeNode)).toBe(false);
+	});
+});
+
+describe('toArray', () => {
+	it('turns a value into an array of that value', () => {
+		expect(toArray(1)).toStrictEqual([1]);
+		expect(toArray('some string')).toStrictEqual(['some string']);
+		expect(toArray([1])).toStrictEqual([[1]]);
+		expect(toArray(null)).toStrictEqual([null]);
+		expect(toArray(undefined)).toStrictEqual([undefined]);
 	});
 });

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { identity, isElement, toArray } from './lib';
+import { identity, isElement, toArray, memoise } from './lib';
 
 // ----- Tests ----- //
 
@@ -43,5 +43,30 @@ describe('toArray', () => {
 		expect(toArray([1])).toStrictEqual([[1]]);
 		expect(toArray(null)).toStrictEqual([null]);
 		expect(toArray(undefined)).toStrictEqual([undefined]);
+	});
+});
+
+describe('memoise', () => {
+	it('always returns the same value', () => {
+		const mockValue = 'a value';
+		const mockFn = jest.fn(() => mockValue);
+
+		const fn = memoise(mockFn);
+		const firstCall = fn();
+		const secondCall = fn();
+
+		expect(firstCall).toEqual(mockValue);
+		expect(secondCall).toEqual(mockValue);
+	});
+
+	it('only calls the memoised function once', () => {
+		const mockValue = 'a value';
+		const mockFn = jest.fn(() => mockValue);
+
+		const fn = memoise(mockFn);
+		fn();
+		fn();
+		fn();
+		expect(mockFn).toBeCalledTimes(1);
 	});
 });

--- a/src/lib.test.tsx
+++ b/src/lib.test.tsx
@@ -1,12 +1,14 @@
 // ----- Imports ----- //
 
+import { none, some } from '@guardian/types';
 import {
+	errorToString,
 	identity,
 	isElement,
-	toArray,
-	memoise,
-	errorToString,
 	isObject,
+	maybeRender,
+	memoise,
+	toArray,
 } from './lib';
 
 // ----- Tests ----- //
@@ -89,7 +91,7 @@ describe('errorToString', () => {
 
 	it(`returns the object's toString`, () => {
 		const o1 = new Object();
-		const o2 = { toString: () => message };
+		const o2 = { toString: (): string => message };
 		expect(errorToString(o1, fallback)).toBe('[object Object]');
 		expect(errorToString(o2, fallback)).toBe(message);
 	});
@@ -136,4 +138,41 @@ describe('isObject', () => {
 	test.each(objects)(`returns true for '%p'}`, (...[obj]) =>
 		expect(isObject(obj)).toBe(true),
 	);
+});
+
+describe('maybeRender', () => {
+	it('renders a react element given `some` value', () => {
+		expect(maybeRender(some('a string'), (value) => <>{value}</>))
+			.toMatchInlineSnapshot(`
+		<React.Fragment>
+		  a string
+		</React.Fragment>
+	`);
+	});
+
+	it('returns a react element given `some` value even if it is falsey', () => {
+		expect(
+			maybeRender(some(null), (value) => <>{value}</>),
+		).toMatchInlineSnapshot(`<React.Fragment />`);
+
+		expect(
+			maybeRender(some(false), (value) => <>{value}</>),
+		).toMatchInlineSnapshot(`<React.Fragment />`);
+
+		expect(
+			maybeRender(some(undefined), (value) => <>{value}</>),
+		).toMatchInlineSnapshot(`<React.Fragment />`);
+		expect(maybeRender(some(''), (value) => <>{value}</>))
+			.toMatchInlineSnapshot(`
+		<React.Fragment>
+		  
+		</React.Fragment>
+	`);
+	});
+
+	it('returns null given a none', () => {
+		expect(
+			maybeRender(none, (value) => <>{value}</>),
+		).toMatchInlineSnapshot(`null`);
+	});
 });

--- a/src/lib.test.tsx
+++ b/src/lib.test.tsx
@@ -5,6 +5,7 @@ import {
 	errorToString,
 	handleErrors,
 	identity,
+	index,
 	isElement,
 	isObject,
 	maybeRender,
@@ -194,5 +195,18 @@ describe('handleErrors', () => {
 		expect(() => handleErrors(res)).toThrowErrorMatchingInlineSnapshot(
 			`"response error message"`,
 		);
+	});
+});
+
+describe('index', () => {
+	const value = 'value';
+	const arr = [value];
+
+	it('returns a some given an index within the bounds of the array', () => {
+		expect(index(0)(arr)).toEqual(some(value));
+	});
+
+	it('returns a none given an out of bounds index', () => {
+		expect(index(1)(arr)).toEqual(none);
 	});
 });

--- a/src/lib.test.tsx
+++ b/src/lib.test.tsx
@@ -11,6 +11,7 @@ import {
 	isObject,
 	maybeRender,
 	memoise,
+	pipe,
 	toArray,
 } from './lib';
 import 'whatwg-fetch';
@@ -36,6 +37,21 @@ describe('compose', () => {
 		expect(f).toHaveBeenCalledWith(b);
 		expect(result).toBe(c);
 	});
+});
+
+describe('pipe', () => {
+	type A = number;
+	type B = string;
+
+	const a: A = 1;
+	const b: B = '1';
+
+	const fn = jest.fn<B, [A]>((a: number) => a.toString());
+
+	const result = pipe<A, B>(a, fn);
+
+	expect(fn).toHaveBeenCalledWith(a);
+	expect(result).toBe(b);
 });
 
 describe('identity', () => {

--- a/src/lib.test.tsx
+++ b/src/lib.test.tsx
@@ -13,6 +13,7 @@ import {
 	memoise,
 	pipe,
 	pipe2,
+	pipe3,
 	toArray,
 } from './lib';
 import 'whatwg-fetch';
@@ -47,7 +48,7 @@ describe('pipe', () => {
 	const a: A = 1;
 	const b: B = '1';
 
-	const fn = jest.fn<B, [A]>((a: number) => b);
+	const fn = jest.fn<B, [A]>((a: A): B => b);
 
 	const result = pipe<A, B>(a, fn);
 
@@ -64,14 +65,37 @@ describe('pipe2', () => {
 	const b: B = '1';
 	const c = true;
 
-	const f = jest.fn<B, [A]>((a: number): string => b);
-	const g = jest.fn<C, [B]>((b: string): boolean => c);
+	const f = jest.fn<B, [A]>((a: A): B => b);
+	const g = jest.fn<C, [B]>((b: B): C => c);
 
 	const result = pipe2<A, B, C>(a, f, g);
 
 	expect(f).toHaveBeenCalledWith(a);
 	expect(g).toHaveBeenCalledWith(b);
 	expect(result).toBe(c);
+});
+
+describe('pipe3', () => {
+	type A = number;
+	type B = string;
+	type C = boolean;
+	type D = [number, string];
+
+	const a: A = 1;
+	const b: B = '1';
+	const c: C = true;
+	const d: D = [a, b];
+
+	const f = jest.fn<B, [A]>((a: A): B => b);
+	const g = jest.fn<C, [B]>((b: B): C => c);
+	const h = jest.fn<D, [C]>((c: C): D => d);
+
+	const result = pipe3<A, B, C, D>(a, f, g, h);
+
+	expect(f).toHaveBeenCalledWith(a);
+	expect(g).toHaveBeenCalledWith(b);
+	expect(h).toHaveBeenCalledWith(c);
+	expect(result).toBe(d);
 });
 
 describe('identity', () => {

--- a/src/lib.test.tsx
+++ b/src/lib.test.tsx
@@ -12,6 +12,7 @@ import {
 	maybeRender,
 	memoise,
 	pipe,
+	pipe2,
 	toArray,
 } from './lib';
 import 'whatwg-fetch';
@@ -46,12 +47,31 @@ describe('pipe', () => {
 	const a: A = 1;
 	const b: B = '1';
 
-	const fn = jest.fn<B, [A]>((a: number) => a.toString());
+	const fn = jest.fn<B, [A]>((a: number) => b);
 
 	const result = pipe<A, B>(a, fn);
 
 	expect(fn).toHaveBeenCalledWith(a);
 	expect(result).toBe(b);
+});
+
+describe('pipe2', () => {
+	type A = number;
+	type B = string;
+	type C = boolean;
+
+	const a: A = 1;
+	const b: B = '1';
+	const c = true;
+
+	const f = jest.fn<B, [A]>((a: number): string => b);
+	const g = jest.fn<C, [B]>((b: string): boolean => c);
+
+	const result = pipe2<A, B, C>(a, f, g);
+
+	expect(f).toHaveBeenCalledWith(a);
+	expect(g).toHaveBeenCalledWith(b);
+	expect(result).toBe(c);
 });
 
 describe('identity', () => {

--- a/src/lib.test.tsx
+++ b/src/lib.test.tsx
@@ -18,7 +18,7 @@ import 'whatwg-fetch';
 // ----- Tests ----- //
 
 describe('compose', () => {
-	it('composes three functions correctly', () => {
+	it('composes two functions correctly', () => {
 		type A = string;
 		type B = number;
 		type C = boolean;

--- a/src/lib.test.tsx
+++ b/src/lib.test.tsx
@@ -3,6 +3,7 @@
 import { none, some } from '@guardian/types';
 import {
 	errorToString,
+	handleErrors,
 	identity,
 	isElement,
 	isObject,
@@ -10,6 +11,7 @@ import {
 	memoise,
 	toArray,
 } from './lib';
+import 'whatwg-fetch';
 
 // ----- Tests ----- //
 
@@ -174,5 +176,23 @@ describe('maybeRender', () => {
 		expect(
 			maybeRender(none, (value) => <>{value}</>),
 		).toMatchInlineSnapshot(`null`);
+	});
+});
+
+describe('handleErrors', () => {
+	it('returns the response if the status is ok', () => {
+		const res = new Response();
+		expect(handleErrors(res)).toBe(res);
+	});
+
+	it('throws an error if the response is not ok', () => {
+		// mock a not ok response
+		const res = new Response('', {
+			status: 400,
+			statusText: 'response error message',
+		});
+		expect(() => handleErrors(res)).toThrowErrorMatchingInlineSnapshot(
+			`"response error message"`,
+		);
 	});
 });

--- a/src/lib.test.tsx
+++ b/src/lib.test.tsx
@@ -2,6 +2,7 @@
 
 import { none, some } from '@guardian/types';
 import {
+	compose,
 	errorToString,
 	handleErrors,
 	identity,
@@ -15,6 +16,27 @@ import {
 import 'whatwg-fetch';
 
 // ----- Tests ----- //
+
+describe('compose', () => {
+	it('composes three functions correctly', () => {
+		type A = string;
+		type B = number;
+		type C = boolean;
+
+		const a: A = 'a';
+		const b: B = 1;
+		const c: C = true;
+
+		const g = jest.fn<B, [A]>((a: A): B => b);
+		const f = jest.fn<C, [B]>((b: B): C => c);
+
+		const composed = compose(f, g);
+		const result = composed(a);
+		expect(g).toHaveBeenCalledWith(a);
+		expect(f).toHaveBeenCalledWith(b);
+		expect(result).toBe(c);
+	});
+});
 
 describe('identity', () => {
 	it('returns the same value that it was given', () => {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,7 +38,7 @@ function memoise<A>(fn: () => A): () => A {
 }
 
 function errorToString(error: unknown, fallback: string): string {
-	if (typeof error === 'object') {
+	if (typeof error === 'object' && !Array.isArray(error)) {
 		return error?.toString() ?? fallback;
 	}
 


### PR DESCRIPTION
This is a subtask of our [Increase test coverage](https://theguardian.atlassian.net/browse/LIVE-1684?atlOrigin=eyJpIjoiOThiNWJlMmI2NDJhNGQ0OGEzZDBkOGNhYzY3NjEyNjUiLCJwIjoiaiJ9) health ticket.

NB. The `whatwg-fetch` module was added to mock a fetch response in the jest environment.

### Test coverage
| | Before | After |
| - | ------ | ----- |
| Statements | 49.66% | 50.95% (+1.29%)|
| Branches | 37.73% | 39.13% (+1.4%)| 
| Functions | 46.45% | 48.94% (+2.49%) |
| Lines | 49.55% | 50.72% (+1.17%) |
