### PR TITLE
LIVE-1686: atoms.ts tests

### DIFF
--- a/src/atoms.test.ts
+++ b/src/atoms.test.ts
@@ -1,6 +1,11 @@
+import { Atoms } from '@guardian/content-api-models/v1/atoms';
 import { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
-import { err } from '@guardian/types';
+import { Atom } from '@guardian/content-atom-model/atom';
+import { AtomType } from '@guardian/content-atom-model/atomType';
+import { ContentChangeDetails } from '@guardian/content-atom-model/contentChangeDetails';
+import { err, fromNullable, ok } from '@guardian/types';
+import { ElementKind } from 'bodyElement';
 import Int64 from 'node-int64';
 import { DocParser } from 'types/parserContext';
 import { formatOptionalDate, parseAtom } from './atoms';
@@ -26,19 +31,99 @@ describe('parseAtom', () => {
 	let docFragment: DocumentFragment;
 	let docParser: DocParser;
 	let blockElement: BlockElement;
+	let atomId: string;
 
 	beforeEach(() => {
+		atomId = 'atom-id';
 		docFragment = document.createDocumentFragment();
 		docParser = (html: string) => docFragment;
 		blockElement = {
 			type: ElementType.CONTENTATOM,
 			assets: [],
+			contentAtomTypeData: {
+				atomId: atomId,
+				atomType: 'interactive',
+			},
 		};
 	});
 
 	it('returns an error if the atom has no data', () => {
+		blockElement.contentAtomTypeData = undefined;
 		expect(parseAtom(blockElement, {}, docParser)).toEqual(
 			err('The atom has no data'),
 		);
+	});
+
+	describe('interactives', () => {
+		let atoms: Atoms;
+		let interactive: Atom;
+
+		beforeEach(() => {
+			interactive = {
+				id: atomId,
+				atomType: AtomType.INTERACTIVE,
+				labels: [],
+				defaultHtml: '',
+				data: {
+					kind: 'interactive',
+					interactive: {
+						type: 'interactive',
+						title: '',
+						css: '',
+						html: '',
+					},
+				},
+				contentChangeDetails: {} as ContentChangeDetails,
+				commissioningDesks: [],
+			};
+			atoms = {
+				interactives: [interactive],
+			};
+		});
+
+		it(`returns an error if no interactive atom id matches`, () => {
+			atoms.interactives = [];
+
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No atom matched this id: ${atomId}`),
+			);
+		});
+
+		it(`returns an error if there's not atom content`, () => {
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No content for atom: ${atomId}`),
+			);
+		});
+
+		it('returns InteractiveAtom result type given the correct args', () => {
+			// (atoms.interactives as Atom[])[0]["data"] as .interactive
+			const atomsWithData = { ...atoms };
+			const css = 'css';
+			const html = 'html';
+			const js = 'js';
+			const interactiveWithData: Atom = {
+				...interactive,
+				data: {
+					kind: 'interactive',
+					interactive: {
+						type: 'interactive',
+						title: '',
+						css,
+						html,
+						mainJS: js,
+					},
+				},
+			};
+			atomsWithData.interactives = [interactiveWithData];
+
+			expect(parseAtom(blockElement, atomsWithData, docParser)).toEqual(
+				ok({
+					kind: ElementKind.InteractiveAtom,
+					html,
+					css,
+					js: fromNullable(js),
+				}),
+			);
+		});
 	});
 });

--- a/src/atoms.test.ts
+++ b/src/atoms.test.ts
@@ -5,6 +5,7 @@ import { Atom } from '@guardian/content-atom-model/atom';
 import { AtomType } from '@guardian/content-atom-model/atomType';
 import { ChartAtom } from '@guardian/content-atom-model/chart/chartAtom';
 import { ContentChangeDetails } from '@guardian/content-atom-model/contentChangeDetails';
+import { ExplainerAtom } from '@guardian/content-atom-model/explainer/explainerAtom';
 import { GuideAtom } from '@guardian/content-atom-model/guide/guideAtom';
 import { GuideItem } from '@guardian/content-atom-model/guide/guideItem';
 import { ProfileAtom } from '@guardian/content-atom-model/profile/profileAtom';
@@ -487,7 +488,7 @@ describe('parseAtom', () => {
 			timeline = {
 				id: atomId,
 				title: '',
-				atomType: AtomType.PROFILE,
+				atomType: AtomType.TIMELINE,
 				labels: [],
 				defaultHtml: '',
 				data: {
@@ -544,6 +545,67 @@ describe('parseAtom', () => {
 						},
 					],
 					description: 'timeline description',
+				}),
+			);
+		});
+	});
+
+	describe('explainer', () => {
+		let atoms: Atoms;
+		let explainer: Atom;
+		let explainerAtom: ExplainerAtom;
+
+		beforeEach(() => {
+			blockElement.contentAtomTypeData = {
+				atomId: atomId,
+				atomType: 'explainer',
+			};
+			explainerAtom = {
+				title: '',
+				body: '',
+				displayType: 0,
+			};
+			explainer = {
+				id: atomId,
+				title: '',
+				atomType: AtomType.EXPLAINER,
+				labels: [],
+				defaultHtml: '',
+				data: {
+					kind: 'explainer',
+					explainer: explainerAtom,
+				},
+				contentChangeDetails: {} as ContentChangeDetails,
+				commissioningDesks: [],
+			};
+			atoms = {
+				explainers: [explainer],
+			};
+		});
+
+		it(`returns an error if no explainer atom id matches`, () => {
+			explainer.data.kind = 'interactive';
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No atom matched this id: ${atomId}`),
+			);
+		});
+
+		it(`returns an error if no explainer title or body`, () => {
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No title or body for atom: ${atomId}`),
+			);
+		});
+
+		it(`parses explainer atom correctly`, () => {
+			explainerAtom.title = 'explainer title';
+			explainerAtom.body = 'explainer body';
+
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				ok({
+					kind: ElementKind.ExplainerAtom,
+					html: 'explainer body',
+					title: 'explainer title',
+					id: atomId,
 				}),
 			);
 		});

--- a/src/atoms.test.ts
+++ b/src/atoms.test.ts
@@ -71,6 +71,17 @@ describe('parseAtom', () => {
 		);
 	});
 
+	it('returns an error if atom type not supported', () => {
+		let unsupportedAtomType = 'unsupported type';
+		blockElement.contentAtomTypeData = {
+			atomId: atomId,
+			atomType: unsupportedAtomType,
+		};
+		expect(parseAtom(blockElement, {}, docParser)).toEqual(
+			err(`Atom type not supported: ${unsupportedAtomType}`),
+		);
+	});
+
 	describe('interactives', () => {
 		let atoms: Atoms;
 		let interactive: Atom;

--- a/src/atoms.test.ts
+++ b/src/atoms.test.ts
@@ -1,5 +1,9 @@
+import { BlockElement } from '@guardian/content-api-models/v1/blockElement';
+import { ElementType } from '@guardian/content-api-models/v1/elementType';
+import { err } from '@guardian/types';
 import Int64 from 'node-int64';
-import { formatOptionalDate } from './atoms';
+import { DocParser } from 'types/parserContext';
+import { formatOptionalDate, parseAtom } from './atoms';
 
 describe('formatOptionalDate', () => {
 	it('returns undefined given an undefined value', () => {
@@ -15,5 +19,26 @@ describe('formatOptionalDate', () => {
 		const date = 1614000379674;
 		const int64 = new Int64(date);
 		expect(formatOptionalDate(int64)).toBe('Mon Feb 22 2021');
+	});
+});
+
+describe('parseAtom', () => {
+	let docFragment: DocumentFragment;
+	let docParser: DocParser;
+	let blockElement: BlockElement;
+
+	beforeEach(() => {
+		docFragment = document.createDocumentFragment();
+		docParser = (html: string) => docFragment;
+		blockElement = {
+			type: ElementType.CONTENTATOM,
+			assets: [],
+		};
+	});
+
+	it('returns an error if the atom has no data', () => {
+		expect(parseAtom(blockElement, {}, docParser)).toEqual(
+			err('The atom has no data'),
+		);
 	});
 });

--- a/src/atoms.test.ts
+++ b/src/atoms.test.ts
@@ -3,6 +3,7 @@ import { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import { Atom } from '@guardian/content-atom-model/atom';
 import { AtomType } from '@guardian/content-atom-model/atomType';
+import { AudioAtom } from '@guardian/content-atom-model/audio/audioAtom';
 import { ChartAtom } from '@guardian/content-atom-model/chart/chartAtom';
 import { ContentChangeDetails } from '@guardian/content-atom-model/contentChangeDetails';
 import { ExplainerAtom } from '@guardian/content-atom-model/explainer/explainerAtom';
@@ -693,6 +694,68 @@ describe('parseAtom', () => {
 					caption: some(frag),
 					duration: some(1000),
 					videoId: 'asset-id',
+				}),
+			);
+		});
+	});
+
+	describe('audio', () => {
+		let atoms: Atoms;
+		let audio: Atom;
+		let audioAtom: AudioAtom;
+
+		beforeEach(() => {
+			blockElement.contentAtomTypeData = {
+				atomId: atomId,
+				atomType: 'audio',
+			};
+			audioAtom = {
+				kicker: 'audio-kickcer',
+				coverUrl: 'cover-url',
+				trackUrl: 'track-url',
+				duration: 1000,
+				contentId: 'content-id',
+			};
+			audio = {
+				id: atomId,
+				title: '',
+				atomType: AtomType.AUDIO,
+				labels: [],
+				defaultHtml: '',
+				data: {
+					kind: 'audio',
+					audio: audioAtom,
+				},
+				contentChangeDetails: {} as ContentChangeDetails,
+				commissioningDesks: [],
+			};
+			atoms = {
+				audios: [audio],
+			};
+		});
+
+		it(`returns an error if no audio atom id matches`, () => {
+			audio.data.kind = 'interactive';
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No atom matched this id: ${atomId}`),
+			);
+		});
+
+		it(`returns an error given no audio title`, () => {
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No title for audio atom with id: ${atomId}`),
+			);
+		});
+
+		it(`parses audio atom correctly`, () => {
+			audio.title = 'audio title';
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				ok({
+					kind: ElementKind.AudioAtom,
+					id: 'atom-id',
+					kicker: 'audio-kickcer',
+					title: 'audio title',
+					trackUrl: 'track-url',
 				}),
 			);
 		});

--- a/src/atoms.test.ts
+++ b/src/atoms.test.ts
@@ -6,6 +6,8 @@ import { AtomType } from '@guardian/content-atom-model/atomType';
 import { ContentChangeDetails } from '@guardian/content-atom-model/contentChangeDetails';
 import { GuideAtom } from '@guardian/content-atom-model/guide/guideAtom';
 import { GuideItem } from '@guardian/content-atom-model/guide/guideItem';
+import { ProfileAtom } from '@guardian/content-atom-model/profile/profileAtom';
+import { ProfileItem } from '@guardian/content-atom-model/profile/profileItem';
 import { QAndAAtom } from '@guardian/content-atom-model/qanda/qAndAAtom';
 import { QAndAItem } from '@guardian/content-atom-model/qanda/qAndAItem';
 import { err, fromNullable, ok } from '@guardian/types';
@@ -288,6 +290,87 @@ describe('parseAtom', () => {
 					image: 'image-file',
 					credit: 'credit',
 					title: qanda.title,
+				}),
+			);
+		});
+	});
+
+	describe('profile', () => {
+		let atoms: Atoms;
+		let profile: Atom;
+		let profileItem: ProfileItem;
+		let profileAtom: ProfileAtom;
+
+		beforeEach(() => {
+			blockElement.contentAtomTypeData = {
+				atomId: atomId,
+				atomType: 'profile',
+			};
+			profileItem = {
+				title: 'profile title',
+				body: 'profile body',
+			};
+			profileAtom = {
+				items: [profileItem],
+			};
+			profile = {
+				id: atomId,
+				title: '',
+				atomType: AtomType.PROFILE,
+				labels: [],
+				defaultHtml: '',
+				data: {
+					kind: 'profile',
+					profile: profileAtom,
+				},
+				contentChangeDetails: {} as ContentChangeDetails,
+				commissioningDesks: [],
+			};
+			atoms = {
+				profiles: [profile],
+			};
+		});
+
+		it(`returns an error if no profile atom id matches`, () => {
+			profile.data.kind = 'interactive';
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No atom matched this id: ${atomId}`),
+			);
+		});
+
+		it(`returns an error if no profile title or body`, () => {
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No title or body for atom: ${atomId}`),
+			);
+		});
+
+		it(`returns ProfileAtom result type given the correct profile`, () => {
+			profile.title = 'profile title';
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				ok({
+					kind: ElementKind.ProfileAtom,
+					html: 'profile body',
+					title: profile.title,
+					id: atomId,
+					image: undefined,
+					credit: undefined,
+				}),
+			);
+
+			profileAtom.headshot = {
+				master: { file: 'image-file', credit: 'credit' },
+				assets: [],
+				mediaId: 'media-id',
+			};
+
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				ok({
+					kind: ElementKind.ProfileAtom,
+					html: 'profile body',
+					id: atomId,
+					image: 'image-file',
+					credit: 'credit',
+					title: profile.title,
 				}),
 			);
 		});

--- a/src/atoms.test.ts
+++ b/src/atoms.test.ts
@@ -1,0 +1,19 @@
+import Int64 from 'node-int64';
+import { formatOptionalDate } from './atoms';
+
+describe('formatOptionalDate', () => {
+	it('returns undefined given an undefined value', () => {
+		expect(formatOptionalDate(undefined)).toBe(undefined);
+	});
+
+	it('returns undefined given a non valid date Int64', () => {
+		const int64 = new Int64('123456789abcdef0');
+		expect(formatOptionalDate(int64)).toBe(undefined);
+	});
+
+	it('returns date string given a valid Int64', () => {
+		const date = 1614000379674;
+		const int64 = new Int64(date);
+		expect(formatOptionalDate(int64)).toBe('Mon Feb 22 2021');
+	});
+});

--- a/src/atoms.test.ts
+++ b/src/atoms.test.ts
@@ -17,6 +17,7 @@ import { ProfileAtom } from '@guardian/content-atom-model/profile/profileAtom';
 import { ProfileItem } from '@guardian/content-atom-model/profile/profileItem';
 import { QAndAAtom } from '@guardian/content-atom-model/qanda/qAndAAtom';
 import { QAndAItem } from '@guardian/content-atom-model/qanda/qAndAItem';
+import { QuizAtom } from '@guardian/content-atom-model/quiz/quizAtom';
 import { TimelineAtom } from '@guardian/content-atom-model/timeline/timelineAtom';
 import { TimelineItem } from '@guardian/content-atom-model/timeline/timelineItem';
 import { err, fromNullable, ok, some } from '@guardian/types';
@@ -756,6 +757,95 @@ describe('parseAtom', () => {
 					kicker: 'audio-kickcer',
 					title: 'audio title',
 					trackUrl: 'track-url',
+				}),
+			);
+		});
+	});
+
+	describe('quiz', () => {
+		let atoms: Atoms;
+		let quiz: Atom;
+		let quizAtom: QuizAtom;
+		let answerMock = {
+			answerText: 'answer text',
+			assets: [],
+			weight: 1,
+			id: 'answer-id',
+		};
+		let questionsMock = [
+			{
+				questionText: 'question text',
+				assets: [],
+				answers: [answerMock],
+				id: 'question-id',
+			},
+		];
+
+		beforeEach(() => {
+			blockElement.contentAtomTypeData = {
+				atomId: atomId,
+				atomType: 'quiz',
+			};
+			quizAtom = {
+				id: 'quiz-id',
+				title: 'quiz title',
+				revealAtEnd: true,
+				published: true,
+				content: {
+					questions: questionsMock,
+				},
+				quizType: 'quiz type',
+			};
+			quiz = {
+				id: atomId,
+				title: '',
+				atomType: AtomType.AUDIO,
+				labels: [],
+				defaultHtml: '',
+				data: {
+					kind: 'quiz',
+					quiz: quizAtom,
+				},
+				contentChangeDetails: {} as ContentChangeDetails,
+				commissioningDesks: [],
+			};
+			atoms = {
+				quizzes: [quiz],
+			};
+		});
+
+		it(`returns an error if no quiz atom id matches`, () => {
+			quiz.data.kind = 'interactive';
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No atom matched this id: ${atomId}`),
+			);
+		});
+
+		it(`returns an error of quiz atom has no content`, () => {
+			quizAtom.content.questions = [];
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				err(`No content for atom: ${atomId}`),
+			);
+		});
+
+		it(`parses quiz atom correctly`, () => {
+			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
+				ok({
+					kind: ElementKind.QuizAtom,
+					id: atomId,
+					questions: [
+						{
+							text: 'question text',
+							...questionsMock[0],
+							answers: [
+								{
+									...answerMock,
+									isCorrect: true,
+									text: 'answer text',
+								},
+							],
+						},
+					],
 				}),
 			);
 		});

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -319,4 +319,4 @@ function parseAtom(
 	}
 }
 
-export { parseAtom };
+export { parseAtom, formatOptionalDate };


### PR DESCRIPTION
# atoms.ts tests

Subtask of the [increase coverage ticket](https://theguardian.atlassian.net/browse/LIVE-1684)

### Test coverage
| | Before | After |
| - | ------ | ----- |
| Statements | 50.95% | 60.82% (+9.87%)|
| Branches | 39.13% | 55.72% (+16.59%)| 
| Functions | 48.94% | 55.67 (+6.73%) |
| Lines | 50.72% | 60.09% (+9.37%) |

