### PR TITLE
LIVE-1834: move design.comment above display.showcase

### DIFF
--- a/src/components/editions/header/index.tsx
+++ b/src/components/editions/header/index.tsx
@@ -247,12 +247,12 @@ const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 		return <ImmersiveHeader item={item} />;
 	} else if (item.design === Design.Interview) {
 		return <InterviewHeader item={item} />;
+	} else if (item.design === Design.Comment) {
+		return <CommentHeader item={item} />;
 	} else if (item.display === Display.Showcase) {
 		return <ShowcaseHeader item={item} />;
 	} else if (item.design === Design.Analysis) {
 		return <AnalysisHeader item={item} />;
-	} else if (item.design === Design.Comment) {
-		return <CommentHeader item={item} />;
 	} else if (item.design === Design.Media) {
 		return isPicture(item.tags) ? (
 			<PictureHeader item={item} />

--- a/src/components/editions/headline/index.tsx
+++ b/src/components/editions/headline/index.tsx
@@ -171,16 +171,24 @@ const getHeadlineStyles = (
 ): SerializedStyles => {
 	const sharedStyles = getSharedStyles(format);
 
-	// Display.Immersive needs to come before Design.Interview
-	switch (format.display) {
-		case Display.Immersive:
-			return css(
-				sharedStyles,
-				getFontStyles('tight', 'bold'),
-				immersiveStyles,
-			);
-		case Display.Showcase:
-			return css(sharedStyles, getFontStyles('tight', 'bold'));
+	if (format.display === Display.Immersive) {
+		return css(
+			sharedStyles,
+			getFontStyles('tight', 'bold'),
+			immersiveStyles,
+		);
+	}
+
+	if (format.design === Design.Comment) {
+		return css(
+			sharedStyles,
+			getFontStyles('regular', 'light'),
+			commentStyles,
+		);
+	}
+
+	if (format.display === Display.Showcase) {
+		return css(sharedStyles, getFontStyles('tight', 'bold'));
 	}
 
 	switch (format.design) {
@@ -197,12 +205,6 @@ const getHeadlineStyles = (
 				sharedStyles,
 				getFontStyles('regular', 'light'),
 				analysisStyles(kickerColor),
-			);
-		case Design.Comment:
-			return css(
-				sharedStyles,
-				getFontStyles('regular', 'light'),
-				commentStyles,
 			);
 		case Design.Media:
 			return css(sharedStyles, galleryStyles);

--- a/src/components/editions/headline/index.tsx
+++ b/src/components/editions/headline/index.tsx
@@ -179,6 +179,7 @@ const getHeadlineStyles = (
 		);
 	}
 
+	// this needs to come before Display.Showcase
 	if (format.design === Design.Comment) {
 		return css(
 			sharedStyles,


### PR DESCRIPTION
## Why are you doing this?

In Dotcom, users are able to add `display.showcase` on top of `design.comment` to trigger a different article header layout. However, in Editions we only have a single `comment` design so we need to ensure `design.comment` comes above `display.showcase` anywhere that's effected.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/109662723-44babe80-7b63-11eb-8114-08c6764bdf4c.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/109662951-7f245b80-7b63-11eb-8159-d848f2f61c26.png" width="300px" /> |
