### PR TITLE
LIVE-1837: move interview above showcase in heirarchy

### DIFF
--- a/src/components/editions/headline/index.tsx
+++ b/src/components/editions/headline/index.tsx
@@ -188,17 +188,20 @@ const getHeadlineStyles = (
 		);
 	}
 
+	// this needs to come before Display.Showcase
+	if (format.design === Design.Interview) {
+		return css(
+			sharedStyles,
+			getFontStyles('tight', 'bold'),
+			interviewStyles,
+		);
+	}
+
 	if (format.display === Display.Showcase) {
 		return css(sharedStyles, getFontStyles('tight', 'bold'));
 	}
 
 	switch (format.design) {
-		case Design.Interview:
-			return css(
-				sharedStyles,
-				getFontStyles('tight', 'bold'),
-				interviewStyles,
-			);
 		case Design.Review:
 			return css(sharedStyles, getFontStyles('tight', 'bold'));
 		case Design.Analysis:


### PR DESCRIPTION
## Why are you doing this?

Showcase styles should not be applied to interviews.

## Changes

- Move Interview styles above Showcase styles in hierarchy

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/109673784-43db5a00-7b6e-11eb-9628-ff3b8b5b3a8f.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/109673738-39b95b80-7b6e-11eb-970e-e2c2fad2536b.png" width="300px" /> |


