### PR TITLE
LIVE-1838: remove atoms which are not required

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -790,278 +790,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   }
 }
 
-.emotion-25 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-26 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-26 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-26 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-26 summary:focus {
-  outline: none;
-}
-
 .emotion-27 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #BB3B80;
-}
-
-.emotion-28 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-29 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-29:hover {
-  background: #BB3B80;
-}
-
-.emotion-30 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-31 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-32 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-32 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-32 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-32 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-32 b {
-  font-weight: 700;
-}
-
-.emotion-32 i {
-  font-style: italic;
-}
-
-.emotion-32 a {
-  color: #7D0068;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-32 a:hover {
-  border-bottom: solid 0.0625rem #BB3B80;
-}
-
-.emotion-33 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-35 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-35:hover {
-  background: #BB3B80;
-}
-
-.emotion-35:focus {
-  border: none;
-}
-
-.emotion-36 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-37 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-37:hover {
-  background: #BB3B80;
-}
-
-.emotion-37:focus {
-  border: none;
-}
-
-.emotion-39 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-42 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -1076,14 +805,14 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-42 {
+  .emotion-27 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-42:before {
+.emotion-27:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -1095,7 +824,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-42:after {
+.emotion-27:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -1105,25 +834,25 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   border-top: 1px solid #BB3B80;
 }
 
-.emotion-43 {
+.emotion-28 {
   margin: 0;
 }
 
-.emotion-44 {
+.emotion-29 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-44 svg {
+.emotion-29 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #BB3B80;
 }
 
-.emotion-45 {
+.emotion-30 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -1302,117 +1031,6 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
         <p
           className="emotion-20"
         />
-        <div
-          className="emotion-25"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-26"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-27"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-28"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-29"
-              >
-                <span
-                  className="emotion-30"
-                >
-                  <span
-                    className="emotion-31"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-32"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-33"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-34"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-35"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-37"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-39"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
         <p
           className="emotion-20"
         />
@@ -1420,13 +1038,13 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
           className="emotion-20"
         />
         <aside
-          className="emotion-42"
+          className="emotion-27"
         >
           <blockquote
-            className="emotion-43"
+            className="emotion-28"
           >
             <p
-              className="emotion-44"
+              className="emotion-29"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -1441,7 +1059,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-45"
+              className="emotion-30"
             >
               Jane Giddins
             </cite>
@@ -2017,278 +1635,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   }
 }
 
-.emotion-28 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-29 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-29 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-29 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-29 summary:focus {
-  outline: none;
-}
-
 .emotion-30 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #C70000;
-}
-
-.emotion-31 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-32 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-32:hover {
-  background: #C70000;
-}
-
-.emotion-33 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-34 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-35 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-35 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-35 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-35 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-35 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-35 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-35 b {
-  font-weight: 700;
-}
-
-.emotion-35 i {
-  font-style: italic;
-}
-
-.emotion-35 a {
-  color: #AB0613;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-35 a:hover {
-  border-bottom: solid 0.0625rem #C70000;
-}
-
-.emotion-36 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-37 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-38 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-38:hover {
-  background: #C70000;
-}
-
-.emotion-38:focus {
-  border: none;
-}
-
-.emotion-39 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-40 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-40:hover {
-  background: #C70000;
-}
-
-.emotion-40:focus {
-  border: none;
-}
-
-.emotion-42 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-45 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -2303,14 +1650,14 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-45 {
+  .emotion-30 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-45:before {
+.emotion-30:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -2322,7 +1669,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-45:after {
+.emotion-30:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -2332,25 +1679,25 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   border-top: 1px solid #C70000;
 }
 
-.emotion-46 {
+.emotion-31 {
   margin: 0;
 }
 
-.emotion-47 {
+.emotion-32 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-47 svg {
+.emotion-32 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #C70000;
 }
 
-.emotion-48 {
+.emotion-33 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -2564,117 +1911,6 @@ exports[`Storyshots Editions/Article Comment 1`] = `
         <p
           className="emotion-23"
         />
-        <div
-          className="emotion-28"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-29"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-30"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-31"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-32"
-              >
-                <span
-                  className="emotion-33"
-                >
-                  <span
-                    className="emotion-34"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-35"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-36"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-37"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-38"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-39"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-40"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-39"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-42"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
         <p
           className="emotion-23"
         />
@@ -2682,13 +1918,13 @@ exports[`Storyshots Editions/Article Comment 1`] = `
           className="emotion-23"
         />
         <aside
-          className="emotion-45"
+          className="emotion-30"
         >
           <blockquote
-            className="emotion-46"
+            className="emotion-31"
           >
             <p
-              className="emotion-47"
+              className="emotion-32"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -2703,7 +1939,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-48"
+              className="emotion-33"
             >
               Jane Giddins
             </cite>
@@ -3195,278 +2431,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
   }
 }
 
-.emotion-25 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-26 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-26 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-26 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-26 summary:focus {
-  outline: none;
-}
-
 .emotion-27 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #C70000;
-}
-
-.emotion-28 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-29 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-29:hover {
-  background: #C70000;
-}
-
-.emotion-30 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-31 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-32 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-32 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-32 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-32 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-32 b {
-  font-weight: 700;
-}
-
-.emotion-32 i {
-  font-style: italic;
-}
-
-.emotion-32 a {
-  color: #AB0613;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-32 a:hover {
-  border-bottom: solid 0.0625rem #C70000;
-}
-
-.emotion-33 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-35 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-35:hover {
-  background: #C70000;
-}
-
-.emotion-35:focus {
-  border: none;
-}
-
-.emotion-36 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-37 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-37:hover {
-  background: #C70000;
-}
-
-.emotion-37:focus {
-  border: none;
-}
-
-.emotion-39 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-42 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -3481,14 +2446,14 @@ exports[`Storyshots Editions/Article Default 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-42 {
+  .emotion-27 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-42:before {
+.emotion-27:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -3500,7 +2465,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-42:after {
+.emotion-27:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -3510,25 +2475,25 @@ exports[`Storyshots Editions/Article Default 1`] = `
   border-top: 1px solid #C70000;
 }
 
-.emotion-43 {
+.emotion-28 {
   margin: 0;
 }
 
-.emotion-44 {
+.emotion-29 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-44 svg {
+.emotion-29 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #C70000;
 }
 
-.emotion-45 {
+.emotion-30 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -3707,117 +2672,6 @@ exports[`Storyshots Editions/Article Default 1`] = `
         <p
           className="emotion-20"
         />
-        <div
-          className="emotion-25"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-26"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-27"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-28"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-29"
-              >
-                <span
-                  className="emotion-30"
-                >
-                  <span
-                    className="emotion-31"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-32"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-33"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-34"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-35"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-37"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-39"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
         <p
           className="emotion-20"
         />
@@ -3825,13 +2679,13 @@ exports[`Storyshots Editions/Article Default 1`] = `
           className="emotion-20"
         />
         <aside
-          className="emotion-42"
+          className="emotion-27"
         >
           <blockquote
-            className="emotion-43"
+            className="emotion-28"
           >
             <p
-              className="emotion-44"
+              className="emotion-29"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -3846,7 +2700,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-45"
+              className="emotion-30"
             >
               Jane Giddins
             </cite>
@@ -4359,278 +3213,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   }
 }
 
-.emotion-26 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-27 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-27 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-27 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-27 summary:focus {
-  outline: none;
-}
-
 .emotion-28 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #E05E00;
-}
-
-.emotion-29 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-30 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-30:hover {
-  background: #E05E00;
-}
-
-.emotion-31 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-32 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-33 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-33 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-33 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-33 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-33 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-33 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-33 b {
-  font-weight: 700;
-}
-
-.emotion-33 i {
-  font-style: italic;
-}
-
-.emotion-33 a {
-  color: #CB4700;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-33 a:hover {
-  border-bottom: solid 0.0625rem #E05E00;
-}
-
-.emotion-34 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-35 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-36 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-36:hover {
-  background: #E05E00;
-}
-
-.emotion-36:focus {
-  border: none;
-}
-
-.emotion-37 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-38 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-38:hover {
-  background: #E05E00;
-}
-
-.emotion-38:focus {
-  border: none;
-}
-
-.emotion-40 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-43 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -4645,14 +3228,14 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-43 {
+  .emotion-28 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-43:before {
+.emotion-28:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -4664,7 +3247,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-43:after {
+.emotion-28:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -4674,25 +3257,25 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   border-top: 1px solid #E05E00;
 }
 
-.emotion-44 {
+.emotion-29 {
   margin: 0;
 }
 
-.emotion-45 {
+.emotion-30 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-45 svg {
+.emotion-30 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #E05E00;
 }
 
-.emotion-46 {
+.emotion-31 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -4876,117 +3459,6 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
         <p
           className="emotion-21"
         />
-        <div
-          className="emotion-26"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-27"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-28"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-29"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-30"
-              >
-                <span
-                  className="emotion-31"
-                >
-                  <span
-                    className="emotion-32"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-33"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-34"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-35"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-36"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-37"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-38"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-37"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-40"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
         <p
           className="emotion-21"
         />
@@ -4994,13 +3466,13 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
           className="emotion-21"
         />
         <aside
-          className="emotion-43"
+          className="emotion-28"
         >
           <blockquote
-            className="emotion-44"
+            className="emotion-29"
           >
             <p
-              className="emotion-45"
+              className="emotion-30"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -5015,7 +3487,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-46"
+              className="emotion-31"
             >
               Jane Giddins
             </cite>
@@ -5507,278 +3979,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
   }
 }
 
-.emotion-25 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-26 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-26 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-26 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-26 summary:focus {
-  outline: none;
-}
-
 .emotion-27 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #0084C6;
-}
-
-.emotion-28 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-29 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-29:hover {
-  background: #0084C6;
-}
-
-.emotion-30 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-31 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-32 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-32 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-32 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-32 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-32 b {
-  font-weight: 700;
-}
-
-.emotion-32 i {
-  font-style: italic;
-}
-
-.emotion-32 a {
-  color: #005689;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-32 a:hover {
-  border-bottom: solid 0.0625rem #0084C6;
-}
-
-.emotion-33 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-35 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-35:hover {
-  background: #0084C6;
-}
-
-.emotion-35:focus {
-  border: none;
-}
-
-.emotion-36 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-37 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-37:hover {
-  background: #0084C6;
-}
-
-.emotion-37:focus {
-  border: none;
-}
-
-.emotion-39 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-42 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -5793,14 +3994,14 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-42 {
+  .emotion-27 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-42:before {
+.emotion-27:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -5812,7 +4013,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-42:after {
+.emotion-27:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -5822,25 +4023,25 @@ exports[`Storyshots Editions/Article Feature 1`] = `
   border-top: 1px solid #0084C6;
 }
 
-.emotion-43 {
+.emotion-28 {
   margin: 0;
 }
 
-.emotion-44 {
+.emotion-29 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-44 svg {
+.emotion-29 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #0084C6;
 }
 
-.emotion-45 {
+.emotion-30 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -6019,117 +4220,6 @@ exports[`Storyshots Editions/Article Feature 1`] = `
         <p
           className="emotion-20"
         />
-        <div
-          className="emotion-25"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-26"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-27"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-28"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-29"
-              >
-                <span
-                  className="emotion-30"
-                >
-                  <span
-                    className="emotion-31"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-32"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-33"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-34"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-35"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-37"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-39"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
         <p
           className="emotion-20"
         />
@@ -6137,13 +4227,13 @@ exports[`Storyshots Editions/Article Feature 1`] = `
           className="emotion-20"
         />
         <aside
-          className="emotion-42"
+          className="emotion-27"
         >
           <blockquote
-            className="emotion-43"
+            className="emotion-28"
           >
             <p
-              className="emotion-44"
+              className="emotion-29"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -6158,7 +4248,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-45"
+              className="emotion-30"
             >
               Jane Giddins
             </cite>
@@ -7539,278 +5629,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   }
 }
 
-.emotion-27 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-28 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-28 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-28 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-28 summary:focus {
-  outline: none;
-}
-
 .emotion-29 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #0084C6;
-}
-
-.emotion-30 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-31 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-31:hover {
-  background: #0084C6;
-}
-
-.emotion-32 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-33 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-34 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-34 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-34 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-34 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-34 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-34 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-34 b {
-  font-weight: 700;
-}
-
-.emotion-34 i {
-  font-style: italic;
-}
-
-.emotion-34 a {
-  color: #005689;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-34 a:hover {
-  border-bottom: solid 0.0625rem #0084C6;
-}
-
-.emotion-35 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-36 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-37 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-37:hover {
-  background: #0084C6;
-}
-
-.emotion-37:focus {
-  border: none;
-}
-
-.emotion-38 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-39 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-39:hover {
-  background: #0084C6;
-}
-
-.emotion-39:focus {
-  border: none;
-}
-
-.emotion-41 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-44 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -7825,14 +5644,14 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-44 {
+  .emotion-29 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-44:before {
+.emotion-29:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -7844,7 +5663,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-44:after {
+.emotion-29:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -7854,25 +5673,25 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   border-top: 1px solid #0084C6;
 }
 
-.emotion-45 {
+.emotion-30 {
   margin: 0;
 }
 
-.emotion-46 {
+.emotion-31 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-46 svg {
+.emotion-31 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #0084C6;
 }
 
-.emotion-47 {
+.emotion-32 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -8060,117 +5879,6 @@ exports[`Storyshots Editions/Article Interview 1`] = `
         <p
           className="emotion-22"
         />
-        <div
-          className="emotion-27"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-28"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-29"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-30"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-31"
-              >
-                <span
-                  className="emotion-32"
-                >
-                  <span
-                    className="emotion-33"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-34"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-35"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-36"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-37"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-38"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-39"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-38"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-41"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
         <p
           className="emotion-22"
         />
@@ -8178,13 +5886,13 @@ exports[`Storyshots Editions/Article Interview 1`] = `
           className="emotion-22"
         />
         <aside
-          className="emotion-44"
+          className="emotion-29"
         >
           <blockquote
-            className="emotion-45"
+            className="emotion-30"
           >
             <p
-              className="emotion-46"
+              className="emotion-31"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -8199,7 +5907,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-47"
+              className="emotion-32"
             >
               Jane Giddins
             </cite>
@@ -8727,278 +6435,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   }
 }
 
-.emotion-31 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-32 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-32 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-32 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-32 summary:focus {
-  outline: none;
-}
-
 .emotion-33 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #A1845C;
-}
-
-.emotion-34 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-35 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-35:hover {
-  background: #A1845C;
-}
-
-.emotion-36 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-37 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-38 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-38 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-38 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-38 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-38 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-38 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-38 b {
-  font-weight: 700;
-}
-
-.emotion-38 i {
-  font-style: italic;
-}
-
-.emotion-38 a {
-  color: #6B5840;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-38 a:hover {
-  border-bottom: solid 0.0625rem #A1845C;
-}
-
-.emotion-39 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-40 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-41 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-41:hover {
-  background: #A1845C;
-}
-
-.emotion-41:focus {
-  border: none;
-}
-
-.emotion-42 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-43 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-43:hover {
-  background: #A1845C;
-}
-
-.emotion-43:focus {
-  border: none;
-}
-
-.emotion-45 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-48 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -9013,14 +6450,14 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-48 {
+  .emotion-33 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-48:before {
+.emotion-33:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -9032,7 +6469,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-48:after {
+.emotion-33:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -9042,25 +6479,25 @@ exports[`Storyshots Editions/Article Review 1`] = `
   border-top: 1px solid #A1845C;
 }
 
-.emotion-49 {
+.emotion-34 {
   margin: 0;
 }
 
-.emotion-50 {
+.emotion-35 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-50 svg {
+.emotion-35 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #A1845C;
 }
 
-.emotion-51 {
+.emotion-36 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -9313,117 +6750,6 @@ exports[`Storyshots Editions/Article Review 1`] = `
         <p
           className="emotion-26"
         />
-        <div
-          className="emotion-31"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-32"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-33"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-34"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-35"
-              >
-                <span
-                  className="emotion-36"
-                >
-                  <span
-                    className="emotion-37"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-38"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-39"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-40"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-41"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-42"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-43"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-42"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-45"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
         <p
           className="emotion-26"
         />
@@ -9431,13 +6757,13 @@ exports[`Storyshots Editions/Article Review 1`] = `
           className="emotion-26"
         />
         <aside
-          className="emotion-48"
+          className="emotion-33"
         >
           <blockquote
-            className="emotion-49"
+            className="emotion-34"
           >
             <p
-              className="emotion-50"
+              className="emotion-35"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -9452,7 +6778,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-51"
+              className="emotion-36"
             >
               Jane Giddins
             </cite>
@@ -9950,278 +7276,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   }
 }
 
-.emotion-25 {
-  display: block;
-  position: relative;
-  margin-bottom: 0.75rem;
-  margin-top: 1rem;
-}
-
-.emotion-26 {
-  margin: 16px 0 36px;
-  background: #EDEDED;
-  color: #121212;
-  padding: 0 5px 6px;
-  border-image: repeating-linear-gradient( to bottom,#DCDCDC,#DCDCDC 1px,transparent 1px,transparent 4px ) 13;
-  border-top: 13px solid black;
-  position: relative;
-}
-
-.emotion-26 summary {
-  list-style: none;
-  margin: 0 0 16px;
-}
-
-.emotion-26 summary::-webkit-details-marker {
-  display: none;
-}
-
-.emotion-26 summary:focus {
-  outline: none;
-}
-
 .emotion-27 {
-  display: block;
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 700;
-  color: #C70000;
-}
-
-.emotion-28 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.15;
-  font-weight: 500;
-  margin: 0;
-  line-height: 22px;
-}
-
-.emotion-29 {
-  background: #121212;
-  color: #FFFFFF;
-  height: 2rem;
-  position: absolute;
-  bottom: 0;
-  -webkit-transform: translate(0,50%);
-  -ms-transform: translate(0,50%);
-  transform: translate(0,50%);
-  padding: 0 15px 0 7px;
-  border-radius: 100em;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 0;
-  margin: 0;
-}
-
-.emotion-29:hover {
-  background: #C70000;
-}
-
-.emotion-30 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-31 {
-  margin-right: 12px;
-  margin-bottom: 6px;
-  width: 33px;
-  fill: white;
-  height: 28px;
-}
-
-.emotion-32 {
-  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-32 p {
-  margin-bottom: 0.5rem;
-}
-
-.emotion-32 ol {
-  list-style: decimal;
-  list-style-position: inside;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul {
-  list-style: none;
-  margin: 0 0 0.75rem;
-  padding: 0;
-  margin-bottom: 1rem;
-}
-
-.emotion-32 ul li {
-  margin-bottom: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.emotion-32 ul li:before {
-  display: inline-block;
-  content: '';
-  border-radius: 0.375rem;
-  height: 0.75rem;
-  width: 0.75rem;
-  margin-right: 0.5rem;
-  background-color: #DCDCDC;
-  margin-left: -1.25rem;
-}
-
-.emotion-32 b {
-  font-weight: 700;
-}
-
-.emotion-32 i {
-  font-style: italic;
-}
-
-.emotion-32 a {
-  color: #AB0613;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: 0.0625rem solid #DCDCDC;
-  -webkit-transition: border-color 0.15s ease-out;
-  transition: border-color 0.15s ease-out;
-}
-
-.emotion-32 a:hover {
-  border-bottom: solid 0.0625rem #C70000;
-}
-
-.emotion-33 {
-  font-size: 13px;
-  line-height: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.emotion-34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.emotion-35 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-}
-
-.emotion-35:hover {
-  background: #C70000;
-}
-
-.emotion-35:focus {
-  border: none;
-}
-
-.emotion-36 {
-  width: 16px;
-  height: 16px;
-}
-
-.emotion-37 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  cursor: pointer;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  background: black;
-  color: white;
-  border-style: hidden;
-  border-radius: 100%;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
-  -o-transform: rotate(180deg);
-}
-
-.emotion-37:hover {
-  background: #C70000;
-}
-
-.emotion-37:focus {
-  border: none;
-}
-
-.emotion-39 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  font-weight: 400;
-  height: 28px;
-}
-
-.emotion-42 {
   width: 10.875rem;
   position: relative;
   box-sizing: border-box;
@@ -10236,14 +7291,14 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 @media (min-width:980px) {
-  .emotion-42 {
+  .emotion-27 {
     float: right;
     clear: right;
     margin-right: calc(-10.875rem - 2.5rem);
   }
 }
 
-.emotion-42:before {
+.emotion-27:before {
   content: '';
   position: absolute;
   top: 100%;
@@ -10255,7 +7310,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   border-radius: 0 0 100% 0;
 }
 
-.emotion-42:after {
+.emotion-27:after {
   content: '';
   position: absolute;
   top: 100%;
@@ -10265,25 +7320,25 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   border-top: 1px solid #C70000;
 }
 
-.emotion-43 {
+.emotion-28 {
   margin: 0;
 }
 
-.emotion-44 {
+.emotion-29 {
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
 }
 
-.emotion-44 svg {
+.emotion-29 svg {
   margin-bottom: -0.6rem;
   height: 2rem;
   margin-left: -0.3rem;
   fill: #C70000;
 }
 
-.emotion-45 {
+.emotion-30 {
   font-style: normal;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -10462,117 +7517,6 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
         <p
           className="emotion-20"
         />
-        <div
-          className="emotion-25"
-          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-          data-atom-type="guide"
-        >
-          <details
-            className="emotion-26"
-            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
-            data-snippet-type="guide"
-          >
-            <summary
-              onClick={[Function]}
-            >
-              <span
-                className="emotion-27"
-              >
-                Quick Guide
-              </span>
-              <h4
-                className="emotion-28"
-              >
-                What is Queen's consent?
-              </h4>
-              <span
-                className="emotion-29"
-              >
-                <span
-                  className="emotion-30"
-                >
-                  <span
-                    className="emotion-31"
-                  >
-                    <svg
-                      viewBox="0 0 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clipRule="evenodd"
-                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  Show
-                </span>
-              </span>
-            </summary>
-            <div>
-              <div
-                className="emotion-32"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-                  }
-                }
-              />
-            </div>
-            <footer
-              className="emotion-33"
-            >
-              <div
-                hidden={false}
-              >
-                <div
-                  className="emotion-34"
-                >
-                  <div>
-                    Was this helpful?
-                  </div>
-                  <button
-                    className="emotion-35"
-                    data-testid="like"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    className="emotion-37"
-                    data-testid="dislike"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      className="emotion-36"
-                      viewBox="0 0 40 40"
-                    >
-                      <path
-                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
-                        fill="#FFF"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="emotion-39"
-                data-testid="feedback"
-                hidden={true}
-              >
-                Thank you for your feedback.
-              </div>
-            </footer>
-          </details>
-        </div>
         <p
           className="emotion-20"
         />
@@ -10580,13 +7524,13 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
           className="emotion-20"
         />
         <aside
-          className="emotion-42"
+          className="emotion-27"
         >
           <blockquote
-            className="emotion-43"
+            className="emotion-28"
           >
             <p
-              className="emotion-44"
+              className="emotion-29"
             >
               <svg
                 viewBox="0 0 30 30"
@@ -10601,7 +7545,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
               Why should the crown be allowed to carry on with a feudal system just because they want to?
             </p>
             <cite
-              className="emotion-45"
+              className="emotion-30"
             >
               Jane Giddins
             </cite>

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -99,7 +99,7 @@ const embedElement: BodyElement = {
 		source: some('mockSource'),
 		sourceDomain: some('mockSourceDomain'),
 		tracking: EmbedTracksType.DOES_NOT_TRACK,
-	}
+	},
 };
 
 const videoElement: BodyElement = {
@@ -109,7 +109,7 @@ const videoElement: BodyElement = {
 		id: 'mockYoutubeId',
 		height: 300,
 		width: 500,
-	}
+	},
 };
 
 const audioElement: BodyElement = {
@@ -119,7 +119,7 @@ const audioElement: BodyElement = {
 		src: 'https://www.spotify.com/',
 		height: 300,
 		width: 500,
-	}
+	},
 };
 
 const liveEventElement = (): BodyElement => ({
@@ -349,7 +349,9 @@ describe('Renders different types of elements', () => {
 	test('ElementKind.Embed', () => {
 		const nodes = render(embedElement);
 		const embed = nodes.flat()[0];
-		expect(getHtml(embed)).toContain('<iframe srcDoc=\"&lt;section&gt;Embed&lt;/section&gt;\" title=\"Embed\" height=\"322\"></iframe>');
+		expect(getHtml(embed)).toContain(
+			'<iframe srcDoc="&lt;section&gt;Embed&lt;/section&gt;" title="Embed" height="322"></iframe>',
+		);
 	});
 
 	test('ElementKind.Audio', () => {
@@ -511,155 +513,6 @@ describe('Renders different types of Editions elements', () => {
 		expect(getHtml(pullquote)).toContain('attribution');
 		expect(getHtml(pullquote)).toContain('quote');
 	});
-
-	test('ElementKind.Tweet', () => {
-		const nodes = renderEditions(tweetElement());
-		const tweet = nodes.flat()[0];
-		expect(getHtml(tweet)).toContain('twitter-tweet');
-	});
-
-	test('ElementKind.Instagram', () => {
-		const nodes = renderEditions(instagramElement());
-		const instagram = nodes.flat()[0];
-		expect(getHtml(instagram)).toBe(
-			'<div><blockquote>Instagram</blockquote></div>',
-		);
-	});
-
-	test('ElementKind.Embed', () => {
-		const nodes = renderEditions(embedElement);
-		const embed = nodes.flat()[0];
-		expect(getHtml(embed)).toContain('<iframe srcDoc=\"&lt;section&gt;Embed&lt;/section&gt;\" title=\"Embed\" height=\"322\"></iframe>');
-	});
-
-	test('ElementKind.Audio', () => {
-		const nodes = renderEditions(audioElement);
-		const audio = nodes.flat()[0];
-		expect(getHtml(audio)).toContain(
-			'src="https://www.spotify.com/" sandbox="allow-scripts" height="300" width="500" title="Audio element"',
-		);
-	});
-
-	test('ElementKind.Video', () => {
-		const nodes = renderEditions(videoElement);
-		const video = nodes.flat()[0];
-		expect(getHtml(video)).toContain(
-			'src="https://www.youtube-nocookie.com/embed/mockYoutubeId?wmode=opaque&amp;feature=oembed" height="300" width="500" allowfullscreen="" title="Video element"',
-		);
-	});
-
-	test('ElementKind.LiveEvent', () => {
-		const nodes = renderEditions(liveEventElement());
-		const liveEvent = nodes.flat()[0];
-		expect(getHtml(liveEvent)).toContain(
-			'<h1>this links to a live event</h1>',
-		);
-	});
-
-	test('ElementKind.InteractiveAtom', () => {
-		const nodes = renderEditions(atomElement());
-		const atom = nodes.flat()[0];
-		expect(getHtml(atom)).toContain('main { background: yellow; }');
-		expect(getHtml(atom)).toContain('console.log(&#x27;init&#x27;)');
-		expect(getHtml(atom)).toContain('Some content');
-	});
-
-	test('ElementKind.ExplainerAtom', () => {
-		const nodes = renderEditions(explainerElement());
-		const explainer = nodes.flat()[0];
-		expect(getHtml(explainer)).toContain('<main>Explainer content</main>');
-	});
-
-	test('ElementKind.GuideAtom', () => {
-		const nodes = renderEditions(guideElement());
-		const guide = nodes.flat()[0];
-		expect(getHtml(guide)).toContain('<main>Guide content</main>');
-		testHandlers(guide);
-	});
-
-	test('ElementKind.QandaAtom', () => {
-		const nodes = renderEditions(qandaElement());
-		const qanda = nodes.flat()[0];
-		expect(getHtml(qanda)).toContain('<main>QandA content</main>');
-		testHandlers(qanda);
-	});
-
-	test('ElementKind.ProfileAtom', () => {
-		const nodes = renderEditions(profileElement());
-		const profile = nodes.flat()[0];
-		expect(getHtml(profile)).toContain('<main>Profile content</main>');
-		testHandlers(profile);
-	});
-
-	test('ElementKind.TimelineAtom', () => {
-		const nodes = renderEditions(timelineElement());
-		const timeline = nodes.flat()[0];
-		expect(getHtml(timeline)).toContain(
-			'<p>Swedish prosecutors announce they are <a href="https://www.theguardian.com/media/2019/may/13/sweden-reopens-case-against-julian-assange">reopening an investigation into a rape allegation</a> against Julian Assange.</p><p><br></p>',
-		);
-		testHandlers(timeline);
-	});
-
-	test('ElementKind.ChartAtom', () => {
-		const nodes = renderEditions(chartElement());
-		const chart = nodes.flat()[0];
-		expect(getHtml(chart)).toContain(
-			'srcDoc="&lt;main&gt;Chart content&lt;/main&gt;"',
-		);
-	});
-
-	test('ElementKind.QuizAtom', () => {
-		const nodes = renderEditions(quizAtom());
-		const quiz = nodes.flat()[0];
-		const html = getHtml(quiz);
-		expect(html).toContain('<div class="js-quiz">');
-		expect(html).toContain(
-			'<script class="js-quiz-params" type="application/json">',
-		);
-	});
-
-	test('ElementKind.AudioAtom', () => {
-		const nodes = renderEditions(audioAtom());
-		const audio = nodes.flat()[0];
-		const html = getHtml(audio);
-		expect(html).toContain(
-			'<div kind="18" title="title" id="" trackUrl="trackUrl" kicker="kicker" pillar="0"',
-		);
-	});
-
-	function testHandlers(node: ReactNode): void {
-		if (isValidElement(node)) {
-			const container = document.createElement('div');
-			document.body.appendChild(container);
-			act(() => {
-				renderDom(node, container);
-			});
-
-			const likeButton = container.querySelector('[data-testid="like"]');
-			const dislikeButton = container.querySelector(
-				'[data-testid="dislike"]',
-			);
-			const feedback = container.querySelector(
-				'[data-testid="feedback"]',
-			);
-			expect(feedback?.getAttribute('hidden')).toBe('');
-
-			act(() => {
-				dislikeButton!.dispatchEvent(
-					new MouseEvent('click', { bubbles: true }),
-				);
-			});
-			act(() => {
-				likeButton!.dispatchEvent(
-					new MouseEvent('click', { bubbles: true }),
-				);
-			});
-
-			expect(feedback?.getAttribute('hidden')).toBeNull();
-			unmountComponentAtNode(container);
-			container.remove();
-		}
-	}
 });
 
 describe('Paragraph tags rendered correctly', () => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -769,53 +769,6 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 			return h(EditionsPullquote, { quote, attribution, format, key });
 		}
 
-		case ElementKind.LiveEvent:
-			return h(LiveEventLink, { ...element, key });
-
-		case ElementKind.Tweet:
-			return h(Tweet, { content: element.content, format, key });
-
-		case ElementKind.Callout: {
-			const { campaign, description } = element;
-			return h(CalloutForm, { campaign, format, description });
-		}
-
-		case ElementKind.Embed:
-			return h(EmbedComponent, { embed: element.embed });
-
-		case ElementKind.Instagram:
-			return instagramRenderer(element);
-
-		case ElementKind.ExplainerAtom:
-			return h(ExplainerAtom, { ...element });
-
-		case ElementKind.GuideAtom:
-			return guideAtomRenderer(format, element);
-
-		case ElementKind.QandaAtom:
-			return qandaAtomRenderer(format, element);
-
-		case ElementKind.ProfileAtom:
-			return profileAtomRenderer(format, element);
-
-		case ElementKind.TimelineAtom:
-			return timelineAtomRenderer(format, element);
-
-		case ElementKind.ChartAtom:
-			return h(ChartAtom, { ...element });
-
-		case ElementKind.InteractiveAtom:
-			return interactiveAtomRenderer(format, element);
-
-		case ElementKind.MediaAtom:
-			return mediaAtomRenderer(format, element);
-
-		case ElementKind.AudioAtom:
-			return audioAtomRenderer(format, element);
-
-		case ElementKind.QuizAtom:
-			return quizAtomRenderer(format, element);
-
 		default:
 			return null;
 	}


### PR DESCRIPTION
## Why are you doing this?

Opening this to start a discussion.

We currently have a number of atoms in Editions-Rendering which either look poor or don't work at all. These were flagged by production during the recent QA session.

https://theguardian.atlassian.net/browse/LIVE-1856
https://theguardian.atlassian.net/browse/LIVE-1855
https://theguardian.atlassian.net/browse/LIVE-1838
https://theguardian.atlassian.net/browse/LIVE-1834

This PR is a suggestion to remove all atoms apart from those in line with the existing Editions app.

Does anyone see any problems with this or wish to suggest an alternative approach?

**Also some of the screenshots are failing, anyone know why?**

## Changes

- remove atoms from `renderer.ts`
- remove tests

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/109810675-be18e680-7c21-11eb-840f-9d924f683b84.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/109810644-b22d2480-7c21-11eb-8afc-b2421fe3fd72.png" width="300px" /> |

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/109816512-bc065600-7c28-11eb-980a-860ceb3ce0dc.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/109816560-c9bbdb80-7c28-11eb-8226-6b153a79d133.png" width="300px" /> |


