### PR TITLE
LIVE-1848: ER headline colour

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -482,12 +482,6 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   padding-bottom: 0;
 }
 
-@media (prefers-color-scheme:dark) {
-  .emotion-10 {
-    color: #DCDCDC;
-  }
-}
-
 @media (min-width:375px) {
   .emotion-10 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
@@ -1678,12 +1672,6 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   font-weight: 300;
   padding-bottom: 0;
   padding-right: 6rem;
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-10 {
-    color: #DCDCDC;
-  }
 }
 
 @media (min-width:375px) {
@@ -2946,12 +2934,6 @@ exports[`Storyshots Editions/Article Default 1`] = `
   font-weight: 500;
 }
 
-@media (prefers-color-scheme:dark) {
-  .emotion-10 {
-    color: #DCDCDC;
-  }
-}
-
 @media (min-width:375px) {
   .emotion-10 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
@@ -4095,12 +4077,6 @@ exports[`Storyshots Editions/Article Feature 1`] = `
   font-weight: 500;
 }
 
-@media (prefers-color-scheme:dark) {
-  .emotion-10 {
-    color: #DCDCDC;
-  }
-}
-
 @media (min-width:375px) {
   .emotion-10 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
@@ -5194,12 +5170,6 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
   border: 0;
 }
 
-@media (prefers-color-scheme:dark) {
-  .emotion-11 {
-    color: #DCDCDC;
-  }
-}
-
 @media (min-width:740px) {
   .emotion-11 {
     width: 526px;
@@ -6032,12 +6002,6 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   font-weight: 700;
   margin-left: 0.75rem;
   border: 0;
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-11 {
-    color: #DCDCDC;
-  }
 }
 
 @media (min-width:375px) {
@@ -7333,12 +7297,6 @@ exports[`Storyshots Editions/Article Review 1`] = `
   font-weight: 700;
 }
 
-@media (prefers-color-scheme:dark) {
-  .emotion-16 {
-    color: #DCDCDC;
-  }
-}
-
 @media (min-width:375px) {
   .emotion-16 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
@@ -8419,12 +8377,6 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   font-size: 1.5rem;
   line-height: 1.15;
   font-weight: 700;
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-6 {
-    color: #DCDCDC;
-  }
 }
 
 @media (min-width:375px) {
@@ -11140,12 +11092,6 @@ exports[`Storyshots Editions/Headline Analysis 1`] = `
   padding-bottom: 0;
 }
 
-@media (prefers-color-scheme:dark) {
-  .emotion-1 {
-    color: #DCDCDC;
-  }
-}
-
 @media (min-width:375px) {
   .emotion-1 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
@@ -11193,12 +11139,6 @@ exports[`Storyshots Editions/Headline Comment 1`] = `
   font-weight: 300;
   padding-bottom: 0;
   padding-right: 6rem;
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-1 {
-    color: #DCDCDC;
-  }
 }
 
 @media (min-width:375px) {
@@ -11280,12 +11220,6 @@ exports[`Storyshots Editions/Headline Default 1`] = `
   font-weight: 500;
 }
 
-@media (prefers-color-scheme:dark) {
-  .emotion-1 {
-    color: #DCDCDC;
-  }
-}
-
 @media (min-width:375px) {
   .emotion-1 {
     font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
@@ -11331,12 +11265,6 @@ exports[`Storyshots Editions/Headline Feature 1`] = `
   font-size: 1.5rem;
   line-height: 1.15;
   font-weight: 500;
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-1 {
-    color: #DCDCDC;
-  }
 }
 
 @media (min-width:375px) {
@@ -11393,12 +11321,6 @@ exports[`Storyshots Editions/Headline Interview 1`] = `
   font-weight: 700;
   margin-left: 0.75rem;
   border: 0;
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-2 {
-    color: #DCDCDC;
-  }
 }
 
 @media (min-width:375px) {
@@ -11507,12 +11429,6 @@ exports[`Storyshots Editions/Headline Media 1`] = `
   border: 0;
 }
 
-@media (prefers-color-scheme:dark) {
-  .emotion-1 {
-    color: #DCDCDC;
-  }
-}
-
 @media (min-width:740px) {
   .emotion-1 {
     width: 526px;
@@ -11552,12 +11468,6 @@ exports[`Storyshots Editions/Headline Review 1`] = `
   font-size: 1.5rem;
   line-height: 1.15;
   font-weight: 700;
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-1 {
-    color: #DCDCDC;
-  }
 }
 
 @media (min-width:375px) {
@@ -11605,12 +11515,6 @@ exports[`Storyshots Editions/Headline Showcase 1`] = `
   font-size: 1.5rem;
   line-height: 1.15;
   font-weight: 700;
-}
-
-@media (prefers-color-scheme:dark) {
-  .emotion-1 {
-    color: #DCDCDC;
-  }
 }
 
 @media (min-width:375px) {

--- a/src/components/editions/headline/index.tsx
+++ b/src/components/editions/headline/index.tsx
@@ -13,7 +13,7 @@ import type {
 import { SvgQuote } from '@guardian/src-icons';
 import type { Format } from '@guardian/types';
 import { Design, Display } from '@guardian/types';
-import { headlineTextColour } from 'editorialStyles';
+import { editionsHeadlineTextColour } from 'editorialStyles';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import type { FC } from 'react';
@@ -118,7 +118,7 @@ const getFontStyles = (
 `;
 
 const getSharedStyles = (format: Format): SerializedStyles => css`
-	${headlineTextColour(format)}
+	${editionsHeadlineTextColour(format)}
 	box-sizing: border-box;
 	border-top: 1px solid ${border.secondary};
 	padding-bottom: ${remSpace[4]};

--- a/src/editorialStyles.ts
+++ b/src/editorialStyles.ts
@@ -8,13 +8,14 @@ import { background, text } from 'editorialPalette';
 
 // ----- Functions ----- //
 
-const textColour = (light: Colour, dark: Colour): SerializedStyles =>
+const textColour = (light: Colour, dark?: Colour): SerializedStyles =>
 	css`
 		color: ${light};
 
-		@media (prefers-color-scheme: dark) {
+		${dark &&
+		`@media (prefers-color-scheme: dark) {
 			color: ${dark};
-		}
+		}`}
 	`;
 
 const backgroundColour = (light: Colour, dark: Colour): SerializedStyles =>
@@ -31,6 +32,10 @@ const headlineTextColour = (format: Format): SerializedStyles =>
 		text.headlinePrimary(format),
 		text.headlinePrimaryInverse(format),
 	);
+
+const editionsHeadlineTextColour = (format: Format): SerializedStyles =>
+	textColour(text.headlinePrimary(format));
+
 const headlineBackgroundColour = (format: Format): SerializedStyles =>
 	backgroundColour(
 		background.headlinePrimary(format),
@@ -39,4 +44,8 @@ const headlineBackgroundColour = (format: Format): SerializedStyles =>
 
 // ----- Exports ----- //
 
-export { headlineTextColour, headlineBackgroundColour };
+export {
+	headlineTextColour,
+	headlineBackgroundColour,
+	editionsHeadlineTextColour,
+};


### PR DESCRIPTION
The Editions headline was using dark mode text colour even though Editions doesn't support it. 

| Before (in dark mode) | After (in dark mode) |
| --- | --- |
| ![Screenshot 2021-03-03 at 15 32 28](https://user-images.githubusercontent.com/12860328/109829778-c3802c00-7c35-11eb-9c5b-af2fd2eab4f8.png) | ![Screenshot 2021-03-03 at 15 32 35](https://user-images.githubusercontent.com/12860328/109829823-cbd86700-7c35-11eb-9cdb-011b11895c2b.png) |


