### PR TITLE
LIVE-1889: discussion-rendering v4.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2221,9 +2221,9 @@
       }
     },
     "@guardian/discussion-rendering": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@guardian/discussion-rendering/-/discussion-rendering-3.2.1.tgz",
-      "integrity": "sha512-1R36HFFf5QrE4+9+8L/MLIqGffqNqixN49C9as0yjoxoYiz+DyUouxfnincQ9i1jruU0a9M16di9XNzc306KKg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@guardian/discussion-rendering/-/discussion-rendering-4.6.1.tgz",
+      "integrity": "sha512-0SK6TKfFwWDTf1Mky6DmnsgT31PRfXBWpIJFvXDt524neVotphkjsOs5FA7Ub3jq+ICuD566mEHYCVSWBcWoMg==",
       "requires": {
         "babel-plugin-emotion": "^10.0.33",
         "customize-cra": "^1.0.0",
@@ -2263,6 +2263,10 @@
           "version": "2.8.2",
           "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-2.8.2.tgz",
           "integrity": "sha512-DUluJNGcOIgx5/EvgE4T5JZSKfceR+oMMZw8UAUVWOrKH8W9xeE4AGCquZlh/COXJDCP6YvDyRW6yk4EVqEwww=="
+        },
+        "@guardian/types": {
+          "version": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
+          "from": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32"
         },
         "react": {
           "version": "16.14.0",
@@ -18624,19 +18628,29 @@
       }
     },
     "react-app-rewired": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.6.tgz",
-      "integrity": "sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.8.tgz",
+      "integrity": "sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==",
       "requires": {
         "semver": "^5.6.0"
       }
     },
     "react-clientside-effect": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
-      "integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.5.tgz",
+      "integrity": "sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==",
       "requires": {
-        "@babel/runtime": "^7.0.0"
+        "@babel/runtime": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
+          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "react-color": {
@@ -22649,9 +22663,9 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "use-callback-ref": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.4.tgz",
-      "integrity": "sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
+      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg=="
     },
     "use-composed-ref": {
       "version": "1.1.0",
@@ -22678,9 +22692,9 @@
       }
     },
     "use-sidecar": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.3.tgz",
-      "integrity": "sha512-ygJwGUBeQfWgDls7uTrlEDzJUUR67L8Rm14v/KfFtYCdHhtjHZx1Krb3DIQl3/Q5dJGfXLEQ02RY8BdNBv87SQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.4.tgz",
+      "integrity": "sha512-A5ggIS3/qTdxCAlcy05anO2/oqXOfpmxnpRE1Jm+fHHtCvUvNSZDGqgOSAXPriBVAcw2fMFFkh5v5KqrFFhCMA==",
       "requires": {
         "detect-node-es": "^1.0.0",
         "tslib": "^1.9.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2248,12 +2248,12 @@
       }
     },
     "@guardian/image-rendering": {
-      "version": "github:guardian/image-rendering#a3119033c610c0b0d8d862e27a778e0466b1d31c",
-      "from": "github:guardian/image-rendering#semver:^5.0.2",
+      "version": "github:guardian/image-rendering#6ad32f87e66a794c2d385cf9e82d605fb9e8b35c",
+      "from": "github:guardian/image-rendering#6ad32f87",
       "requires": {
         "@emotion/core": "^10.1.1",
         "@guardian/src-foundations": "^2.7.1",
-        "@guardian/types": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
+        "@guardian/types": "github:guardian/types#semver:1.1.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "typescript": "^4.1.3"
@@ -2263,10 +2263,6 @@
           "version": "2.8.2",
           "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-2.8.2.tgz",
           "integrity": "sha512-DUluJNGcOIgx5/EvgE4T5JZSKfceR+oMMZw8UAUVWOrKH8W9xeE4AGCquZlh/COXJDCP6YvDyRW6yk4EVqEwww=="
-        },
-        "@guardian/types": {
-          "version": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
-          "from": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32"
         },
         "react": {
           "version": "16.14.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@guardian/bridget": "^1.8.0",
     "@guardian/content-api-models": "^15.10.0",
     "@guardian/content-atom-model": "^3.2.4",
-    "@guardian/discussion-rendering": "^3.2.1",
+    "@guardian/discussion-rendering": "^4.6.1",
     "@guardian/image-rendering": "github:guardian/image-rendering#semver:^5.0.2",
     "@guardian/node-riffraff-artifact": "^0.1.9",
     "@guardian/renditions": "git+https://github.com/guardian/renditions.git#0.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@guardian/content-api-models": "^15.10.0",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^4.6.1",
-    "@guardian/image-rendering": "github:guardian/image-rendering#semver:^5.0.2",
+    "@guardian/image-rendering": "github:guardian/image-rendering#6ad32f87",
     "@guardian/node-riffraff-artifact": "^0.1.9",
     "@guardian/renditions": "git+https://github.com/guardian/renditions.git#0.1.1",
     "@guardian/src-brand": "^2.6.0",

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -25,6 +25,7 @@ import {
 } from 'native/nativeApi';
 import { createElement as h } from 'react';
 import ReactDOM from 'react-dom';
+import { stringToPillar } from 'themeStyles';
 import { logger } from '../logger';
 
 // ----- Run ----- //
@@ -172,7 +173,7 @@ function renderComments(): void {
 		const props = {
 			shortUrl,
 			baseUrl: 'https://discussion.theguardian.com/discussion-api',
-			pillar,
+			pillar: stringToPillar(pillar),
 			user,
 			isClosedForComments,
 			additionalHeaders,

--- a/src/themeStyles.ts
+++ b/src/themeStyles.ts
@@ -111,6 +111,29 @@ function themeToPillar(theme: Theme): string {
 	}
 }
 
+const stringToPillar = (pillar: string): Pillar => {
+	switch (pillar) {
+		case 'news':
+			return Pillar.News;
+		case 'opinion':
+			return Pillar.Opinion;
+		case 'culture':
+			return Pillar.Culture;
+		case 'sport':
+			return Pillar.Sport;
+		case 'lifestyle':
+			return Pillar.Lifestyle;
+		default:
+			return Pillar.News;
+	}
+};
+
 // ----- Exports ----- //
 
-export { ThemeStyles, getThemeStyles, themeFromString, themeToPillar };
+export {
+	ThemeStyles,
+	getThemeStyles,
+	themeFromString,
+	themeToPillar,
+	stringToPillar,
+};


### PR DESCRIPTION
[Jira ticket](https://theguardian.atlassian.net/browse/LIVE-1889)
Precursor to the emotion 11 updates. 

Updating to discussion-rendering 4.6.1 just before a major types update. 
Once discussion-rendering was updated, the `@guardian/types` were clashing with the main dependency and  image-rendering's dependency.
`image-rendering` is declaring `@guardian/types` as both dependency and as a peer dependency, which was causing a ts compiler conflict (even though the types were identical 🤔). 
This PR uses this commit https://github.com/guardian/image-rendering/commit/6ad32f87e66a794c2d385cf9e82d605fb9e8b35c which is based off image-rendering 5.0.2 but removing `types` as a peer dependency. 
This update is intermediary so both discussion and image rendering should be updated further up with the emotion 11 update work.
