### PR TITLE
Lock screenshot action at ubuntu-18

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     article_screenshots:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         strategy:
             matrix:
                 article:
@@ -81,7 +81,7 @@ jobs:
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_IMAGE_UPLOADER_SECRET_ACCESS_KEY }}
 
     comment:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         needs: article_screenshots
         strategy:
             max-parallel: 1


### PR DESCRIPTION
The screenshot github action was depending on `ubuntu-latest` which in turn was depending on a 1.x version of AWS cli. 
The cli version we needed ships with ubuntu-18, however GH actions are phasing out an update to their `ubuntu-latest` tag as `ubuntu-20` which must have happened for us yesterday afternoon. This in turn uses aws cli 2.x which broke the s3 copy command.

Locking it at `ubuntu-18` instead of `latest` fixes this, 18 is still supported so it's ok for us to keep it for now. We might want to think of a health ticket in the future to update the screenshot job to use `ubuntu-20`.

Thanks to @jacobwinch and @frankie297 for helping out.