### PR TITLE
LIVE-1901: remove content-fit

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -4070,9 +4070,6 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   font-size: 1.0625rem;
   padding: 0.25rem 0 0.5rem;
   box-sizing: border-box;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 @media (min-width:740px) {
@@ -12827,9 +12824,6 @@ exports[`Storyshots Editions/Series Default 1`] = `
   font-size: 1.0625rem;
   padding: 0.25rem 0 0.5rem;
   box-sizing: border-box;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 @media (min-width:740px) {
@@ -12856,9 +12850,6 @@ exports[`Storyshots Editions/Series Immersive 1`] = `
   font-size: 1.0625rem;
   padding: 0.25rem 0 0.5rem;
   box-sizing: border-box;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
   position: absolute;
   left: 0;
   bottom: 0;
@@ -12892,9 +12883,6 @@ exports[`Storyshots Editions/Series Interview 1`] = `
   font-size: 1.0625rem;
   padding: 0.25rem 0 0.5rem;
   box-sizing: border-box;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
   position: absolute;
   left: 0;
   bottom: 0;

--- a/src/components/editions/series/index.tsx
+++ b/src/components/editions/series/index.tsx
@@ -22,7 +22,6 @@ const styles = (kicker: string): SerializedStyles => css`
 	font-size: 1.0625rem;
 	padding: ${remSpace[1]} 0 ${remSpace[2]};
 	box-sizing: border-box;
-	width: fit-content;
 
 	${from.tablet} {
 		padding-bottom: ${remSpace[3]};


### PR DESCRIPTION
## Why are you doing this?

Fixes a bug where sometimes the kicker split over two lines.

## Changes

- remove `content-fit` css property

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/110334787-0f0e4d80-801b-11eb-919b-8c1bcef69154.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/110334844-1cc3d300-801b-11eb-80de-34b6b4fcd8ab.png" width="300px" /> | 