### PR TITLE
LIVE-1919: fix broken caption icon

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -382,6 +382,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 .emotion-7 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #BB3B80;
@@ -413,18 +414,6 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-7 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 @media (min-width:740px) {
@@ -1594,6 +1583,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 .emotion-7 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #C70000;
@@ -1625,18 +1615,6 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-7 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 @media (min-width:740px) {
@@ -2871,6 +2849,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
 }
 
 .emotion-7 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #C70000;
@@ -2902,18 +2881,6 @@ exports[`Storyshots Editions/Article Default 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-7 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 @media (min-width:740px) {
@@ -4029,6 +3996,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-7 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #E05E00;
@@ -4060,18 +4028,6 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-7 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 @media (min-width:740px) {
@@ -5210,6 +5166,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 }
 
 .emotion-7 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #0084C6;
@@ -5241,18 +5198,6 @@ exports[`Storyshots Editions/Article Feature 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-7 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 @media (min-width:740px) {
@@ -6301,6 +6246,7 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
 }
 
 .emotion-7 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #C70000;
@@ -6332,18 +6278,6 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-7 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 .emotion-8 {
@@ -7156,6 +7090,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 .emotion-6 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #0084C6;
@@ -7187,18 +7122,6 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-6 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-6 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 .emotion-7 {
@@ -8441,6 +8364,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 .emotion-7 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #A1845C;
@@ -8472,18 +8396,6 @@ exports[`Storyshots Editions/Article Review 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-7 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-7 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 @media (min-width:740px) {
@@ -9744,6 +9656,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 .emotion-9 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #C70000;
@@ -9775,18 +9688,6 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-9 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-9 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 @media (min-width:740px) {
@@ -11733,6 +11634,7 @@ exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
 }
 
 .emotion-2 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #C70000;
@@ -11764,18 +11666,6 @@ exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-2 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-2 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 .emotion-3 {
@@ -11907,6 +11797,7 @@ exports[`Storyshots Editions/HeaderMedia Image 1`] = `
 }
 
 .emotion-2 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #C70000;
@@ -11938,18 +11829,6 @@ exports[`Storyshots Editions/HeaderMedia Image 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-2 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-2 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 @media (min-width:740px) {
@@ -12122,6 +12001,7 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
 }
 
 .emotion-2 summary {
+  display: block;
   pointer-events: auto;
   text-align: center;
   background-color: #A1845C;
@@ -12153,18 +12033,6 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
-}
-
-@media (min-width:740px) {
-  .emotion-2 details[open] {
-    padding-left: 1.5rem;
-  }
-}
-
-@media (min-width:980px) {
-  .emotion-2 details[open] {
-    padding-left: 9rem;
-  }
 }
 
 @media (min-width:740px) {

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -6280,6 +6280,18 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
   box-sizing: border-box;
 }
 
+@media (min-width:740px) {
+  .emotion-7 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-7 details[open] {
+    padding-left: 9rem;
+  }
+}
+
 .emotion-8 {
   line-height: 32px;
   font-size: 0;
@@ -7122,6 +7134,18 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-6 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-6 details[open] {
+    padding-left: 9rem;
+  }
 }
 
 .emotion-7 {
@@ -11666,6 +11690,18 @@ exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
   line-height: 1.5;
   font-weight: 400;
   box-sizing: border-box;
+}
+
+@media (min-width:740px) {
+  .emotion-2 details[open] {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:980px) {
+  .emotion-2 details[open] {
+    padding-left: 9rem;
+  }
 }
 
 .emotion-3 {

--- a/src/components/editions/headerImageCaption.tsx
+++ b/src/components/editions/headerImageCaption.tsx
@@ -1,6 +1,7 @@
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { SvgCamera } from '@guardian/src-icons';
@@ -12,6 +13,7 @@ import type { FC, ReactElement } from 'react';
 const captionId = 'header-image-caption';
 
 const HeaderImageCaptionStyles = (
+	isFullWidthImage: boolean,
 	iconBackgroundColor?: string,
 ): SerializedStyles => css`
 	summary {
@@ -46,6 +48,14 @@ const HeaderImageCaptionStyles = (
 		color: ${neutral[100]};
 		${textSans.small()};
 		box-sizing: border-box;
+
+		${isFullWidthImage &&
+		`${from.tablet} {
+			padding-left: ${remSpace[6]};
+		}
+		${from.desktop} {
+			padding-left: 9rem;
+		}`}
 	}
 	pointer-events: none;
 	position: absolute;
@@ -74,6 +84,7 @@ interface Props {
 	styles?: SerializedStyles;
 	iconColor?: string;
 	iconBackgroundColor?: string;
+	isFullWidthImage: boolean;
 }
 
 const HeaderImageCaption: FC<Props> = ({
@@ -82,12 +93,19 @@ const HeaderImageCaption: FC<Props> = ({
 	styles,
 	iconColor,
 	iconBackgroundColor,
+	isFullWidthImage,
 }: Props) =>
 	pipe2(
 		caption,
 		map((cap) => (
 			<figcaption
-				css={[HeaderImageCaptionStyles(iconBackgroundColor), styles]}
+				css={[
+					HeaderImageCaptionStyles(
+						isFullWidthImage,
+						iconBackgroundColor,
+					),
+					styles,
+				]}
 			>
 				<details>
 					<summary>

--- a/src/components/editions/headerImageCaption.tsx
+++ b/src/components/editions/headerImageCaption.tsx
@@ -16,6 +16,7 @@ const HeaderImageCaptionStyles = (
 	iconBackgroundColor?: string,
 ): SerializedStyles => css`
 	summary {
+		display: block;
 		pointer-events: auto;
 		text-align: center;
 		background-color: ${iconBackgroundColor

--- a/src/components/editions/headerImageCaption.tsx
+++ b/src/components/editions/headerImageCaption.tsx
@@ -1,7 +1,6 @@
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import { remSpace } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { SvgCamera } from '@guardian/src-icons';
@@ -47,14 +46,6 @@ const HeaderImageCaptionStyles = (
 		color: ${neutral[100]};
 		${textSans.small()};
 		box-sizing: border-box;
-
-		${from.tablet} {
-			padding-left: ${remSpace[6]};
-		}
-
-		${from.desktop} {
-			padding-left: 9rem;
-		}
 	}
 	pointer-events: none;
 	position: absolute;

--- a/src/components/editions/headerMedia/index.tsx
+++ b/src/components/editions/headerMedia/index.tsx
@@ -163,6 +163,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 						styles={getCaptionStyles(format)}
 						iconColor={iconColor}
 						iconBackgroundColor={iconBackgroundColor}
+						isFullWidthImage={isFullWidthImage(format)}
 					/>
 					<StarRating item={item} />
 				</figure>

--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -17,6 +17,7 @@ const HeaderImageCaptionStyles = (
 	iconBackgroundColor?: string,
 ): SerializedStyles => css`
 	summary {
+		display: block;
 		text-align: center;
 		background-color: ${iconBackgroundColor
 			? iconBackgroundColor


### PR DESCRIPTION
## Why are you doing this?
In Chrome 89, it seems there must have been a change that realigns with the spec. This in turn broke the caption icon, the way it has been broken on firefox for ages.

This PR fixes it so it works in chrome (older versions and 89) and safari (thanks @mxdvl)
Also I noticed there was some strange padding in the editions caption on wider viewports which I don't understand so I removed it. If anyone knows why it was there in the first place, do give a shout.

### icon fix
| before | after |
| -- | -- |
|![Screenshot 2021-03-09 at 12 38 20](https://user-images.githubusercontent.com/12860328/110471875-966bc780-80d4-11eb-9ac9-6362f0271d39.png) | ![Screenshot 2021-03-09 at 12 38 30](https://user-images.githubusercontent.com/12860328/110471909-9cfa3f00-80d4-11eb-900a-95f65fac4f1d.png) |

### editions caption padding
| before | after |
| -- | -- |
| ![Screenshot 2021-03-09 at 12 39 05](https://user-images.githubusercontent.com/12860328/110471962-b0a5a580-80d4-11eb-9c85-70084809e7d5.png) | ![Screenshot 2021-03-09 at 12 39 30](https://user-images.githubusercontent.com/12860328/110471995-b9967700-80d4-11eb-9361-d83ae5dbf7d8.png) |





