### PR TITLE
LIVE-1894: Add useDarkMode prop for link styling

### DIFF
--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -17,12 +17,14 @@ interface Props {
 	children?: ReactNode;
 	format: Format;
 	className?: SerializedStyles;
+	useDarkMode?: boolean;
 }
 
-const styles = css`
+const styles = (useDarkMode: boolean) => css`
 	text-decoration: none;
 
-	${darkModeCss`
+	${useDarkMode &&
+	darkModeCss`
         color: ${neutral[86]};
         border-color: ${neutral[46]};
     `}
@@ -53,8 +55,14 @@ const colour = (format: Format): SerializedStyles => {
 	}
 };
 
-const Anchor: FC<Props> = ({ format, children, href, className }: Props) => (
-	<a css={[styles, colour(format), className]} href={href}>
+const Anchor: FC<Props> = ({
+	format,
+	children,
+	href,
+	className,
+	useDarkMode = true,
+}: Props) => (
+	<a css={[styles(useDarkMode), colour(format), className]} href={href}>
 		{children}
 	</a>
 );

--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -17,12 +17,12 @@ interface Props {
 	children?: ReactNode;
 	format: Format;
 	className?: SerializedStyles;
-	useDarkMode?: boolean;
+	supportsDarkMode?: boolean;
 }
 
-const styles = (useDarkMode: boolean): SerializedStyles => css`
+const styles = (supportsDarkMode: boolean): SerializedStyles => css`
 	text-decoration: none;
-	${useDarkMode &&
+	${supportsDarkMode &&
 	darkModeCss`
         color: ${neutral[86]};
         border-color: ${neutral[46]};
@@ -59,9 +59,9 @@ const Anchor: FC<Props> = ({
 	children,
 	href,
 	className,
-	useDarkMode = true,
+	supportsDarkMode = true,
 }: Props) => (
-	<a css={[styles(useDarkMode), colour(format), className]} href={href}>
+	<a css={[styles(supportsDarkMode), colour(format), className]} href={href}>
 		{children}
 	</a>
 );

--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -20,9 +20,8 @@ interface Props {
 	useDarkMode?: boolean;
 }
 
-const styles = (useDarkMode: boolean) => css`
+const styles = (useDarkMode: boolean): SerializedStyles  => css`
 	text-decoration: none;
-
 	${useDarkMode &&
 	darkModeCss`
         color: ${neutral[86]};

--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -20,7 +20,7 @@ interface Props {
 	useDarkMode?: boolean;
 }
 
-const styles = (useDarkMode: boolean): SerializedStyles  => css`
+const styles = (useDarkMode: boolean): SerializedStyles => css`
 	text-decoration: none;
 	${useDarkMode &&
 	darkModeCss`

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -242,12 +242,14 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 	}
 };
 
-const textElement = (format: Format) => (
+const textElement = (format: Format, useDarkMode = true) => (
 	node: Node,
 	key: number,
 ): ReactNode => {
 	const text = node.textContent ?? '';
-	const children = Array.from(node.childNodes).map(textElement(format));
+	const children = Array.from(node.childNodes).map(
+		textElement(format, useDarkMode),
+	);
 	switch (node.nodeName) {
 		case 'P':
 			return h(Paragraph, { key, format }, children);
@@ -262,6 +264,7 @@ const textElement = (format: Format) => (
 					href: withDefault('')(getHref(node)),
 					format,
 					key,
+					useDarkMode,
 				},
 				transform(text, format),
 			);
@@ -353,9 +356,12 @@ const noLinksStandfirstTextElement = (format: Format) => (
 	}
 };
 
-const text = (doc: DocumentFragment, format: Format): ReactNode[] =>
-	Array.from(doc.childNodes).map(textElement(format));
-
+const text = (
+	doc: DocumentFragment,
+	format: Format,
+	useDarkMode = true,
+): ReactNode[] =>
+	Array.from(doc.childNodes).map(textElement(format, useDarkMode));
 const standfirstText = (
 	doc: DocumentFragment,
 	format: Format,
@@ -468,10 +474,11 @@ const textRenderer = (
 	format: Format,
 	excludeStyles: boolean,
 	element: Text,
+	useDarkMode?: boolean,
 ): ReactNode => {
 	return excludeStyles
 		? Array.from(element.doc.childNodes).map(plainTextElement)
-		: text(element.doc, format);
+		: text(element.doc, format, useDarkMode);
 };
 
 const instagramRenderer = (element: Instagram): ReactNode => {
@@ -757,7 +764,7 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 ): ReactNode => {
 	switch (element.kind) {
 		case ElementKind.Text:
-			return textRenderer(format, excludeStyles, element);
+			return textRenderer(format, excludeStyles, element, false);
 
 		case ElementKind.Image:
 			return format.design === Design.Media

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -242,13 +242,13 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 	}
 };
 
-const textElement = (format: Format, useDarkMode = true) => (
+const textElement = (format: Format, supportsDarkMode = true) => (
 	node: Node,
 	key: number,
 ): ReactNode => {
 	const text = node.textContent ?? '';
 	const children = Array.from(node.childNodes).map(
-		textElement(format, useDarkMode),
+		textElement(format, supportsDarkMode),
 	);
 	switch (node.nodeName) {
 		case 'P':
@@ -264,7 +264,7 @@ const textElement = (format: Format, useDarkMode = true) => (
 					href: withDefault('')(getHref(node)),
 					format,
 					key,
-					useDarkMode,
+					supportsDarkMode,
 				},
 				transform(text, format),
 			);
@@ -359,9 +359,9 @@ const noLinksStandfirstTextElement = (format: Format) => (
 const text = (
 	doc: DocumentFragment,
 	format: Format,
-	useDarkMode = true,
+	supportsDarkMode = true,
 ): ReactNode[] =>
-	Array.from(doc.childNodes).map(textElement(format, useDarkMode));
+	Array.from(doc.childNodes).map(textElement(format, supportsDarkMode));
 const standfirstText = (
 	doc: DocumentFragment,
 	format: Format,
@@ -474,11 +474,11 @@ const textRenderer = (
 	format: Format,
 	excludeStyles: boolean,
 	element: Text,
-	useDarkMode?: boolean,
+	supportsDarkMode?: boolean,
 ): ReactNode => {
 	return excludeStyles
 		? Array.from(element.doc.childNodes).map(plainTextElement)
-		: text(element.doc, format, useDarkMode);
+		: text(element.doc, format, supportsDarkMode);
 };
 
 const instagramRenderer = (element: Instagram): ReactNode => {


### PR DESCRIPTION
## Why are you doing this?
The live apps supports dark mode but Editions doesn't. This PR adds a useDarkMode prop to allow us to disable dark mode styles on body anchor links.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/110497577-7cd77980-80ee-11eb-88b8-5664acd8ccc1.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/110496256-36cde600-80ed-11eb-8fa1-fdb3ea956144.png" width="300px" /> |


| AR | 
| --- | 
| <img src="https://user-images.githubusercontent.com/20416599/110496317-45b49880-80ed-11eb-9171-43dd076cdf1c.png" width="300px" /> |
