### PR TITLE
Remove '!important' from atom bg CSS

### DIFF
--- a/src/components/atoms/interactiveAtom.tsx
+++ b/src/components/atoms/interactiveAtom.tsx
@@ -34,7 +34,7 @@ const atomCss = `
     
     @media (prefers-color-scheme: dark) {
         body {
-            background: white !important;
+            background: white;
             padding: ${remSpace[2]} !important;
         } 
     }`;


### PR DESCRIPTION
In a majority of cases atoms should have a white background in dark mode on apps. However we are now creating interactive atoms with a styleset that allows them to have dark mode styles which should be shown on the default dark background. 

In this atoms I want to be able to override the `background: white;` in the atom CSS. Only atoms where there are special dark mode styles will do this. Currently I can't override it because of the `!important` on the style rule here. 

The styles here run after the styles from the atom so if they are more powerful or have the same power these styles win out.

## Why are you doing this?

So interactives atoms that have dark mode styles can have a dark background and not a white background in apps. 

## Screenshots
<img src="https://user-images.githubusercontent.com/10324129/110515482-5c181f80-8100-11eb-9782-15339e29d39e.png" width="450">

