### PR TITLE
ammended footer content with policy and the order of execution for fo…

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -13607,6 +13607,22 @@ exports[`Storyshots Footer Default 1`] = `
   }
 }
 
+.emotion-2 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.35;
+  font-weight: 400;
+  color: #121212;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+@media (prefers-color-scheme:dark) {
+  .emotion-2 {
+    color: #999999;
+  }
+}
+
 <div
   className="emotion-0"
 >
@@ -13616,6 +13632,13 @@ exports[`Storyshots Footer Default 1`] = `
   <br />
   <a
     className="emotion-1"
+    href="https://www.theguardian.com/help/privacy-settings"
+  >
+    Privacy Settings
+  </a>
+   · 
+  <a
+    className="emotion-2"
     href="https://www.theguardian.com/help/privacy-policy"
   >
     Privacy Policy

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -227,8 +227,8 @@ function footerInit(): void {
 function isCCPA(): void {
 	userClient
 		.doesCcpaApply()
-		.then((isOptedIn) => {
-			const comp = h(FooterCcpa, { isCcpa: isOptedIn });
+		.then((isCcpa) => {
+			const comp = h(FooterCcpa, { isCcpa });
 			ReactDOM.render(comp, document.getElementById('articleFooter'));
 		})
 		.catch((error) => {
@@ -467,12 +467,12 @@ reportNativeElementPositionChanges();
 topics();
 slideshow();
 formatDates();
+footerInit();
 insertEpic();
 callouts();
 renderComments();
 hasSeenCards();
 initAudioAtoms();
 hydrateQuizAtoms();
-footerInit();
 localDates();
 richLinks();

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -49,7 +49,17 @@ const renderContent = (ccpaStatus: boolean): JSX.Element | null => {
 			</>
 		);
 	} else {
-		return null;
+		return (
+			<>
+				<a
+					css={anchor}
+					href="https://www.theguardian.com/help/privacy-settings"
+				>
+					Privacy Settings
+				</a>
+				&nbsp;&#183;&nbsp;
+			</>
+		);
 	}
 };
 


### PR DESCRIPTION
## Why are you doing this?

iOS currently is communicating with SSR articles to implement doesCcpaApply() to effectively render CCPA footer content for US residents.

## Changes

- Added a timeOut delay for async - a delay to allow time for the the data to be parsed and processed to `bridget` before reading the boolean value from `article.ts`
- Added Privacy settings in footer when CCPA not present

NOTE: This was updated from an older PR in order to reduce conflicts

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/110632458-8e2c8e80-819f-11eb-9f43-441ba220933f.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/110631752-c54e7000-819e-11eb-955f-b93a86e8af9c.png" width="300px" /> |
