### PR TITLE
LIVE-1903: don't render callout as generic embed

### DIFF
--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -343,7 +343,11 @@ const parse = (context: Context, atoms?: Atoms, campaigns?: Campaign[]) => (
 				.querySelector('[data-callout-tagname]')
 				?.getAttribute('data-callout-tagname');
 
-			if (id && campaigns) {
+			if (id) {
+				if (!campaigns) {
+					return err('No campaign data for this callout');
+				}
+
 				const campaign = campaigns.find(
 					(campaign) => campaign.fields.tagName === id,
 				);


### PR DESCRIPTION
## Why are you doing this?

Callouts without campaigns were rendering as generic embeds. This PR instead throws an error if no campaign is present.

** We might need to check if this is the correct behaviour - if callouts can exist without campaigns this will need ammending.

## Changes

- add separate conditional to check if campaigns exist

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/110649372-70682500-81b1-11eb-8004-6142ba5d196a.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/110649416-7958f680-81b1-11eb-924b-2d38e16a36c9.png" width="300px" /> |
