### PR TITLE
Use IMDSv2 metadata service

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -300,6 +300,8 @@ Resources:
         - !Ref InstanceSecurityGroup
         - Fn::ImportValue: !Sub SecurityGroups-${Stage}-MapiGuardianLondonSSH
         - !Ref DefaultVpcSecurityGroup
+      MetadataOptions:
+          HttpTokens: required
       UserData:
         "Fn::Base64":
           !Sub |


### PR DESCRIPTION
Stolen from Phil's [PR](https://github.com/guardian/amigo/pull/544) but explains it quite clearly:

This PR aims to resolve https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-8-remediation by making HTTPTokens 'required' when using the EC2 metadata service. Essentially amazon has released a more secure way of fetching metadata and they think that it should be enforced on all instances as the previous approach presented a security risk.

For more details on the metadata options see here https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-config.html#launch-configurations-imds
