### PR TITLE
Publish a new scala package for apps-rendering-api-models

### DIFF
--- a/api-models/scala/version.sbt
+++ b/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.2-SNAPSHOT"
+version in ThisBuild := "0.11.2"

--- a/api-models/scala/version.sbt
+++ b/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.2"
+version in ThisBuild := "0.11.3-SNAPSHOT"

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -236,7 +236,7 @@ describe('fromCapi returns correct Item', () => {
 
 	test('matchreport', () => {
 		const item = f(contentWithTag('tone/matchreports'));
-		expect(item.design).toBe(Design.Article);
+		expect(item.design).toBe(Design.MatchReport);
 	});
 
 	test('interview', () => {

--- a/src/item.ts
+++ b/src/item.ts
@@ -260,7 +260,7 @@ const isQuiz = hasTag('tone/quizzes');
 
 const isLabs = hasTag('tone/advertisement-features');
 
-const isMatchReport = hasTag('tone/matchreport');
+const isMatchReport = hasTag('tone/matchreports');
 const isPicture = hasTag('type/picture');
 
 const fromCapiLiveBlog = (context: Context) => (


### PR DESCRIPTION
## Why are you doing this?
Published a new scala package for apps-rendering-api-models 0.11.2

You can find the package in 
https://oss.sonatype.org/#nexus-search;quick~apps-rendering-api-models
and
https://repo1.maven.org/maven2/com/gu/apps-rendering-api-models_2.12/

**Other changes**: The tag for a match report is `tone/matchreports` but in Item we were checking for `tone/matchreport` and as a result the item was not created with football content. The tag checking was updated in this PR.

Test result: 
https://mobile.code.dev-guardianapis.com/rendered-items/football/2020/jun/23/tottenhams-harry-kane-back-on-target-to-deepen-west-hams-misery