### PR TITLE
LIVE-2093: Fix epic styles

### DIFF
--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -17,7 +17,7 @@ import {
 } from 'client/nativeCommunication';
 import setup from 'client/setup';
 import FooterContent from 'components/footerContent';
-import Epic from 'components/shared/epic';
+import EpicContent from 'components/shared/epicContent';
 import { formatDate, formatLocal, isValidDate } from 'date';
 import { handleErrors, isObject } from 'lib';
 import {
@@ -119,7 +119,7 @@ function formatDates(): void {
 
 // TODO: show epics on opinion articles
 function insertEpic(): void {
-	const epicPlaceholder = document.getElementById('epic-placeholder');
+	const epicPlaceholder = document.getElementById('js-epic-placeholder');
 	if (epicPlaceholder) {
 		epicPlaceholder.innerHTML = '';
 	}
@@ -139,7 +139,7 @@ function insertEpic(): void {
 						firstButton,
 						secondButton,
 					};
-					ReactDOM.render(h(Epic, epicProps), epicPlaceholder);
+					ReactDOM.render(h(EpicContent, epicProps), epicPlaceholder);
 				}
 			})
 			.catch((error) => console.error(error));

--- a/src/components/shared/epic.tsx
+++ b/src/components/shared/epic.tsx
@@ -1,9 +1,7 @@
 // ----- Imports ----- //
 
 import type { SerializedStyles } from '@emotion/react';
-import { css, ThemeProvider } from '@emotion/react';
-import { PurchaseScreenReason } from '@guardian/bridget/PurchaseScreenReason';
-import { Button, buttonReaderRevenue } from '@guardian/src-button';
+import { css } from '@emotion/react';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import {
@@ -11,24 +9,23 @@ import {
 	brandAltBackground,
 	neutral,
 } from '@guardian/src-foundations/palette';
-import { body, headline } from '@guardian/src-foundations/typography';
-import { SvgArrowRightStraight } from '@guardian/src-icons';
-import { acquisitionsClient } from 'native/nativeApi';
-import { useEffect, useRef, useState } from 'react';
+import { body, headline, textSans } from '@guardian/src-foundations/typography';
 import { darkModeCss } from 'styles';
 
 // ----- Styles ----- //
 
 const styles: SerializedStyles = css`
-	${from.wide} {
-		margin: ${remSpace[2]} 0;
-	}
+	& > div {
+		${from.wide} {
+			margin: ${remSpace[2]} 0;
+		}
 
-	border-top: 1px solid ${brandAltBackground.primary};
-	background: ${neutral[97]};
-	padding: ${remSpace[2]};
-	${body.medium()}
-	clear: left;
+		border-top: 1px solid ${brandAltBackground.primary};
+		background: ${neutral[97]};
+		padding: ${remSpace[2]};
+		${body.medium()}
+		clear: left;
+	}
 
 	h1:first-of-type {
 		margin-top: 0;
@@ -47,113 +44,69 @@ const styles: SerializedStyles = css`
 		background: ${brandAltBackground.primary};
 		padding: 0.1rem 0.125rem;
 	}
+
+	// Source Button styles
+	.button-container svg {
+		margin-right: -4px;
+		flex: 0 0 auto;
+		display: block;
+		fill: currentColor;
+		position: relative;
+		width: 30px;
+		height: auto;
+	}
+
+	.src-button-space {
+		width: 12px;
+	}
+
+	button {
+		display: inline-flex;
+
+		justify-content: space-between;
+
+		align-items: center;
+		box-sizing: border-box;
+		border: none;
+		background: transparent;
+		cursor: pointer;
+		transition: 0.3s ease-in-out;
+		text-decoration: none;
+		white-space: nowrap;
+		${textSans.medium()}
+		line-height: 1.5;
+		font-weight: 700;
+		height: 44px;
+		min-height: 44px;
+		padding: 0 20px;
+		border-radius: 44px;
+		padding-bottom: 2px;
+		background-color: #ffe500;
+		color: #052962;
+
+		margin: 0 ${remSpace[2]} ${remSpace[2]} 0;
+	}
 `;
 
 const darkStyles: SerializedStyles = darkModeCss`
-    color: ${neutral[93]};
-    background-color: ${neutral[20]};
-    border-top: 1px solid ${brandAlt[200]};
+	& > div {
+		color: ${neutral[93]};
+		background-color: ${neutral[20]};
+		border-top: 1px solid ${brandAlt[200]};
 
-    mark {
-        background: ${brandAlt[200]};
-    }
+		mark {
+			background: ${brandAlt[200]};
+		}
 
-    .button-container button {
-        background: ${brandAlt[200]};
-    }
+		.button-container button {
+			background: ${brandAlt[200]};
+		}
+	}
+
 `;
 
-// ----- Component ----- //
-
-interface EpicProps {
-	title: string;
-	body: string;
-	firstButton: string;
-	secondButton?: string;
-}
-
-const isElementPartiallyInViewport = (
-	el: React.MutableRefObject<HTMLDivElement>,
-): boolean => {
-	const rect = el.current.getBoundingClientRect();
-	const windowHeight =
-		window.innerHeight || document.documentElement.clientHeight;
-	const windowWidth =
-		window.innerWidth || document.documentElement.clientWidth;
-	const vertInView = rect.top <= windowHeight && rect.top + rect.height >= 0;
-	const horInView = rect.left <= windowWidth && rect.left + rect.width >= 0;
-	return vertInView && horInView;
-};
-
-const debounce = (fn: () => void, time: number): (() => void) => {
-	let timeout: NodeJS.Timeout;
-	return function (...args: []): void {
-		const functionCall = (): void => fn(...args);
-		clearTimeout(timeout);
-		timeout = setTimeout(functionCall, time);
-	};
-};
-
-function Epic({
-	title,
-	body,
-	firstButton,
-	secondButton,
-}: EpicProps): React.ReactElement | null {
-	const [impressionSeen, setImpressionSeen] = useState(false);
-	const epicContainer = useRef() as React.MutableRefObject<HTMLDivElement>;
-
-	useEffect(() => {
-		const handleSeenEpic = debounce(() => {
-			if (
-				!impressionSeen &&
-				isElementPartiallyInViewport(epicContainer)
-			) {
-				void acquisitionsClient.epicSeen();
-				setImpressionSeen(true);
-			}
-		}, 100);
-		window.addEventListener('scroll', handleSeenEpic);
-		return (): void => {
-			window.removeEventListener('scroll', handleSeenEpic);
-		};
-	}, [impressionSeen]);
-
-	const epicButton = (
-		text: string,
-		action: () => Promise<void>,
-	): JSX.Element => (
-		<Button
-			onClick={action}
-			iconSide="right"
-			icon={<SvgArrowRightStraight />}
-		>
-			{text}
-		</Button>
-	);
-
-	return (
-		<div css={[styles, darkStyles]} ref={epicContainer}>
-			<h1 dangerouslySetInnerHTML={{ __html: title }}></h1>
-			<div dangerouslySetInnerHTML={{ __html: body }}></div>
-			<div className="button-container">
-				<ThemeProvider theme={buttonReaderRevenue}>
-					{epicButton(firstButton, () =>
-						acquisitionsClient.launchPurchaseScreen(
-							PurchaseScreenReason.epic,
-						),
-					)}
-					{secondButton
-						? epicButton(secondButton, () =>
-								acquisitionsClient.launchPurchaseScreen(
-									PurchaseScreenReason.epic,
-								),
-						  )
-						: null}
-				</ThemeProvider>
-			</div>
-		</div>
-	);
+function Epic(): React.ReactElement {
+	return <div css={[styles, darkStyles]} id="js-epic-placeholder"></div>;
 }
 
 // ----- Exports ----- //

--- a/src/components/shared/epicContent.tsx
+++ b/src/components/shared/epicContent.tsx
@@ -1,0 +1,105 @@
+import { ThemeProvider } from '@emotion/react';
+import { PurchaseScreenReason } from '@guardian/bridget/PurchaseScreenReason';
+import { Button, buttonReaderRevenue } from '@guardian/src-button';
+import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { acquisitionsClient } from 'native/nativeApi';
+import { useEffect, useRef, useState } from 'react';
+
+// ----- Styles ----- //
+
+// ----- Component ----- //
+
+interface EpicProps {
+	title: string;
+	body: string;
+	firstButton: string;
+	secondButton?: string;
+}
+
+const isElementPartiallyInViewport = (
+	el: React.MutableRefObject<HTMLDivElement>,
+): boolean => {
+	const rect = el.current.getBoundingClientRect();
+	const windowHeight =
+		window.innerHeight || document.documentElement.clientHeight;
+	const windowWidth =
+		window.innerWidth || document.documentElement.clientWidth;
+	const vertInView = rect.top <= windowHeight && rect.top + rect.height >= 0;
+	const horInView = rect.left <= windowWidth && rect.left + rect.width >= 0;
+	return vertInView && horInView;
+};
+
+const debounce = (fn: () => void, time: number): (() => void) => {
+	let timeout: NodeJS.Timeout;
+	return function (...args: []): void {
+		const functionCall = (): void => fn(...args);
+		clearTimeout(timeout);
+		timeout = setTimeout(functionCall, time);
+	};
+};
+
+function EpicContent({
+	title,
+	body,
+	firstButton,
+	secondButton,
+}: EpicProps): React.ReactElement | null {
+	const [impressionSeen, setImpressionSeen] = useState(false);
+	const epicContainer = useRef() as React.MutableRefObject<HTMLDivElement>;
+
+	useEffect(() => {
+		const handleSeenEpic = debounce(() => {
+			if (
+				!impressionSeen &&
+				isElementPartiallyInViewport(epicContainer)
+			) {
+				void acquisitionsClient.epicSeen();
+				setImpressionSeen(true);
+			}
+		}, 100);
+		window.addEventListener('scroll', handleSeenEpic);
+		return (): void => {
+			window.removeEventListener('scroll', handleSeenEpic);
+		};
+	}, [impressionSeen]);
+
+	const epicButton = (
+		text: string,
+		action: () => Promise<void>,
+	): JSX.Element => (
+		<Button
+			onClick={action}
+			iconSide="right"
+			icon={<SvgArrowRightStraight />}
+		>
+			{text}
+		</Button>
+	);
+
+	return (
+		<div ref={epicContainer}>
+			<h1 dangerouslySetInnerHTML={{ __html: title }}></h1>
+			<div dangerouslySetInnerHTML={{ __html: body }}></div>
+			<div className="button-container">
+				<ThemeProvider theme={buttonReaderRevenue}>
+					{epicButton(firstButton, () =>
+						acquisitionsClient.launchPurchaseScreen(
+							PurchaseScreenReason.epic,
+						),
+					)}
+					{secondButton
+						? epicButton(secondButton, () =>
+								acquisitionsClient.launchPurchaseScreen(
+									PurchaseScreenReason.epic,
+								),
+						  )
+						: null}
+				</ThemeProvider>
+			</div>
+		</div>
+	);
+}
+
+// ----- Exports ----- //
+
+export default EpicContent;

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -94,8 +94,8 @@ interface Props {
 const Standard: FC<Props> = ({ item, children }) => {
 	// client side code won't render an Epic if there's an element with this id
 	const epicContainer = item.shouldHideReaderRevenue ? null : (
-		<div css={articleWidthStyles} id="epic-placeholder">
-			<Epic title="" body="" firstButton="" secondButton="" />
+		<div css={articleWidthStyles}>
+			<Epic />
 		</div>
 	);
 


### PR DESCRIPTION
## Why are you doing this?

Since merging emotion 11, client runtime styles are being blocked by CSP, this affected the footer and epic so far. The big mystery is why wasn't emotion blocking them before 🤔 Or maybe something else is happening, which we will need to investigate, but for now we need to fix the styles as they're user facing (even if just for beta users).

The fix here is not very nice and will need to think of something better .. Moving the styles up to the wrapper (like in https://github.com/guardian/apps-rendering/pull/1236). This mostly worked, except for the buttons. The `Epic` component uses `Source`'s `Button` component which is rendered client side.
I've kept the Source button for now however copied its styles up so they can be rendered server side, while we think of a better solution.


## Changes

- changed `#epic-placeholder` to `#js-epic-placeholder`
- moved `Epic` to `EpicContent`
- `Epic` is now the wrapper component.

