### PR TITLE
LIVE-1740: Update @guardian/types to 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2519,9 +2519,9 @@
       }
     },
     "@guardian/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-hTrk7EEsqSI/q7fyz2PuKMwKXuXRcwY7Ws+h72bvvimmpayfTwFQgEJfsjABxTSxdTw6bGA8T3F5GV4DJs9zog=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-8JQFfHqskOyc1ruSwWiJD8W4XuCsGorMpwEMRsBM3/zHykAiizsJu7827UbeFCWJ5FUquO/blXzm7oK8ZO99CQ=="
     },
     "@icons/material": {
       "version": "0.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2519,9 +2519,9 @@
       }
     },
     "@guardian/types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-8JQFfHqskOyc1ruSwWiJD8W4XuCsGorMpwEMRsBM3/zHykAiizsJu7827UbeFCWJ5FUquO/blXzm7oK8ZO99CQ=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-6.0.0.tgz",
+      "integrity": "sha512-HAYOUfy+Xm1WodByJ7fUH4emSSzVh3YW8euJx1r4TopsG/tIsI94IntOI38s6kwtsClY90gFKG25UiasKJL/Jw=="
     },
     "@icons/material": {
       "version": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@guardian/src-svgs": "^2.8.2",
     "@guardian/src-text-area": "^3.3.0",
     "@guardian/src-text-input": "^3.3.0",
-    "@guardian/types": "^5.1.0",
+    "@guardian/types": "^6.0.0",
     "@types/jsdom": "^16.2.5",
     "@types/uuid": "^8.3.0",
     "@types/webpack-node-externals": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@guardian/src-svgs": "^2.8.2",
     "@guardian/src-text-area": "^3.3.0",
     "@guardian/src-text-input": "^3.3.0",
-    "@guardian/types": "^3.0.0",
+    "@guardian/types": "^5.1.0",
     "@types/jsdom": "^16.2.5",
     "@types/uuid": "^8.3.0",
     "@types/webpack-node-externals": "^2.5.0",

--- a/src/components/body.tsx
+++ b/src/components/body.tsx
@@ -42,7 +42,7 @@ const notImplemented = (
 );
 
 const Body: FC<Props> = ({ item, shouldHideAds }) => {
-	if (item.design === Design.Live) {
+	if (item.design === Design.LiveBlog) {
 		return notImplemented;
 	}
 

--- a/src/components/editions/article/index.tsx
+++ b/src/components/editions/article/index.tsx
@@ -129,7 +129,7 @@ const Article: FC<Props> = ({ item }) => {
 		item.design === Design.Interview ||
 		item.design === Design.Feature ||
 		item.design === Design.Media ||
-		item.design === Design.GuardianView
+		item.design === Design.Editorial
 	) {
 		return (
 			<main css={mainStyles}>

--- a/src/components/editions/header/index.tsx
+++ b/src/components/editions/header/index.tsx
@@ -245,7 +245,7 @@ const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 	// Display.Immersive needs to come before Design.Interview
 	if (item.display === Display.Immersive) {
 		return <ImmersiveHeader item={item} />;
-	} else if (item.design === Design.GuardianView) {
+	} else if (item.design === Design.Editorial) {
 		return <StandardHeader item={item} />;
 	} else if (item.design === Design.Interview) {
 		return <InterviewHeader item={item} />;

--- a/src/components/headerImage.tsx
+++ b/src/components/headerImage.tsx
@@ -80,7 +80,7 @@ const immersiveImgStyles = css`
 
 const getStyles = ({ design, display }: Format): SerializedStyles => {
 	switch (design) {
-		case Design.Live:
+		case Design.LiveBlog:
 			return css(styles, liveStyles);
 		default:
 			if (display === Display.Immersive) {

--- a/src/components/headerVideo.tsx
+++ b/src/components/headerVideo.tsx
@@ -45,7 +45,7 @@ const styles = (format: Format): SerializedStyles => css`
 	${from.wide} {
 		padding-bottom: ${videoHeight}px;
 		width: ${wideContentWidth}px;
-		${format.design !== Design.Live ? marginAuto : null}
+		${format.design !== Design.LiveBlog ? marginAuto : null}
 	}
 `;
 

--- a/src/components/shared/tags.tsx
+++ b/src/components/shared/tags.tsx
@@ -22,7 +22,7 @@ const tagsStyles = (format: Format): SerializedStyles => {
 		switch (format.design) {
 			case Design.Comment:
 				return neutral[86];
-			case Design.Live:
+			case Design.LiveBlog:
 				return neutral[93];
 			default:
 				return neutral[97];

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -279,7 +279,7 @@ const comment: Item = {
 };
 
 const editorial: Item = {
-	design: Design.GuardianView,
+	design: Design.Editorial,
 	...fields,
 };
 

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -224,9 +224,9 @@ describe('fromCapi returns correct Item', () => {
 		expect(item.design).toBe(Design.Feature);
 	});
 
-	test('live', () => {
+	test('live blog', () => {
 		const item = f(contentWithTag('tone/minutebyminute'));
-		expect(item.design).toBe(Design.Live);
+		expect(item.design).toBe(Design.LiveBlog);
 	});
 
 	test('recipe', () => {
@@ -244,9 +244,9 @@ describe('fromCapi returns correct Item', () => {
 		expect(item.design).toBe(Design.Interview);
 	});
 
-	test('guardianview', () => {
+	test('editorial', () => {
 		const item = f(contentWithTag('tone/editorials'));
-		expect(item.design).toBe(Design.GuardianView);
+		expect(item.design).toBe(Design.Editorial);
 	});
 
 	test('quiz', () => {

--- a/src/item.ts
+++ b/src/item.ts
@@ -75,7 +75,7 @@ interface ResizedRelatedContent extends RelatedContent {
 }
 
 interface Liveblog extends Fields {
-	design: Design.Live;
+	design: Design.LiveBlog;
 	blocks: LiveBlock[];
 	totalBodyBlocks: number;
 }
@@ -99,7 +99,7 @@ interface Interactive extends Fields {
 // Catch-all for other Designs for now. As coverage of Designs increases,
 // this will likely be split out into each Design type.
 interface Standard extends Fields {
-	design: Exclude<Design, Design.Live | Design.Review | Design.Comment>;
+	design: Exclude<Design, Design.LiveBlog | Design.Review | Design.Comment>;
 	body: Body;
 }
 
@@ -270,7 +270,7 @@ const fromCapiLiveBlog = (context: Context) => (
 	const body = content.blocks?.body?.slice(0, 7) ?? [];
 
 	return {
-		design: Design.Live,
+		design: Design.LiveBlog,
 		blocks: parseLiveBlocks(body)(context),
 		totalBodyBlocks: content.blocks?.totalBodyBlocks ?? body.length,
 		...itemFields(context, request),
@@ -330,7 +330,7 @@ const fromCapi = (context: Context) => (request: RenderingRequest): Item => {
 		};
 	} else if (isGuardianView(tags)) {
 		return {
-			design: Design.GuardianView,
+			design: Design.Editorial,
 			...itemFieldsWithBody(context, request),
 		};
 	} else if (isQuiz(tags)) {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -183,7 +183,7 @@ const listItemStyles = (format: Format): SerializedStyles[] => {
 	switch (format.design) {
 		case Design.Media:
 			return [baseStyles, mediaStyles];
-		case Design.Live:
+		case Design.LiveBlog:
 			return [baseStyles, liveblogStyles];
 		default:
 			return [baseStyles];

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -48,7 +48,7 @@ const extractInteractiveAssets = (elements: BodyElement[]): Assets =>
 	);
 
 const getElements = (item: Item): Array<Result<string, BodyElement>> =>
-	item.design === Design.Live
+	item.design === Design.LiveBlog
 		? item.blocks.flatMap((block) => block.body)
 		: item.body;
 

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -38,7 +38,7 @@ const docParser = JSDOM.fragment.bind(null);
 
 const scriptName = ({ design, display }: Format): Option<string> => {
 	switch (design) {
-		case Design.Live:
+		case Design.LiveBlog:
 			return some('liveblog.js');
 		case Design.Interactive:
 			return display !== Display.Immersive ? some('article.js') : none;


### PR DESCRIPTION
## Why are you doing this?

We need to be on `@guardian/types` v4.0.0 so we can work on the Letter templates, however types is already on v6.0.0 so updating this in one go.

Initially we thought we will have to wait until these v5.1.0 (opened before 6 was released) are merged:
- https://github.com/guardian/atoms-rendering/pull/232 (merged now)
- https://github.com/guardian/discussion-rendering/pull/479
- https://github.com/guardian/image-rendering/pull/253

I opened this PR as a draft so we're ready to go, but looks like it that the build doesn't need these PRs merged after all 🤷‍♂️ .. possibly because nothing is conflicting in our codebase between v3 and v6 🎉 Therefore I'm publishing this PR to unblock the team.