### PR TITLE
Live 1182 remove editions embeds

### DIFF
--- a/src/components/embed.tsx
+++ b/src/components/embed.tsx
@@ -13,22 +13,23 @@ import type { FC } from 'react';
 
 interface Props {
 	embed: Embed;
+	editions?: boolean;
 }
 
 /**
  * Handles rendering of all third-party embeds.
  * See the `Embed` type for more information.
  */
-const EmbedComponent: FC<Props> = ({ embed }) => {
+const EmbedComponent: FC<Props> = ({ embed, editions }) => {
 	switch (embed.kind) {
 		case EmbedKind.Spotify:
-			return (
+			return !editions ? (
 				<Audio
 					src={embed.src}
 					width={embed.width}
 					height={embed.height}
 				/>
-			);
+			) : null;
 
 		case EmbedKind.YouTube:
 			return (

--- a/src/components/embed.tsx
+++ b/src/components/embed.tsx
@@ -13,7 +13,7 @@ import type { FC } from 'react';
 
 interface Props {
 	embed: Embed;
-	editions?: boolean;
+	editions: boolean;
 }
 
 /**

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -619,16 +619,6 @@ describe('Renders different types of Editions elements', () => {
 		);
 	});
 
-	test('ElementKind.KnowledgeQuizAtom', () => {
-		const nodes = renderEditions(knowledgeQuizAtom());
-		const quiz = nodes.flat()[0];
-		const html = getHtml(quiz);
-		expect(html).toContain('<div class="js-quiz">');
-		expect(html).toContain(
-			'<script class="js-quiz-params" type="application/json">',
-		);
-	});
-
 	function testHandlers(node: ReactNode): void {
 		if (isValidElement(node)) {
 			const container = document.createElement('div');

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -629,15 +629,6 @@ describe('Renders different types of Editions elements', () => {
 		);
 	});
 
-	test('ElementKind.AudioAtom', () => {
-		const nodes = renderEditions(audioAtom());
-		const audio = nodes.flat()[0];
-		const html = getHtml(audio);
-		expect(html).toContain(
-			'<div kind="17" title="title" id="" trackUrl="trackUrl" kicker="kicker" pillar="0"',
-		);
-	});
-
 	function testHandlers(node: ReactNode): void {
 		if (isValidElement(node)) {
 			const container = document.createElement('div');

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -543,14 +543,6 @@ describe('Renders different types of Editions elements', () => {
 		);
 	});
 
-	test('ElementKind.Audio', () => {
-		const nodes = renderEditions(audioElement);
-		const audio = nodes.flat()[0];
-		expect(getHtml(audio)).toContain(
-			'src="https://www.spotify.com/" sandbox="allow-scripts" height="300" width="500" title="Audio element"',
-		);
-	});
-
 	test('ElementKind.Video', () => {
 		const nodes = renderEditions(videoElement);
 		const video = nodes.flat()[0];

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -611,14 +611,6 @@ describe('Renders different types of Editions elements', () => {
 		testHandlers(timeline);
 	});
 
-	test('ElementKind.ChartAtom', () => {
-		const nodes = renderEditions(chartElement());
-		const chart = nodes.flat()[0];
-		expect(getHtml(chart)).toContain(
-			'srcDoc="&lt;main&gt;Chart content&lt;/main&gt;"',
-		);
-	});
-
 	function testHandlers(node: ReactNode): void {
 		if (isValidElement(node)) {
 			const container = document.createElement('div');

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -784,7 +784,7 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 			return h(Tweet, { content: element.content, format, key });
 
 		case ElementKind.Embed:
-			return h(EmbedComponent, { embed: element.embed });
+			return h(EmbedComponent, { embed: element.embed, editions: true });
 
 		case ElementKind.ExplainerAtom:
 			return h(ExplainerAtom, { ...element });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -810,9 +810,6 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 		case ElementKind.MediaAtom:
 			return mediaAtomRenderer(format, element);
 
-		case ElementKind.AudioAtom:
-			return audioAtomRenderer(format, element);
-
 		case ElementKind.KnowledgeQuizAtom:
 		case ElementKind.PersonalityQuizAtom:
 			return quizAtomRenderer(format, element);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -801,9 +801,6 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 		case ElementKind.TimelineAtom:
 			return timelineAtomRenderer(format, element);
 
-		case ElementKind.ChartAtom:
-			return h(ChartAtom, { ...element });
-
 		case ElementKind.InteractiveAtom:
 			return interactiveAtomRenderer(format, element);
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -783,11 +783,6 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 		case ElementKind.Tweet:
 			return h(Tweet, { content: element.content, format, key });
 
-		case ElementKind.Callout: {
-			const { campaign, description } = element;
-			return h(CalloutForm, { campaign, format, description });
-		}
-
 		case ElementKind.Embed:
 			return h(EmbedComponent, { embed: element.embed });
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -810,10 +810,6 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 		case ElementKind.MediaAtom:
 			return mediaAtomRenderer(format, element);
 
-		case ElementKind.KnowledgeQuizAtom:
-		case ElementKind.PersonalityQuizAtom:
-			return quizAtomRenderer(format, element);
-
 		default:
 			return null;
 	}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -722,7 +722,7 @@ const render = (format: Format, excludeStyles = false) => (
 		}
 
 		case ElementKind.Embed:
-			return h(EmbedComponent, { embed: element.embed });
+			return h(EmbedComponent, { embed: element.embed, editions: false });
 
 		case ElementKind.ExplainerAtom: {
 			return h(ExplainerAtom, { ...element });


### PR DESCRIPTION
## Why are you doing this?

Removing atoms and embeds as part of Editions embed fixes.

### Changes
- remove Editions audio atom
- remove Editions callout
- remove Editions quiz atom
- remove Editions Spotify embed
- remove Editions chart atom
