### PR TITLE
LIVE-2208: fix bridget client / server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13152,6 +13152,17 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "bluebird": {
@@ -13436,12 +13447,12 @@
       }
     },
     "buffer": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
-      "integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-crc32": {
@@ -14818,6 +14829,17 @@
       "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "requires": {
         "buffer": "^5.1.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "crc32-stream": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/webpack-node-externals": "^2.5.0",
     "aws-sdk": "^2.822.0",
     "babel-jest": "^26.6.2",
+    "buffer": "^6.0.3",
     "compression": "^1.7.4",
     "core-js": "^3.8.2",
     "create-emotion-server": "^10.0.27",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -54,6 +54,9 @@ function resolve(loggerName: string): ResolveOptions {
 			// `react-dom/server`, and for DCR to alias that to `preact-render-to-string`.
 			// Then we can get rid of this line.
 			'preact-render-to-string': 'react-dom/server',
+			// Webpack 5 removed a lot of the nodejs polyfills including Buffer
+			// We rely on Buffer for our thrift client/server
+			Buffer: 'buffer',
 		},
 	};
 }
@@ -152,7 +155,12 @@ export const clientConfig: Configuration = {
 		path: path.resolve(__dirname, 'dist/assets'),
 		filename: '[name].js',
 	},
-	plugins: [new WebpackManifestPlugin({ writeToFileEmit: true })],
+	plugins: [
+		new WebpackManifestPlugin({ writeToFileEmit: true }),
+		new webpack.ProvidePlugin({
+			Buffer: ['buffer', 'Buffer'],
+		}),
+	],
 	resolve: resolve('clientDev'),
 	devServer: {
 		publicPath: '/assets/',


### PR DESCRIPTION
## Why are you doing this?
We have introduced webpack 5 in https://github.com/guardian/apps-rendering/pull/1215 
Webpack 5 strips away any automatic nodejs polyfills, including Buffer (you can see the list of node libs for browser [here](https://github.com/webpack/node-libs-browser)). 
Bridget (and more technically Thrift) relies on Buffer, hence webpack 5 broke features like following authors or launching the lightbox. We need to manually polyfill node libs that we want now, so I'm introducing `feross/buffer` which is the same buffer polyfill webpack v4 was using.


## Changes

- add `buffer` as a dependency
- update webpack config with `resolve.alias` and the Provide plugin.
