### PR TITLE
LIVE-2132: use same frame-src script 

### DIFF
--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -137,7 +137,6 @@ function cspEditions(
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-	frame-src https://www.theguardian.com 
     frame-src https://www.theguardian.com https://embed.theguardian.com https://interactive.guim.co.uk ${
 		thirdPartyEmbed.youtube ? 'https://www.youtube-nocookie.com' : ''
 	} ${

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -137,16 +137,14 @@ function cspEditions(
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-	frame-src https://www.theguardian.com ${
-		thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''
-	};
+	frame-src https://www.theguardian.com 
     frame-src https://www.theguardian.com https://embed.theguardian.com https://interactive.guim.co.uk ${
 		thirdPartyEmbed.youtube ? 'https://www.youtube-nocookie.com' : ''
 	} ${
 		thirdPartyEmbed.twitter
 			? 'https://platform.twitter.com https://syndication.twitter.com https://twitter.com'
 			: ''
-	};
+	} ${thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''};
 	`;
 }
 


### PR DESCRIPTION
## Why are you doing this?

@JamieB-gu commented on a previously merged PR (https://github.com/guardian/apps-rendering/pull/1250) with a suggestion of using the same `frame-src` script rather than a new one, this PR implements that suggestion.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/114043130-ed082500-987d-11eb-96bc-3c9a2db1d6bf.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/114043181-f72a2380-987d-11eb-8544-d93c6cde6581.png" width="300px" /> |
