### PR TITLE
Add Wazuh Security Service

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -203,7 +203,9 @@ Resources:
               - Action: s3:GetObject
                 Effect: Allow
                 Resource: arn:aws:s3:::mobile-apps-api-dist/*
-              - Action: ec2:DescribeTags
+              - Action:
+                  - ec2:DescribeTags
+                  - ec2:DescribeInstances
                 Effect: Allow
                 Resource: '*'
               - Action:
@@ -289,6 +291,17 @@ Resources:
           ToPort: 3040
       VpcId: !ImportValue MobileAppsApiVPC-VpcId
 
+  WazuhSecurityGroup:
+      Type: AWS::EC2::SecurityGroup
+      Properties:
+          GroupDescription: Allow outbound traffic from wazuh agent to manager
+          VpcId: !ImportValue MobileAppsApiVPC-VpcId
+          SecurityGroupEgress:
+              - IpProtocol: tcp
+                FromPort: 1514
+                ToPort: 1515
+                CidrIp: 0.0.0.0/0
+
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
@@ -300,6 +313,7 @@ Resources:
         - !Ref InstanceSecurityGroup
         - Fn::ImportValue: !Sub SecurityGroups-${Stage}-MapiGuardianLondonSSH
         - !Ref DefaultVpcSecurityGroup
+        - !Ref WazuhSecurityGroup
       MetadataOptions:
           HttpTokens: required
       UserData:


### PR DESCRIPTION
## Why are you doing this?
Adds the Wazuh Security Group to our instances

 ## To test
Use this command to test the service is active and running:
```ssm cmd -c "service wazuh-agent status | grep Active && journalctl -u wazuh-agent | grep -E \"(Valid|error)\"" -t app,stage,stack -p <janus_profile>```

You should see something similar to:
```========= i-040399xxxxxxx =========
STDOUT:
   Active: active (running) since Tue 2021-02-09 12:16:06 UTC; 6 days ago
Feb 09 12:15:58 ip-10-248-48-90 authenticate-with-wazuh-manager.sh[1060]: 2021/02/09 12:15:58 agent-auth: INFO: Valid key created. Finished.

STDERR:

========= i-01fc71000xxxxxx =========
STDOUT:
   Active: active (running) since Mon 2021-02-15 11:20:29 UTC; 6h ago
Feb 15 11:20:21 ip-10-248-48-147 authenticate-with-wazuh-manager.sh[1068]: 2021/02/15 11:20:21 agent-auth: INFO: Valid key created. Finished.

STDERR:```