### PR TITLE
LIVE-2148: interactive atoms

### DIFF
--- a/src/components/embed.tsx
+++ b/src/components/embed.tsx
@@ -6,7 +6,6 @@ import Instagram from 'components/instagram';
 import Video from 'components/video';
 import { EmbedKind, youtubeUrl } from 'embed';
 import type { Embed } from 'embed';
-import React from 'react';
 import type { FC } from 'react';
 
 // ----- Component ----- //

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -120,13 +120,19 @@ const buildCsp = (
     media-src 'self' https://audio.guim.co.uk/
 `.trim();
 
-function cspEditions(
-	{ styles }: Assets,
+function buildCspEditions(
+	{ styles, scripts }: Assets,
 	thirdPartyEmbed: ThirdPartyEmbeds,
 ): string {
 	return `
 	default-src 'self';
-	style-src 'self' ${assetHashes(styles)};
+    style-src ${styleSrc(styles, thirdPartyEmbed.twitter, false)};
+	script-src 'self' ${assetHashes(scripts)}
+	https://interactive.guim.co.uk ${
+		thirdPartyEmbed.twitter
+			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
+			: ''
+	};
 	img-src 'self' https://static.theguardian.com https://*.guim.co.uk ${
 		thirdPartyEmbed.twitter
 			? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:'
@@ -137,13 +143,20 @@ function cspEditions(
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-    frame-src https://www.theguardian.com https://embed.theguardian.com https://interactive.guim.co.uk ${
-		thirdPartyEmbed.youtube ? 'https://www.youtube-nocookie.com' : ''
+	frame-src https://www.theguardian.com ${
+		thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''
+	} https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
+		thirdPartyEmbed.spotify ? 'https://open.spotify.com' : ''
 	} ${
+		thirdPartyEmbed.youtube ? 'https://www.youtube-nocookie.com' : ''
+	} https://player.vimeo.com/ ${
 		thirdPartyEmbed.twitter
 			? 'https://platform.twitter.com https://syndication.twitter.com https://twitter.com'
 			: ''
-	} ${thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''};
+	};
+	font-src 'self' https://interactive.guim.co.uk;
+	connect-src 'self' https://discussion.theguardian.com/discussion-api/ https://callouts.code.dev-guardianapis.com/formstack-campaign/submit https://interactive.guim.co.uk https://sf-hs-sg.ibytedtos.com/ https://gdn-cdn.s3.amazonaws.com/;
+	media-src 'self' https://audio.guim.co.uk/
 	`;
 }
 
@@ -152,6 +165,7 @@ function csp(
 	additionalAssets: Assets,
 	thirdPartyEmbed: ThirdPartyEmbeds,
 	hasInlineStyles: boolean,
+	isEditions: boolean,
 ): string {
 	const interactives = interactiveAssets(item);
 	const assets = {
@@ -159,9 +173,11 @@ function csp(
 		scripts: [...interactives.scripts, ...additionalAssets.scripts],
 	};
 
-	return buildCsp(assets, thirdPartyEmbed, hasInlineStyles);
+	return isEditions
+		? buildCspEditions(assets, thirdPartyEmbed)
+		: buildCsp(assets, thirdPartyEmbed, hasInlineStyles);
 }
 
 // ----- Exports ----- //
 
-export { assetHashes, csp, cspEditions };
+export { assetHashes, csp };

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -7,7 +7,7 @@ import type { EmotionCritical } from '@emotion/server/create-instance';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import type { Option } from '@guardian/types';
 import { map, none, some } from '@guardian/types';
-import { getThirdPartyEmbeds, requiresInlineStyles } from 'capi';
+import { getThirdPartyEmbeds } from 'capi';
 import type { ThirdPartyEmbeds } from 'capi';
 import { atomCss, atomScript } from 'components/atoms/interactiveAtom';
 import Article from 'components/editions/article';
@@ -70,12 +70,8 @@ function renderHead(
 
 	return `
         ${renderToString(meta)}
-        <link rel="stylesheet" type="text/css" href="/fontSize.css">
         <style>${generalStyles}</style>
         <style data-emotion-css="${emotionIds.join(' ')}">${itemStyles}</style>
-        <script id="targeting-params" type="application/json">
-            ${JSON.stringify(request.targetingParams)}
-        </script>
     `;
 }
 
@@ -115,7 +111,6 @@ function render(
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
 	const body = renderBody(item);
 	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
-	const inlineStyles = requiresInlineStyles(request.content);
 
 	const head = renderHead(
 		item,
@@ -123,7 +118,7 @@ function render(
 		thirdPartyEmbeds,
 		body.css,
 		body.ids,
-		inlineStyles,
+		false,
 	);
 
 	const clientScript = map(getAssetLocation)(some('editions.js'));

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -7,17 +7,20 @@ import type { EmotionCritical } from '@emotion/server/create-instance';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import type { Option } from '@guardian/types';
 import { map, none, some } from '@guardian/types';
-import { getThirdPartyEmbeds } from 'capi';
+import { getThirdPartyEmbeds, requiresInlineStyles } from 'capi';
 import type { ThirdPartyEmbeds } from 'capi';
+import { atomCss, atomScript } from 'components/atoms/interactiveAtom';
 import Article from 'components/editions/article';
+import Meta from 'components/meta';
 import Scripts from 'components/scripts';
 import type { Item } from 'item';
 import { fromCapi } from 'item';
 import { JSDOM } from 'jsdom';
 import { compose } from 'lib';
 import type { ReactElement } from 'react';
+import { createElement as h } from 'react';
 import { renderToString } from 'react-dom/server';
-import { cspEditions } from 'server/csp';
+import { csp } from 'server/csp';
 import { pageFonts } from 'styles';
 
 // ----- Types ----- //
@@ -34,37 +37,47 @@ const docParser = JSDOM.fragment.bind(null);
 // ----- Functions ----- //
 
 const styles = `
-    ${pageFonts}
+	${pageFonts}
+
 	html {
-		height: 100%;
-	}
-    body {
 		margin: 0;
 		height: 100%;
 		min-height: 100%;
-    }
+	}
 `;
 
-const renderHead = (
+function renderHead(
+	item: Item,
 	request: RenderingRequest,
 	thirdPartyEmbeds: ThirdPartyEmbeds,
 	itemStyles: string,
 	emotionIds: string[],
-): string => {
-	const cspString = cspEditions(
-		{ scripts: [], styles: [styles, itemStyles] },
+	inlineStyles: boolean,
+): string {
+	const generalStyles = styles;
+	const isEditions = true;
+	const cspString = csp(
+		item,
+		{
+			scripts: [atomScript],
+			styles: [generalStyles, itemStyles, atomCss],
+		},
 		thirdPartyEmbeds,
+		inlineStyles,
+		isEditions,
 	);
+	const meta = h(Meta, { title: request.content.webTitle, cspString });
 
 	return `
-		<meta charSet="utf-8" />
-		<title>${request.content.webTitle}</title>
-		<meta name="viewport" content="initial-scale=1" />
-		<meta http-equiv="Content-Security-Policy" content="${cspString}" />
-        <style>${styles}</style>
+        ${renderToString(meta)}
+        <link rel="stylesheet" type="text/css" href="/fontSize.css">
+        <style>${generalStyles}</style>
         <style data-emotion-css="${emotionIds.join(' ')}">${itemStyles}</style>
+        <script id="targeting-params" type="application/json">
+            ${JSON.stringify(request.targetingParams)}
+        </script>
     `;
-};
+}
 
 const renderBody = (item: Item): EmotionCritical =>
 	compose(
@@ -102,7 +115,16 @@ function render(
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
 	const body = renderBody(item);
 	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
-	const head = renderHead(request, thirdPartyEmbeds, body.css, body.ids);
+	const inlineStyles = requiresInlineStyles(request.content);
+
+	const head = renderHead(
+		item,
+		request,
+		thirdPartyEmbeds,
+		body.css,
+		body.ids,
+		inlineStyles,
+	);
 
 	const clientScript = map(getAssetLocation)(some('editions.js'));
 

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -100,6 +100,7 @@ function renderHead(
 	inlineStyles: boolean,
 ): string {
 	const generalStyles = styles(item);
+	const isEditions = false;
 	const cspString = csp(
 		item,
 		{
@@ -108,6 +109,7 @@ function renderHead(
 		},
 		thirdPartyEmbeds,
 		inlineStyles,
+		isEditions,
 	);
 	const meta = h(Meta, { title: request.content.webTitle, cspString });
 


### PR DESCRIPTION
## Why are you doing this?

We're looking to include additional atoms and embeds in Editions where possible. This PR brings together the AR and ER approaches to CSP and allows us to render `interactive` atoms.

See this article for an example:
http://localhost:8080/world/2020/jun/10/uk-coronavirus-lockdown-20000-lives-boris-johnson-neil-ferguson?editions


## Changes

- Use `meta` component for Editions header
- share `csp` component between editions and AR
- add additional fields (rules?) to csp functions 

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/114376267-6012e380-9b7d-11eb-8c8c-82c2869d57e8.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/114376318-6c973c00-9b7d-11eb-9325-dae406519d71.png" width="300px" /> | 
