### PR TITLE
Bump `node-riffraff-artifact` To 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,15 +2637,14 @@
       "from": "github:guardian/image-rendering#1167f8bc"
     },
     "@guardian/node-riffraff-artifact": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@guardian/node-riffraff-artifact/-/node-riffraff-artifact-0.1.9.tgz",
-      "integrity": "sha512-rMZyyI8jFHoH3pNgysytw0vyg5vYOv46m7jvdion7gRe2dKNOnVJHK4zTfweD1DnydTk5NP9czYCu4Ruqj4pig==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@guardian/node-riffraff-artifact/-/node-riffraff-artifact-0.2.0.tgz",
+      "integrity": "sha512-ZxrmKrhnm69X5MFhfOlv2id1fyPybLIfCSkmcnRpeWDQlSh6iVRTqiO45ilDsQXSk1rS/FyizlRMZVQ9XbKzyg==",
       "requires": {
         "@mojotech/json-type-validation": "^3.1.0",
         "@types/temp": "^0.8.34",
         "archiver": "^3.1.1",
         "aws-sdk": "^2.610.0",
-        "mock-aws-s3": "^3.0.0",
         "ora": "^4.0.3",
         "temp": "^0.9.1",
         "yaml": "^1.7.2",
@@ -13138,9 +13137,9 @@
       }
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -13161,7 +13160,8 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "bn.js": {
       "version": "5.2.0",
@@ -14050,9 +14050,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
-      "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q=="
     },
     "cli-table3": {
       "version": "0.6.0",
@@ -17652,17 +17652,6 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
-    "fs-extra": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.6.4.tgz",
-      "integrity": "sha1-9G8MdbeEH40gCzNIzU1pHVoJnRU=",
-      "requires": {
-        "jsonfile": "~1.0.1",
-        "mkdirp": "0.3.x",
-        "ncp": "~0.4.2",
-        "rimraf": "~2.2.0"
-      }
-    },
     "fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -20991,11 +20980,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "jsonfile": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.0.1.tgz",
-      "integrity": "sha1-6l7+QLg2kLmGZ2FKc5L8YOhCwN0="
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -22218,18 +22202,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-    },
-    "mock-aws-s3": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mock-aws-s3/-/mock-aws-s3-3.0.0.tgz",
-      "integrity": "sha512-mvDwXrMvxghpXwntztuVGpdEt671DvRYWjJ9fojsKuFB8w782CzNNmp45mXmY8noimpopKWsrKXUZzOq3MZVEA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "bluebird": "^3.5.1",
-        "fs-extra": "0.6.4",
-        "underscore": "1.8.3"
+        "minimist": "^1.2.5"
       }
     },
     "moment": {
@@ -22352,11 +22329,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "ncp": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
     },
     "negotiator": {
       "version": "0.6.2",
@@ -25630,7 +25602,8 @@
     "rimraf": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
     },
     "ripemd160": {
       "version": "2.0.2",
@@ -27320,9 +27293,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -27393,22 +27366,14 @@
       }
     },
     "temp": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.2.tgz",
-      "integrity": "sha512-KLVd6CXeUYsqmI/LBWDLg3bFkdZPg0Xr/Gn79GUuPNiISzp6v/EKUaCOrxqeH1w/wVNmrljyDRgKxhZV9JzyJA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "requires": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -28013,11 +27978,6 @@
           "dev": true
         }
       }
-    },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unfetch": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^4.6.1",
     "@guardian/image-rendering": "github:guardian/image-rendering#1167f8bc",
-    "@guardian/node-riffraff-artifact": "^0.1.9",
+    "@guardian/node-riffraff-artifact": "^0.2.0",
     "@guardian/renditions": "git+https://github.com/guardian/renditions.git#0.1.1",
     "@guardian/src-brand": "^3.3.0",
     "@guardian/src-button": "^3.3.0",


### PR DESCRIPTION
## Why are you doing this?

Picks up changes from https://github.com/guardian/node-riffraff-artifact/pull/24.

@AWare in theory there should be no impact on the consumer, it's just internal changes to the tests?

## Changes

- Bumped `node-riffraff-artifact` to 0.2.0
