### PR TITLE
LIVE-2135: remove check for timeline events

### DIFF
--- a/src/atoms.test.ts
+++ b/src/atoms.test.ts
@@ -529,7 +529,7 @@ describe('parseAtom', () => {
 
 		it(`returns an error if no timeline title or body`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No title or body for atom: ${atomId}`),
+				err(`No title for atom: ${atomId}`),
 			);
 		});
 

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -176,6 +176,7 @@ function parseAtom(
 			}
 
 			const { title } = atom;
+
 			const events: TimelineEvent[] = atom.data.timeline.events.map(
 				(event) => ({
 					title: event.title,
@@ -188,8 +189,8 @@ function parseAtom(
 
 			const description = atom.data.timeline.description;
 
-			if (!title || events.length === 0) {
-				return err(`No title or body for atom: ${id}`);
+			if (!title) {
+				return err(`No title for atom: ${id}`);
 			}
 
 			if (events.some((event) => event.date === '')) {


### PR DESCRIPTION
## Why are you doing this?

Timeline atoms weren't rendering in either Editions Rendering or Apps Rendering. 

This PR removes the check for timeline `events` that blocked the atom from rendering **when a user had inputted all data as a description**  - this seems to be the standard way timeline atoms are used.

https://www.theguardian.com/world/2018/jun/18/yemen-crisis-saudi-coalition-demands-houthis-unconditional-withdrawal-from-port

## Changes

- Remove check for timeline events

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/114437391-66757f80-9bbe-11eb-8fe7-6a23ac06e025.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/114437286-404fdf80-9bbe-11eb-8ed4-7ab09704041d.png" width="300px" /> |
