### PR TITLE
Webpack 5 —  The Sequel 🕸📦

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -257,9 +257,13 @@ const clientConfigProduction = {
 				styles: assetsTemplateCss,
 			},
 		}),
+		new webpack.ProvidePlugin({
+			Buffer: ['buffer', 'Buffer'],
+		}),
 	],
 	output: {
 		path: path.resolve(__dirname, 'dist/assets'),
+		publicPath: '',
 		filename: '[name].[contenthash].js',
 	},
 	resolve: clientResolveProd,


### PR DESCRIPTION
## Why are you doing this?

Bridget calls were not working (lightbox, follow etc...) because of Webpack 5 stopped polyfilling some libs like Buffer (https://github.com/guardian/apps-rendering/pull/1249)

That problem was fixed in the mentioned PR, however the prod configuration wasn't providing the Buffer alias, so I've updated it, thinking I hit the jackpot with that one.. alas no .. it turned out eventually that none of our JS was running because webpack 5 was prefixing our asset location with "auto" (a bug that took me hours to get to 😑). If you look at any current AR article in prod you'll see that in the html at the bottom the script tag looks something like this:
```html
<script src="/assets/autoarticle.39866c4a7d757b6f43ac.js"></script>
```
Adding the `publicPath: ''` to the webpack config solves it .. what a world, eh?

![bugs-never-end](https://user-images.githubusercontent.com/12860328/114438227-62962d00-9bbf-11eb-9629-b7beee170703.gif)

