### PR TITLE
LIVE-2179: Send targeting params on init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,9 +2564,9 @@
       }
     },
     "@guardian/bridget": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-1.8.0.tgz",
-      "integrity": "sha512-NUaaFIZq8OP7ghmbvDsR58nABcu44x8xOZPalUHcTTUMeGQrqFRNEK2i8eJ218C6c8iyq6QjAUdApsrN36r6aQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-1.9.0.tgz",
+      "integrity": "sha512-pKbJxsaUpaFsL11e7VnzwhI39lVUU5WFyzpi+gNKY+UytZfzfCqyU6X1CODmV+YoBsmfrKlVHhmRMFPNUKQc0Q=="
     },
     "@guardian/content-api-models": {
       "version": "15.10.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@emotion/server": "^11.0.0",
     "@guardian/apps-rendering-api-models": "^0.11.2",
     "@guardian/atoms-rendering": "^12.2.0",
-    "@guardian/bridget": "^1.8.0",
+    "@guardian/bridget": "^1.9.0",
     "@guardian/content-api-models": "^15.10.0",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^4.6.1",

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -14,6 +14,7 @@ import {
 	reportNativeElementPositionChanges,
 	slideshow,
 	videos,
+	sendTargetingParams,
 } from 'client/nativeCommunication';
 import setup from 'client/setup';
 import FooterContent from 'components/footerContent';
@@ -451,6 +452,7 @@ function richLinks(): void {
 }
 
 setup();
+sendTargetingParams();
 ads();
 videos();
 reportNativeElementPositionChanges();

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -12,9 +12,9 @@ import { App } from '@guardian/discussion-rendering/build/App';
 import {
 	ads,
 	reportNativeElementPositionChanges,
+	sendTargetingParams,
 	slideshow,
 	videos,
-	sendTargetingParams,
 } from 'client/nativeCommunication';
 import setup from 'client/setup';
 import FooterContent from 'components/footerContent';

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -8,11 +8,11 @@ import { errorToString, isObject, memoise } from 'lib';
 import { logger } from 'logger';
 import {
 	acquisitionsClient,
+	analyticsClient,
 	commercialClient,
 	galleryClient,
 	userClient,
 	videoClient,
-	analyticsClient,
 } from '../native/nativeApi';
 
 type Slot = AdSlot | VideoSlot;
@@ -267,7 +267,7 @@ function reportNativeElementPositionChanges(): void {
 
 function sendTargetingParams(): void {
 	const targetingParams = getTargetingParams();
-	analyticsClient.sendTargetingParams(targetingParams);
+	void analyticsClient.sendTargetingParams(targetingParams);
 }
 
 export {

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -12,6 +12,7 @@ import {
 	galleryClient,
 	userClient,
 	videoClient,
+	analyticsClient,
 } from '../native/nativeApi';
 
 type Slot = AdSlot | VideoSlot;
@@ -264,4 +265,15 @@ function reportNativeElementPositionChanges(): void {
 	}
 }
 
-export { ads, slideshow, videos, reportNativeElementPositionChanges };
+function sendTargetingParams(): void {
+	const targetingParams = getTargetingParams();
+	analyticsClient.sendTargetingParams(targetingParams);
+}
+
+export {
+	ads,
+	slideshow,
+	videos,
+	reportNativeElementPositionChanges,
+	sendTargetingParams,
+};

--- a/src/native/nativeApi.ts
+++ b/src/native/nativeApi.ts
@@ -1,4 +1,5 @@
 import * as Acquisitions from '@guardian/bridget/Acquisitions';
+import * as Analytics from '@guardian/bridget/Analytics';
 import * as Commercial from '@guardian/bridget/Commercial';
 import * as Discussion from '@guardian/bridget/Discussion';
 import * as Environment from '@guardian/bridget/Environment';
@@ -7,7 +8,6 @@ import * as Metrics from '@guardian/bridget/Metrics';
 import * as Notifications from '@guardian/bridget/Notifications';
 import * as User from '@guardian/bridget/User';
 import * as Video from '@guardian/bridget/Videos';
-import * as Analytics from '@guardian/bridget/Analytics';
 import { createAppClient } from './thrift/nativeConnection';
 
 const environmentClient: Environment.Client<void> = createAppClient<

--- a/src/native/nativeApi.ts
+++ b/src/native/nativeApi.ts
@@ -7,6 +7,7 @@ import * as Metrics from '@guardian/bridget/Metrics';
 import * as Notifications from '@guardian/bridget/Notifications';
 import * as User from '@guardian/bridget/User';
 import * as Video from '@guardian/bridget/Videos';
+import * as Analytics from '@guardian/bridget/Analytics';
 import { createAppClient } from './thrift/nativeConnection';
 
 const environmentClient: Environment.Client<void> = createAppClient<
@@ -41,6 +42,10 @@ const discussionClient: Discussion.Client<void> = createAppClient<
 	Discussion.Client<void>
 >(Discussion.Client, 'buffered', 'compact');
 
+const analyticsClient: Analytics.Client<void> = createAppClient<
+	Analytics.Client<void>
+>(Analytics.Client, 'buffered', 'compact');
+
 export {
 	environmentClient,
 	commercialClient,
@@ -51,4 +56,5 @@ export {
 	videoClient,
 	metricsClient,
 	discussionClient,
+	analyticsClient,
 };


### PR DESCRIPTION
## Why are you doing this?

We need to send targeting params to the native apps on init. 
Bridget was updated to 1.9.0 to use the new service (https://github.com/guardian/bridget/pull/72)



## Changes

- Bump to Bridget 1.9.0
- Create the analytics Bridget client
- Use the client to send targeting params on init

