### PR TITLE
LIVE-2183: Bridget footer links 🦶🔗

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,9 +2564,9 @@
       }
     },
     "@guardian/bridget": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-1.9.0.tgz",
-      "integrity": "sha512-pKbJxsaUpaFsL11e7VnzwhI39lVUU5WFyzpi+gNKY+UytZfzfCqyU6X1CODmV+YoBsmfrKlVHhmRMFPNUKQc0Q=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-1.10.0.tgz",
+      "integrity": "sha512-O+FRXyw8kC4OGRQqar+D/4/B+FGI20Xt5T6IaRq7KFPhCqqqu6fjvI70zQimfzPJixtvPcqpVPXd3wviSasmBg=="
     },
     "@guardian/content-api-models": {
       "version": "15.10.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@emotion/server": "^11.0.0",
     "@guardian/apps-rendering-api-models": "^0.11.2",
     "@guardian/atoms-rendering": "^12.2.0",
-    "@guardian/bridget": "^1.9.0",
+    "@guardian/bridget": "^1.10.0",
     "@guardian/content-api-models": "^15.10.0",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^4.6.1",

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -15150,14 +15150,14 @@ exports[`Storyshots Footer Default 1`] = `
     <br />
     <a
       href="https://www.theguardian.com/help/privacy-settings"
-      id="ar-privacy-settings"
+      id="js-privacy-settings"
     >
       Privacy Settings
     </a>
      · 
     <a
       href="https://www.theguardian.com/help/privacy-policy"
-      id="ar-privacy-policy"
+      id="js-privacy-policy"
     >
       Privacy Policy
     </a>
@@ -15217,14 +15217,14 @@ exports[`Storyshots Footer With Ccpa 1`] = `
     <br />
     <a
       href="https://www.theguardian.com/help/privacy-policy"
-      id="ar-privacy-settings"
+      id="js-privacy-settings"
     >
       California Residents - Do Not Sell
     </a>
      · 
     <a
       href="https://www.theguardian.com/help/privacy-policy"
-      id="ar-privacy-policy"
+      id="js-privacy-policy"
     >
       Privacy Policy
     </a>

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -15150,12 +15150,14 @@ exports[`Storyshots Footer Default 1`] = `
     <br />
     <a
       href="https://www.theguardian.com/help/privacy-settings"
+      id="ar-privacy-settings"
     >
       Privacy Settings
     </a>
      · 
     <a
       href="https://www.theguardian.com/help/privacy-policy"
+      id="ar-privacy-policy"
     >
       Privacy Policy
     </a>
@@ -15215,12 +15217,14 @@ exports[`Storyshots Footer With Ccpa 1`] = `
     <br />
     <a
       href="https://www.theguardian.com/help/privacy-policy"
+      id="ar-privacy-settings"
     >
       California Residents - Do Not Sell
     </a>
      · 
     <a
       href="https://www.theguardian.com/help/privacy-policy"
+      id="ar-privacy-policy"
     >
       Privacy Policy
     </a>

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -217,8 +217,8 @@ function renderComments(): void {
 }
 
 function footerLinks(): void {
-	const privacySettingsLink = document.getElementById('ar-privacy-settings');
-	const privacyPolicyLink = document.getElementById('ar-privacy-policy');
+	const privacySettingsLink = document.getElementById('js-privacy-settings');
+	const privacyPolicyLink = document.getElementById('js-privacy-policy');
 
 	privacyPolicyLink?.addEventListener('click', (e) => {
 		e.preventDefault();

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -232,8 +232,6 @@ function footerLinks(): void {
 }
 
 function footerInit(): void {
-	footerLinks();
-
 	userClient
 		.doesCcpaApply()
 		.then((isCcpa) => {

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -24,6 +24,7 @@ import { handleErrors, isObject } from 'lib';
 import {
 	acquisitionsClient,
 	discussionClient,
+	navigationClient,
 	notificationsClient,
 	userClient,
 } from 'native/nativeApi';
@@ -215,12 +216,30 @@ function renderComments(): void {
 	}
 }
 
+function footerLinks(): void {
+	const privacySettingsLink = document.getElementById('ar-privacy-settings');
+	const privacyPolicyLink = document.getElementById('ar-privacy-policy');
+
+	privacyPolicyLink?.addEventListener('click', (e) => {
+		e.preventDefault();
+		void navigationClient.openPrivacyPolicy();
+	});
+
+	privacySettingsLink?.addEventListener('click', (e) => {
+		e.preventDefault();
+		void navigationClient.openPrivacySettings();
+	});
+}
+
 function footerInit(): void {
+	footerLinks();
+
 	userClient
 		.doesCcpaApply()
 		.then((isCcpa) => {
 			const comp = h(FooterContent, { isCcpa });
 			ReactDOM.render(comp, document.getElementById('js-footer'));
+			footerLinks();
 		})
 		.catch((error) => {
 			logger.error(error);

--- a/src/components/footerContent.tsx
+++ b/src/components/footerContent.tsx
@@ -8,7 +8,10 @@ const PrivacySettings: FC<{ isCcpa: boolean }> = ({ isCcpa }) => {
 	if (isCcpa) {
 		return (
 			<>
-				<a href="https://www.theguardian.com/help/privacy-policy">
+				<a
+					id="ar-privacy-settings"
+					href="https://www.theguardian.com/help/privacy-policy"
+				>
 					California Residents - Do Not Sell
 				</a>
 				&nbsp;&#183;&nbsp;
@@ -17,7 +20,10 @@ const PrivacySettings: FC<{ isCcpa: boolean }> = ({ isCcpa }) => {
 	} else {
 		return (
 			<>
-				<a href="https://www.theguardian.com/help/privacy-settings">
+				<a
+					id="ar-privacy-settings"
+					href="https://www.theguardian.com/help/privacy-settings"
+				>
 					Privacy Settings
 				</a>
 				&nbsp;&#183;&nbsp;
@@ -41,7 +47,10 @@ const FooterContent: FC<Props> = ({ isCcpa }) => {
 			affiliated companies. All rights reserved.
 			<br />
 			<PrivacySettings isCcpa={isCcpa} />
-			<a href="https://www.theguardian.com/help/privacy-policy">
+			<a
+				id="ar-privacy-policy"
+				href="https://www.theguardian.com/help/privacy-policy"
+			>
 				Privacy Policy
 			</a>
 		</div>

--- a/src/components/footerContent.tsx
+++ b/src/components/footerContent.tsx
@@ -9,7 +9,7 @@ const PrivacySettings: FC<{ isCcpa: boolean }> = ({ isCcpa }) => {
 		return (
 			<>
 				<a
-					id="ar-privacy-settings"
+					id="js-privacy-settings"
 					href="https://www.theguardian.com/help/privacy-policy"
 				>
 					California Residents - Do Not Sell
@@ -21,7 +21,7 @@ const PrivacySettings: FC<{ isCcpa: boolean }> = ({ isCcpa }) => {
 		return (
 			<>
 				<a
-					id="ar-privacy-settings"
+					id="js-privacy-settings"
 					href="https://www.theguardian.com/help/privacy-settings"
 				>
 					Privacy Settings
@@ -48,7 +48,7 @@ const FooterContent: FC<Props> = ({ isCcpa }) => {
 			<br />
 			<PrivacySettings isCcpa={isCcpa} />
 			<a
-				id="ar-privacy-policy"
+				id="js-privacy-policy"
 				href="https://www.theguardian.com/help/privacy-policy"
 			>
 				Privacy Policy

--- a/src/native/nativeApi.ts
+++ b/src/native/nativeApi.ts
@@ -5,6 +5,7 @@ import * as Discussion from '@guardian/bridget/Discussion';
 import * as Environment from '@guardian/bridget/Environment';
 import * as Gallery from '@guardian/bridget/Gallery';
 import * as Metrics from '@guardian/bridget/Metrics';
+import * as Navigation from '@guardian/bridget/Navigation';
 import * as Notifications from '@guardian/bridget/Notifications';
 import * as User from '@guardian/bridget/User';
 import * as Video from '@guardian/bridget/Videos';
@@ -46,6 +47,10 @@ const analyticsClient: Analytics.Client<void> = createAppClient<
 	Analytics.Client<void>
 >(Analytics.Client, 'buffered', 'compact');
 
+const navigationClient: Navigation.Client<void> = createAppClient<
+	Navigation.Client<void>
+>(Navigation.Client, 'buffered', 'compact');
+
 export {
 	environmentClient,
 	commercialClient,
@@ -57,4 +62,5 @@ export {
 	metricsClient,
 	discussionClient,
 	analyticsClient,
+	navigationClient,
 };


### PR DESCRIPTION
## Why are you doing this?


At present the 'privacy settings' and 'privacy policy' in the article footers are links. We would like these to call Bridget functions, which the native layer can then use to open the appropriate settings section.
[JIRA ticket](https://theguardian.atlassian.net/browse/LIVE-2183)

## Changes
- create the Navigation bridget client
- add dom element ids to the footer link
- trigger bridget calls on link click
- Bump Bridget to `1.10.0` from https://github.com/guardian/bridget/pull/73 


iOS PR https://github.com/guardian/ios-live/pull/5660