### PR TITLE
Live 2132 remove instagram embed er

### DIFF
--- a/src/components/embed.tsx
+++ b/src/components/embed.tsx
@@ -40,7 +40,9 @@ const EmbedComponent: FC<Props> = ({ embed, editions }) => {
 			);
 
 		case EmbedKind.Instagram:
-			return <Instagram id={embed.id} caption={embed.caption} />;
+			return !editions ? (
+				<Instagram id={embed.id} caption={embed.caption} />
+			) : null;
 
 		case EmbedKind.Generic:
 			return <GenericEmbed embed={embed} />;

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -527,14 +527,6 @@ describe('Renders different types of Editions elements', () => {
 		expect(getHtml(tweet)).toContain('twitter-tweet');
 	});
 
-	test('ElementKind.Instagram', () => {
-		const nodes = renderEditions(instagramElement());
-		const instagram = nodes.flat()[0];
-		expect(getHtml(instagram)).toBe(
-			'<iframe src="https://www.instagram.com/p/embedId/embed" height="830" title="&lt;blockquote&gt;Instagram&lt;/blockquote&gt;"></iframe>',
-		);
-	});
-
 	test('ElementKind.Embed', () => {
 		const nodes = renderEditions(embedElement);
 		const embed = nodes.flat()[0];

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -143,9 +143,7 @@ function buildCspEditions(
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-	frame-src https://www.theguardian.com ${
-		thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''
-	} https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
+	frame-src https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
 		thirdPartyEmbed.spotify ? 'https://open.spotify.com' : ''
 	} ${
 		thirdPartyEmbed.youtube ? 'https://www.youtube-nocookie.com' : ''

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -143,7 +143,7 @@ function buildCspEditions(
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-	frame-src https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
+	frame-src https://www.theguardian.com https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
 		thirdPartyEmbed.spotify ? 'https://open.spotify.com' : ''
 	} ${
 		thirdPartyEmbed.youtube ? 'https://www.youtube-nocookie.com' : ''


### PR DESCRIPTION
## Why are you doing this?

Editions have decided not to render Instagram embeds in articles.