### PR TITLE
Restrict Support To iOS 13 Or Later

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/server.ts",
   "browserslist": [
     "android >= 5",
-    "ios >= 11"
+    "ios >= 13"
   ],
   "scripts": {
     "postinstall": "is-ci || husky install",


### PR DESCRIPTION
## Why are you doing this?

The iOS App only supports iOS 13 or later, so it's not worth targeting anything lower than that in our builds. The [`browserslist`](https://github.com/browserslist/browserslist) is used to inform our build tools which browsers we support.

### Questions

- What does this mean for Editions?

## Changes

- Set `browserslist` to iOS 13 and above
