### PR TITLE
LIVE-2348: Prefix related item link with theguardian.com

### DIFF
--- a/src/relatedContent.test.ts
+++ b/src/relatedContent.test.ts
@@ -54,7 +54,7 @@ describe('parseRelatedContent', () => {
 					title: 'contentTitle',
 					lastModified: undefined,
 					headerImage: undefined,
-					link: '/contentId',
+					link: 'https://theguardian.com/contentId',
 					type: RelatedItemType.ARTICLE,
 					pillar: {
 						id: 'somePillarId',
@@ -112,10 +112,10 @@ describe('parseRelatedContent', () => {
 		]);
 
 		expect(actual.relatedItems.length).toBe(4);
-		expect(actual.relatedItems[0].link).toBe('/id1');
-		expect(actual.relatedItems[1].link).toBe('/id2');
-		expect(actual.relatedItems[2].link).toBe('/id3');
-		expect(actual.relatedItems[3].link).toBe('/id4');
+		expect(actual.relatedItems[0].link).toBe('https://theguardian.com/id1');
+		expect(actual.relatedItems[1].link).toBe('https://theguardian.com/id2');
+		expect(actual.relatedItems[2].link).toBe('https://theguardian.com/id3');
+		expect(actual.relatedItems[3].link).toBe('https://theguardian.com/id4');
 	});
 });
 

--- a/src/relatedContent.ts
+++ b/src/relatedContent.ts
@@ -77,7 +77,7 @@ const parseRelatedContent = (relatedContent: Content[]): RelatedContent => {
 					title: content.webTitle,
 					lastModified: content.fields?.lastModified,
 					headerImage: parseHeaderImage(content),
-					link: `/${content.id}`,
+					link: `https://theguardian.com/${content.id}`,
 					type: parseRelatedItemType(content),
 					pillar: {
 						id: content.pillarId ?? 'pillar/news',


### PR DESCRIPTION
## Why are you doing this?

We want the related content items in SSR articles to open in a native view, since there's already a built-in guardian link parser that will open the item in a native view controller, we can use this as we go into prod. in the future we will need to do something about it (Bridget probably), as this means all related items in an SSR article will open up in the legacy templates.

| before | after |
| -- | -- |
| ![2021-04-26 15 17 42](https://user-images.githubusercontent.com/12860328/116098539-14932600-a6a3-11eb-9e18-48ae4e3adcb7.gif) | ![2021-04-26 15 20 55](https://user-images.githubusercontent.com/12860328/116098619-207ee800-a6a3-11eb-9372-e82eabb3919d.gif) |

