### PR TITLE
LIVE-2138: add conditional

### DIFF
--- a/src/components/editions/avatar/index.tsx
+++ b/src/components/editions/avatar/index.tsx
@@ -29,6 +29,10 @@ const Avatar: FC<Props> = ({ item }) => {
 	const [contributor] = item.contributors;
 	const format = getFormat(item);
 
+	if (!contributor) {
+		return null;
+	}
+
 	return pipe2(
 		contributor.image,
 		map((image) => (

--- a/src/components/editions/avatar/index.tsx
+++ b/src/components/editions/avatar/index.tsx
@@ -29,10 +29,6 @@ const Avatar: FC<Props> = ({ item }) => {
 	const [contributor] = item.contributors;
 	const format = getFormat(item);
 
-	if (!contributor) {
-		return null;
-	}
-
 	return pipe2(
 		contributor.image,
 		map((image) => (

--- a/src/components/editions/byline/index.tsx
+++ b/src/components/editions/byline/index.tsx
@@ -222,8 +222,9 @@ const renderText = (byline: DocumentFragment, format: Format): ReactNode =>
 const hasShareIcon = (format: Format): boolean =>
 	!(format.design === Design.Analysis || format.design === Design.Comment);
 
-const hasAvatar = (format: Format): boolean => format.design === Design.Comment;
-
+const hasAvatar = (item: Item): boolean => {
+	return item.design === Design.Comment && item.contributors.length > 0;
+};
 const ignoreKickerColour = (format: Format): boolean =>
 	format.design === Design.Media || format.display === Display.Immersive;
 
@@ -241,7 +242,7 @@ const Byline: FC<Props> = ({ item }) => {
 					<ShareIcon />
 				</span>
 			)}
-			{hasAvatar(format) && (
+			{hasAvatar(item) && (
 				<div css={avatarWrapperStyles}>
 					<EditionsAvatar item={item} />
 				</div>


### PR DESCRIPTION
## Why are you doing this?

Sometimes comment pieces are missing a `contributor` which causes the template not to load, this PR adds a conditional to check for this.


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/116425810-7afe7c80-a83a-11eb-9228-758192caab65.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/116426195-cf096100-a83a-11eb-90ec-389092953fa4.png" width="300px" /> |
