### PR TITLE
LIVE-2138: add recipe article type to Editions as standard template

### DIFF
--- a/src/components/editions/article/index.tsx
+++ b/src/components/editions/article/index.tsx
@@ -131,7 +131,8 @@ const Article: FC<Props> = ({ item }) => {
 		item.design === Design.Media ||
 		item.design === Design.Editorial ||
 		item.design === Design.Letter ||
-		item.design === Design.Quiz
+		item.design === Design.Quiz ||
+		item.design === Design.Recipe
 	) {
 		return (
 			<main css={mainStyles}>


### PR DESCRIPTION
## Why are you doing this?

Recipe article types were being used by production but not included in Editions Rendering. This PR adds `Design.Recipe` to the list of rendered articles to fix that.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/116437580-7e4b3580-a845-11eb-997c-01bc98b63a83.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/116437627-8b682480-a845-11eb-9a86-59db42d99547.png" width="300px" /> |
