### PR TITLE
Live 2351 football scores

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -361,7 +361,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 @media (min-width: 740px) {
   .emotion-6 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 
@@ -1574,7 +1574,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 @media (min-width: 740px) {
   .emotion-6 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 
@@ -2854,7 +2854,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
 @media (min-width: 740px) {
   .emotion-6 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 
@@ -4015,7 +4015,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 @media (min-width: 740px) {
   .emotion-6 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 
@@ -5199,7 +5199,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 @media (min-width: 740px) {
   .emotion-6 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 
@@ -8444,7 +8444,7 @@ exports[`Storyshots Editions/Article Letter 1`] = `
 @media (min-width: 740px) {
   .emotion-5 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 
@@ -9565,7 +9565,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
 @media (min-width: 740px) {
   .emotion-6 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 
@@ -10871,7 +10871,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 @media (min-width: 740px) {
   .emotion-8 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 
@@ -13031,7 +13031,7 @@ exports[`Storyshots Editions/HeaderMedia Image 1`] = `
 @media (min-width: 740px) {
   .emotion-1 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 
@@ -13235,7 +13235,7 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
 @media (min-width: 740px) {
   .emotion-1 {
     width: calc(100vw - 3.75rem);
-    height: calc((100vw - 3.75rem) * height / width);
+    height: calc((100vw - 3.75rem) * 0.6);
   }
 }
 

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -15734,24 +15734,6 @@ exports[`Storyshots FootballScores Default 1`] = `
 }
 
 .emotion-13 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  font-weight: 400;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  grid-column: 2;
-  grid-row: 2;
-}
-
-@media (min-width: 660px) {
-  .emotion-13 {
-    grid-column: 1;
-  }
-}
-
-.emotion-14 {
   display: grid;
   grid-template-columns: auto 1fr;
   border-top: 1px dotted #000000;
@@ -15761,7 +15743,7 @@ exports[`Storyshots FootballScores Default 1`] = `
 }
 
 @media (min-width: 660px) {
-  .emotion-14 {
+  .emotion-13 {
     display: inline-grid;
     width: 50%;
     vertical-align: top;
@@ -15769,7 +15751,7 @@ exports[`Storyshots FootballScores Default 1`] = `
   }
 }
 
-.emotion-15 {
+.emotion-14 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
   line-height: 1.15;
@@ -15779,7 +15761,7 @@ exports[`Storyshots FootballScores Default 1`] = `
   grid-row: 1;
 }
 
-.emotion-16 {
+.emotion-15 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 2.625rem;
   line-height: 1.15;
@@ -15790,12 +15772,12 @@ exports[`Storyshots FootballScores Default 1`] = `
 }
 
 @media (min-width: 660px) {
-  .emotion-16 {
+  .emotion-15 {
     margin-left: 1rem;
   }
 }
 
-.emotion-19 {
+.emotion-18 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.9375rem;
   line-height: 1.5;
@@ -15863,20 +15845,17 @@ exports[`Storyshots FootballScores Default 1`] = `
         </span>
       </div>
     </div>
-    <ul
-      className="emotion-13"
-    />
   </section>
   <section
-    className="emotion-14"
+    className="emotion-13"
   >
     <h3
-      className="emotion-15"
+      className="emotion-14"
     >
       Man City
     </h3>
     <div
-      className="emotion-16"
+      className="emotion-15"
     >
       <div
         className="emotion-11"
@@ -15889,7 +15868,7 @@ exports[`Storyshots FootballScores Default 1`] = `
       </div>
     </div>
     <ul
-      className="emotion-19"
+      className="emotion-18"
     >
       <li>
         Sterling

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -9466,6 +9466,1210 @@ exports[`Storyshots Editions/Article Letter 1`] = `
 </main>
 `;
 
+exports[`Storyshots Editions/Article Match Report 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FFFFFF;
+}
+
+.emotion-3 {
+  border-bottom: 1px solid #DCDCDC;
+}
+
+@media (min-width: 740px) {
+  .emotion-3 {
+    width: 526px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-3 {
+    width: 545px;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-3 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-3 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-3 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-4 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+@media (min-width: 740px) {
+  .emotion-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width: 980px) {
+  .emotion-5 {
+    width: 750px;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-6 {
+    width: calc(100vw - 3.75rem);
+    background-color: #FFE500;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-6 {
+    width: inherit;
+  }
+}
+
+.emotion-7 {
+  background-color: #FFE500;
+  padding: 0.5rem;
+}
+
+.emotion-8 {
+  text-indent: -10000px;
+  position: absolute;
+  margin: 0;
+}
+
+.emotion-9 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+}
+
+@media (min-width: 660px) {
+  .emotion-9 {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.emotion-10 {
+  grid-column: 1;
+  grid-row: 1;
+  text-align: center;
+  margin-right: 0.5rem;
+}
+
+@media (min-width: 660px) {
+  .emotion-10 {
+    grid-column: 2;
+    margin-right: 0;
+  }
+}
+
+.emotion-11 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 700;
+  border: 1px dotted #000000;
+  border-radius: 100%;
+  display: inline-block;
+  width: 3rem;
+  height: 3rem;
+  padding-top: 0.75rem;
+  box-sizing: border-box;
+}
+
+.emotion-12 {
+  grid-column: 2;
+}
+
+@media (min-width: 660px) {
+  .emotion-12 {
+    grid-column: 1;
+  }
+}
+
+.emotion-13 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+}
+
+.emotion-14 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.emotion-15 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  border-top: 1px dotted #000000;
+  padding-top: 0.25rem;
+  margin-top: 0.75rem;
+  box-sizing: border-box;
+}
+
+@media (min-width: 660px) {
+  .emotion-15 {
+    display: inline-grid;
+    width: 50%;
+    vertical-align: top;
+    grid-template-columns: 1fr auto;
+    border-right: 1px dotted #000000;
+  }
+}
+
+.emotion-16 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+  margin: 0;
+  grid-column: 2;
+  grid-row: 1;
+}
+
+@media (min-width: 660px) {
+  .emotion-16 {
+    grid-column: 1;
+  }
+}
+
+.emotion-17 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  grid-column: 1;
+  grid-row: 1/3;
+  margin-right: 1rem;
+}
+
+@media (min-width: 660px) {
+  .emotion-17 {
+    grid-column: 2;
+  }
+}
+
+.emotion-18 {
+  border: 1px solid #000000;
+  border-radius: 100%;
+  display: block;
+  width: 1.5em;
+  height: 1.5em;
+  position: relative;
+}
+
+.emotion-19 {
+  position: absolute;
+  top: 7%;
+  left: 29%;
+}
+
+.emotion-20 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  grid-column: 2;
+  grid-row: 2;
+}
+
+@media (min-width: 660px) {
+  .emotion-20 {
+    grid-column: 1;
+  }
+}
+
+.emotion-21 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  border-top: 1px dotted #000000;
+  padding-top: 0.25rem;
+  margin-top: 0.75rem;
+  box-sizing: border-box;
+}
+
+@media (min-width: 660px) {
+  .emotion-21 {
+    display: inline-grid;
+    width: 50%;
+    vertical-align: top;
+    grid-template-columns: 1fr auto;
+  }
+}
+
+.emotion-22 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+  margin: 0;
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.emotion-23 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  grid-column: 1;
+  grid-row: 1/3;
+  margin-right: 1rem;
+}
+
+@media (min-width: 660px) {
+  .emotion-23 {
+    margin-left: 1rem;
+  }
+}
+
+.emotion-26 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.emotion-27 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+}
+
+@media (min-width: 740px) {
+  .emotion-27 {
+    width: 740px;
+    height: calc(740px * 0.6);
+  }
+}
+
+@media (min-width: 1300px) {
+  .emotion-27 {
+    width: 980px;
+    height: calc(980px * 0.6);
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-27 {
+    width: calc(100vw - 3.75rem);
+    height: calc((100vw - 3.75rem) * 0.6);
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-27 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-28 {
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-28 summary {
+  display: block;
+  pointer-events: auto;
+  text-align: center;
+  background-color: #0084C6;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-28 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-28 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  padding: 0.5rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width: 740px) {
+  .emotion-28 {
+    width: calc(100vw - 3.75rem);
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-28 {
+    width: 750px;
+  }
+}
+
+.emotion-29 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-29 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-29 path {
+  fill: #F1F8FC;
+}
+
+.emotion-30 {
+  box-sizing: border-box;
+  font-family: GT Guardian Titlepiece,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #0084C6;
+  font-size: 1.0625rem;
+  padding: 0.25rem 0 0.5rem;
+  box-sizing: border-box;
+}
+
+@media (min-width: 740px) {
+  .emotion-30 {
+    padding-bottom: 0.75rem;
+  }
+}
+
+.emotion-31 {
+  position: relative;
+}
+
+.emotion-32 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.5rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (min-width: 375px) {
+  .emotion-32 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-32 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+.emotion-33 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+@media (min-width: 740px) {
+  .emotion-33 {
+    width: 526px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-33 {
+    width: 545px;
+  }
+}
+
+.emotion-33 p,
+.emotion-33 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-33 address {
+  font-style: normal;
+}
+
+.emotion-33 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-33 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-33 svg path {
+  fill: #0084C6;
+}
+
+.emotion-34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-35 {
+  box-sizing: border-box;
+}
+
+@media (min-width: 740px) {
+  .emotion-35 {
+    width: 539px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-35 {
+    width: 558px;
+  }
+}
+
+.emotion-36 {
+  background-image: repeating-linear-gradient(
+  		to bottom,
+  		#DCDCDC,
+  		#DCDCDC 1px,
+  		transparent 1px,
+  		transparent 0.25rem
+  	);
+  background-repeat: repeat-x;
+  -webkit-background-position: top;
+  background-position: top;
+  -webkit-background-size: 1px calc(0.25rem * 3 + 1px);
+  background-size: 1px calc(0.25rem * 3 + 1px);
+  height: calc(0.25rem * 3 + 1px);
+}
+
+.emotion-37 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin: 0;
+}
+
+.emotion-37 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  padding-top: 0.375rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-37 svg circle {
+  stroke: #0084C6;
+}
+
+.emotion-37 svg path {
+  fill: #0084C6;
+}
+
+@media (min-width: 740px) {
+  .emotion-37 {
+    padding-bottom: 2.25rem;
+  }
+}
+
+.emotion-38 {
+  color: #0084C6;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.emotion-39 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: #121212;
+}
+
+.emotion-40 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
+@media (min-width: 740px) {
+  .emotion-41 {
+    width: 526px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-41 {
+    width: 545px;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-41 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-41 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-41 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-42 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.emotion-42 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-42 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width: 740px) {
+  .emotion-42 {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .emotion-42 p {
+    margin: 0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-42 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-43 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width: 660px) {
+  .emotion-43 {
+    width: 620px;
+  }
+}
+
+.emotion-44 {
+  width: 100%;
+  height: calc(100% * 0.6666081768731357);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width: 660px) {
+  .emotion-44 {
+    width: 620px;
+    height: calc(620px * 0.6666081768731357);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .emotion-44 {
+    background-color: #333333;
+  }
+}
+
+.emotion-45 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  font-weight: 400;
+  padding-top: 0.5rem;
+  color: #767676;
+}
+
+.emotion-46 {
+  fill: #0084C6;
+  height: 0.8em;
+  padding-right: 0.25rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .emotion-46 {
+    fill: #00B2FF;
+  }
+}
+
+.emotion-48 {
+  width: 100%;
+  height: calc(100% * 0.6666666666666666);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width: 660px) {
+  .emotion-48 {
+    width: 620px;
+    height: calc(620px * 0.6666666666666666);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .emotion-48 {
+    background-color: #333333;
+  }
+}
+
+<main
+  className="emotion-0"
+>
+  <article
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <section
+        className="emotion-3"
+      >
+        <header
+          className="emotion-4"
+        >
+          <figure
+            aria-labelledby="header-image-caption"
+            className="emotion-5"
+          >
+            <div
+              className="emotion-6"
+            >
+              <section
+                className="emotion-7"
+              >
+                <h2
+                  className="emotion-8"
+                >
+                  Scores
+                </h2>
+                <div
+                  className="emotion-9"
+                >
+                  <div
+                    className="emotion-10"
+                  >
+                    <span
+                      className="emotion-11"
+                    >
+                      FT
+                    </span>
+                  </div>
+                  <div
+                    className="emotion-12"
+                  >
+                    <nav
+                      className="emotion-13"
+                    >
+                      Premier League
+                    </nav>
+                    <address
+                      className="emotion-14"
+                    >
+                      The King Power Stadium
+                    </address>
+                  </div>
+                </div>
+                <section
+                  className="emotion-15"
+                >
+                  <h3
+                    className="emotion-16"
+                  >
+                    Leicester
+                  </h3>
+                  <div
+                    className="emotion-17"
+                  >
+                    <div
+                      className="emotion-18"
+                    >
+                      <span
+                        className="emotion-19"
+                      >
+                        2
+                      </span>
+                    </div>
+                  </div>
+                  <ul
+                    className="emotion-20"
+                  >
+                    <li>
+                      Castagne
+                       
+                      50
+                      '
+                       
+                    </li>
+                    <li>
+                      Iheanacho
+                       
+                      80
+                      '
+                       
+                    </li>
+                  </ul>
+                </section>
+                <section
+                  className="emotion-21"
+                >
+                  <h3
+                    className="emotion-22"
+                  >
+                    Crystal Palace
+                  </h3>
+                  <div
+                    className="emotion-23"
+                  >
+                    <div
+                      className="emotion-18"
+                    >
+                      <span
+                        className="emotion-19"
+                      >
+                        1
+                      </span>
+                    </div>
+                  </div>
+                  <ul
+                    className="emotion-26"
+                  >
+                    <li>
+                      Zaha
+                       
+                      12
+                      '
+                       
+                    </li>
+                  </ul>
+                </section>
+              </section>
+            </div>
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="(min-width: 740px) 740px, (min-width: 1300px) 980px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt="image"
+                className="js-launch-slideshow js-main-image emotion-27"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="emotion-28"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="emotion-29"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+          </figure>
+          <nav
+            className="emotion-30"
+          >
+            Sport 
+          </nav>
+          <div
+            className="emotion-31"
+          >
+            <h1
+              className="emotion-32"
+            >
+              Reclaimed lakes and giant airports: how Mexico City might have looked
+            </h1>
+          </div>
+          <div
+            className="emotion-33"
+          >
+            <div
+              className="emotion-34"
+            >
+              <p>
+                The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+              </p>
+            </div>
+          </div>
+          <div
+            className="emotion-35"
+          >
+            <div
+              className="emotion-36"
+            />
+          </div>
+          <div
+            className="emotion-37"
+          >
+            <address>
+              <span
+                className="emotion-38"
+              >
+                Jane Smith
+              </span>
+              <span
+                className="emotion-39"
+              >
+                 Editor of things
+              </span>
+            </address>
+            <span
+              className="js-share-button"
+              role="button"
+            >
+              <button
+                className="emotion-40"
+                onClick={[Function]}
+              >
+                <svg
+                  fill="none"
+                  viewBox="0 0 30 30"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="15"
+                    cy="15"
+                    r="14.5"
+                  />
+                  <path
+                    d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="emotion-41"
+    >
+      <section
+        className="emotion-42"
+      >
+        <figure
+          className="emotion-43"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=45&fit=bounds&s=253ff45edb114b0605b7bce66b7f78f3 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=45&fit=bounds&s=3be9e2a7e7f1b2ac4efab144d6c07a28 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=45&fit=bounds&s=14c3c8f7d54a8d8794664492efc68641 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=45&fit=bounds&s=2745788813a433224e06421647d60b2c 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=45&fit=bounds&s=dcdc2c3d03aee717124c58914a5c39de 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=85&fit=bounds&s=c125868b875fa9ec4a8ce180360836e0 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=85&fit=bounds&s=dde3e8a919521443e8b0f5fba726fb24 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=85&fit=bounds&s=3b57ebd649babc411c89f62a27bd800a 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=85&fit=bounds&s=d0d5bfe2a9ce9000f6d8afc8b864fe92 2000w"
+            />
+            <img
+              alt="Washington, DC, US Subcommittee chair Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol, during a House Judiciary subcommittee on Crime, Terrorism, and Homeland Security hearing"
+              className="js-launch-slideshow emotion-44"
+              data-caption="<strong>Washington DC, US</strong> <br><br>Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol during a House judiciary subcommittee hearing"
+              data-credit="Photograph: Al Drago/Getty Images"
+              data-ratio={0.6666081768731357}
+              src="https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3"
+            />
+          </picture>
+          <figcaption
+            className="emotion-45"
+          >
+            <svg
+              className="emotion-46"
+              viewBox="0 0 10 9"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="0,9 5,0 10,9"
+              />
+            </svg>
+            <span>
+              Washington DC, US
+            </span>
+            <span>
+              Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol during a House judiciary subcommittee hearing
+            </span>
+             
+            Photograph: Al Drago/Getty Images
+          </figcaption>
+        </figure>
+        <figure
+          className="emotion-43"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=45&fit=bounds&s=20c42477022d7ce2b2ac2d0b5cb688de 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=45&fit=bounds&s=dff09e82b640f93f268212b3a0de5b4e 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=45&fit=bounds&s=a4e0cdc7de19d34a17c874c3a81a1ebe 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=45&fit=bounds&s=478eaedffbc1085109b5b4e29f2200b9 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=45&fit=bounds&s=e8e63bb3ec8ead5b6607b25fea2cd528 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=85&fit=bounds&s=00a782574440af9727bf87616b94d572 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=85&fit=bounds&s=d4b61df8dc308483ca3b92c7da5de42e 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=85&fit=bounds&s=b9a3f3096a28cadaef022bbbf5322c56 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=85&fit=bounds&s=c476519c6a377a16d963a8cf9888713a 2000w"
+            />
+            <img
+              alt="Prayagraj, India A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers, during Magh Mela festival"
+              className="js-launch-slideshow emotion-48"
+              data-caption="<strong>Prayagraj, India</strong> <br><br>A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers"
+              data-credit="Photograph: Rajesh Kumar Singh/AP"
+              data-ratio={0.6666666666666666}
+              src="https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063"
+            />
+          </picture>
+          <figcaption
+            className="emotion-45"
+          >
+            <svg
+              className="emotion-46"
+              viewBox="0 0 10 9"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="0,9 5,0 10,9"
+              />
+            </svg>
+            <span>
+              Prayagraj, India
+            </span>
+            <span>
+              A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers
+            </span>
+             
+            Photograph: Rajesh Kumar Singh/AP
+          </figcaption>
+        </figure>
+        <figure
+          className="emotion-43"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=45&fit=bounds&s=b6beebe9a75fe6d5ce9475c0d13e429c 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=45&fit=bounds&s=1516f1b11f5a186d13bc2e7dc56eecde 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=45&fit=bounds&s=665b8f94e20042d415967c7a382cd561 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=45&fit=bounds&s=7bb7869708fa9d17b025aa334ba3a564 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=45&fit=bounds&s=3c40f4ca2a68a4393201f94f025eb68a 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=85&fit=bounds&s=7231bc978677afa567b999de7645602a 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=85&fit=bounds&s=cdeb3b040ff85ccebaa83f54643c87cb 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=85&fit=bounds&s=61bde3db8713dfa8ab6c9d94d3b53d3e 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=85&fit=bounds&s=fe5d0c455c7a8bf71082086f9b24e934 2000w"
+            />
+            <img
+              alt="Hua Hin, Thailand A bird flies over the abandoned sculpture of a Buddhist monk in Cha-am outside Hua Hin, south of Bangkok"
+              className="js-launch-slideshow emotion-48"
+              data-caption="<strong>Hua Hin, Thailand <br><br></strong>A bird flies over the abandoned sculpture of a Buddhist monk south of Bangkok"
+              data-credit="Photograph: Mladen Antonov/AFP/Getty Images"
+              data-ratio={0.6666666666666666}
+              src="https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c"
+            />
+          </picture>
+          <figcaption
+            className="emotion-45"
+          >
+            <svg
+              className="emotion-46"
+              viewBox="0 0 10 9"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="0,9 5,0 10,9"
+              />
+            </svg>
+            <span>
+              Hua Hin, Thailand
+            </span>
+            <span>
+              A bird flies over the abandoned sculpture of a Buddhist monk south of Bangkok
+            </span>
+             
+            Photograph: Mladen Antonov/AFP/Getty Images
+          </figcaption>
+        </figure>
+        <figure
+          className="emotion-43"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=45&fit=bounds&s=0f3c3dbd3fc24dc38b6a25593933d036 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=45&fit=bounds&s=3eb9e25c8e38ec8ae5e9b0a7e10c6c67 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=45&fit=bounds&s=317b489ad130fde80b1ea52214b0341a 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=45&fit=bounds&s=e0770f452eb0745fa25c47b78cdff4b4 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=45&fit=bounds&s=798fd1d9b81dc6b3fa425022e6201e64 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=85&fit=bounds&s=dc30181295bcbe657a051d55966d119a 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=85&fit=bounds&s=59187d1926376734fedf391885c21c75 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=85&fit=bounds&s=31b6374d30517dca65cbb0d7c0454535 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=85&fit=bounds&s=15e40dc6afcdbfefe241ddb4748c8ac5 2000w"
+            />
+            <img
+              alt="Mulhouse, France A polar bear cub makes its first steps outside, in an enclosure at the Zoological and Botanical park in eastern France. The cub was born in November 2020"
+              className="js-launch-slideshow emotion-48"
+              data-caption="<strong>Mulhouse, France</strong> <br><br>A polar bear cub takes its first steps outside in an enclosure at the zoological and botanical park"
+              data-credit="Photograph: Sébastien Bozon/AFP/Getty Images"
+              data-ratio={0.6666666666666666}
+              src="https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867"
+            />
+          </picture>
+          <figcaption
+            className="emotion-45"
+          >
+            <svg
+              className="emotion-46"
+              viewBox="0 0 10 9"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="0,9 5,0 10,9"
+              />
+            </svg>
+            <span>
+              Mulhouse, France
+            </span>
+            <span>
+              A polar bear cub takes its first steps outside in an enclosure at the zoological and botanical park
+            </span>
+             
+            Photograph: Sébastien Bozon/AFP/Getty Images
+          </figcaption>
+        </figure>
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
 exports[`Storyshots Editions/Article Review 1`] = `
 .emotion-0 {
   height: 100%;

--- a/src/capi.test.ts
+++ b/src/capi.test.ts
@@ -8,7 +8,7 @@ describe('server logic runs as expected', () => {
 		const capiUrl = capiEndpoint(articleId, key);
 
 		expect(capiUrl).toEqual(
-			'https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue%2CdisplayHint%2CstarRating%2Ccommentable%2CinternalShortId%2CliveBloggingNow%2ClastModified&show-tags=all&show-blocks=all&show-elements=all&show-related=true',
+			'https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue%2CdisplayHint%2CstarRating%2Ccommentable%2CinternalShortId%2CliveBloggingNow%2ClastModified&show-tags=all&show-blocks=all&show-elements=all&show-related=true&show-references=all',
 		);
 	});
 });

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -190,9 +190,21 @@ const capiEndpoint = (articleId: string, key: string): string => {
 		'show-blocks': 'all',
 		'show-elements': 'all',
 		'show-related': 'true',
+		'show-references': 'all',
 	});
 
 	return `https://content.guardianapis.com/${articleId}?${params.toString()}`;
+};
+
+const footballEndpoint = (articleId: string, key: string): string => {
+	// If you need a new field here, MAPI probably also needs updating
+
+	const params = new URLSearchParams({
+		format: 'thrift',
+		'api-key': key,
+	});
+
+	return `https://content.guardianapis.com/football/everton?${params.toString()}`;
 };
 
 const capiDateTimeToDate = (date: CapiDateTime): Option<Date> =>
@@ -224,4 +236,5 @@ export {
 	articleMainImage,
 	checkForThirdPartyEmbed,
 	requiresInlineStyles,
+	footballEndpoint,
 };

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -196,17 +196,6 @@ const capiEndpoint = (articleId: string, key: string): string => {
 	return `https://content.guardianapis.com/${articleId}?${params.toString()}`;
 };
 
-const footballEndpoint = (articleId: string, key: string): string => {
-	// If you need a new field here, MAPI probably also needs updating
-
-	const params = new URLSearchParams({
-		format: 'thrift',
-		'api-key': key,
-	});
-
-	return `https://content.guardianapis.com/football/everton?${params.toString()}`;
-};
-
 const capiDateTimeToDate = (date: CapiDateTime): Option<Date> =>
 	// Thrift definitions define some dates as CapiDateTime but CAPI returns strings
 	dateFromString(date.iso8601);
@@ -236,5 +225,4 @@ export {
 	articleMainImage,
 	checkForThirdPartyEmbed,
 	requiresInlineStyles,
-	footballEndpoint,
 };

--- a/src/components/editions/article/article.stories.tsx
+++ b/src/components/editions/article/article.stories.tsx
@@ -10,6 +10,7 @@ import {
 	feature,
 	interview,
 	letter,
+	matchReport,
 	media,
 	review,
 } from 'fixtures/item';
@@ -128,6 +129,15 @@ const Letter = (): ReactElement => (
 		}}
 	/>
 );
+const MatchReport = (): ReactElement => (
+	<Article
+		item={{
+			...matchReport,
+			tags: [getTag('tone/sport', 'Sport ')],
+			theme: selectPillar(Pillar.Sport),
+		}}
+	/>
+);
 
 const Gallery = (): ReactElement => (
 	<Article
@@ -165,4 +175,5 @@ export {
 	Editorial,
 	Gallery,
 	Letter,
+	MatchReport,
 };

--- a/src/components/editions/article/index.tsx
+++ b/src/components/editions/article/index.tsx
@@ -132,7 +132,8 @@ const Article: FC<Props> = ({ item }) => {
 		item.design === Design.Editorial ||
 		item.design === Design.Letter ||
 		item.design === Design.Quiz ||
-		item.design === Design.Recipe
+		item.design === Design.Recipe ||
+		item.design === Design.MatchReport
 	) {
 		return (
 			<main css={mainStyles}>

--- a/src/components/editions/headerMedia/index.tsx
+++ b/src/components/editions/headerMedia/index.tsx
@@ -11,6 +11,7 @@ import HeaderImageCaption, {
 	captionId,
 } from 'components/editions/headerImageCaption';
 import StarRating from 'components/editions/starRating';
+import FootballScores from 'components/footballScores';
 import { MainMediaKind } from 'headerMedia';
 import type { Image } from 'image';
 import type { Item } from 'item';
@@ -130,30 +131,51 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 				image: { nativeCaption, credit },
 			} = media;
 
+			const matchScores = 'football' in item ? item.football : none;
+
 			return (
-				<figure css={[getStyles(format)]} aria-labelledby={captionId}>
-					<Img
-						image={image}
-						sizes={getImageSizes(format)}
-						format={item}
-						className={some(getImageStyle(image, format))}
-						supportsDarkMode={false}
-						lightbox={some({
-							className: 'js-launch-slideshow js-main-image',
-							caption: none,
-							credit: none,
-						})}
-					/>
-					<HeaderImageCaption
-						caption={nativeCaption}
-						credit={credit}
-						styles={getCaptionStyles(format)}
-						iconColor={iconColor}
-						iconBackgroundColor={iconBackgroundColor}
-						isFullWidthImage={isFullWidthImage(format)}
-					/>
-					<StarRating item={item} />
-				</figure>
+				<>
+					<figure
+						css={[getStyles(format)]}
+						aria-labelledby={captionId}
+					>
+						{maybeRender(matchScores, (scores) => (
+							<div
+								id="js-football-scores"
+								style={{ width: '100vw' }}
+							>
+								<FootballScores
+									league={scores.league}
+									stadium={scores.stadium}
+									homeTeam={scores.homeTeam}
+									awayTeam={scores.awayTeam}
+									status={scores.status}
+								/>
+							</div>
+						))}
+						<Img
+							image={image}
+							sizes={getImageSizes(format)}
+							format={item}
+							className={some(getImageStyle(image, format))}
+							supportsDarkMode={false}
+							lightbox={some({
+								className: 'js-launch-slideshow js-main-image',
+								caption: none,
+								credit: none,
+							})}
+						/>
+						<HeaderImageCaption
+							caption={nativeCaption}
+							credit={credit}
+							styles={getCaptionStyles(format)}
+							iconColor={iconColor}
+							iconBackgroundColor={iconBackgroundColor}
+							isFullWidthImage={isFullWidthImage(format)}
+						/>
+						<StarRating item={item} />
+					</figure>
+				</>
 			);
 		} else {
 			const {

--- a/src/components/editions/headerMedia/index.tsx
+++ b/src/components/editions/headerMedia/index.tsx
@@ -132,20 +132,25 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 			} = media;
 
 			const matchScores = 'football' in item ? item.football : none;
-			console.log(matchScores);
+
 			return (
 				<figure css={[getStyles(format)]} aria-labelledby={captionId}>
-					{maybeRender(matchScores, (scores) => (
-						<div id="js-football-scores" style={{ width: '100vw' }}>
-							<FootballScores
-								league={scores.league}
-								stadium={scores.stadium}
-								homeTeam={scores.homeTeam}
-								awayTeam={scores.awayTeam}
-								status={scores.status}
-							/>
-						</div>
-					))}
+					{maybeRender(matchScores, (scores) => {
+						return (
+							<div
+								id="js-football-scores"
+								style={{ width: '100vw' }}
+							>
+								<FootballScores
+									league={scores.league}
+									stadium={scores.stadium}
+									homeTeam={scores.homeTeam}
+									awayTeam={scores.awayTeam}
+									status={scores.status}
+								/>
+							</div>
+						);
+					})}
 					<Img
 						image={image}
 						sizes={getImageSizes(format)}

--- a/src/components/editions/headerMedia/index.tsx
+++ b/src/components/editions/headerMedia/index.tsx
@@ -132,7 +132,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 			} = media;
 
 			const matchScores = 'football' in item ? item.football : none;
-
+			console.log(matchScores);
 			return (
 				<figure css={[getStyles(format)]} aria-labelledby={captionId}>
 					{maybeRender(matchScores, (scores) => (

--- a/src/components/editions/headerMedia/index.tsx
+++ b/src/components/editions/headerMedia/index.tsx
@@ -134,48 +134,40 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 			const matchScores = 'football' in item ? item.football : none;
 
 			return (
-				<>
-					<figure
-						css={[getStyles(format)]}
-						aria-labelledby={captionId}
-					>
-						{maybeRender(matchScores, (scores) => (
-							<div
-								id="js-football-scores"
-								style={{ width: '100vw' }}
-							>
-								<FootballScores
-									league={scores.league}
-									stadium={scores.stadium}
-									homeTeam={scores.homeTeam}
-									awayTeam={scores.awayTeam}
-									status={scores.status}
-								/>
-							</div>
-						))}
-						<Img
-							image={image}
-							sizes={getImageSizes(format)}
-							format={item}
-							className={some(getImageStyle(image, format))}
-							supportsDarkMode={false}
-							lightbox={some({
-								className: 'js-launch-slideshow js-main-image',
-								caption: none,
-								credit: none,
-							})}
-						/>
-						<HeaderImageCaption
-							caption={nativeCaption}
-							credit={credit}
-							styles={getCaptionStyles(format)}
-							iconColor={iconColor}
-							iconBackgroundColor={iconBackgroundColor}
-							isFullWidthImage={isFullWidthImage(format)}
-						/>
-						<StarRating item={item} />
-					</figure>
-				</>
+				<figure css={[getStyles(format)]} aria-labelledby={captionId}>
+					{maybeRender(matchScores, (scores) => (
+						<div id="js-football-scores" style={{ width: '100vw' }}>
+							<FootballScores
+								league={scores.league}
+								stadium={scores.stadium}
+								homeTeam={scores.homeTeam}
+								awayTeam={scores.awayTeam}
+								status={scores.status}
+							/>
+						</div>
+					))}
+					<Img
+						image={image}
+						sizes={getImageSizes(format)}
+						format={item}
+						className={some(getImageStyle(image, format))}
+						supportsDarkMode={false}
+						lightbox={some({
+							className: 'js-launch-slideshow js-main-image',
+							caption: none,
+							credit: none,
+						})}
+					/>
+					<HeaderImageCaption
+						caption={nativeCaption}
+						credit={credit}
+						styles={getCaptionStyles(format)}
+						iconColor={iconColor}
+						iconBackgroundColor={iconBackgroundColor}
+						isFullWidthImage={isFullWidthImage(format)}
+					/>
+					<StarRating item={item} />
+				</figure>
 			);
 		} else {
 			const {

--- a/src/components/editions/headerMedia/index.tsx
+++ b/src/components/editions/headerMedia/index.tsx
@@ -4,6 +4,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { Sizes } from '@guardian/image-rendering';
 import { Img } from '@guardian/image-rendering';
+import { brandAltBackground } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';
 import { Design, Display, none, some } from '@guardian/types';
@@ -54,6 +55,17 @@ const fullWidthCaptionStyles = css`
 	height: 100%;
 `;
 
+const footballWrapperStyles: SerializedStyles = css`
+	${from.tablet} {
+		width: calc(100vw - 3.75rem);
+		background-color: ${brandAltBackground.primary};
+	}
+
+	${from.desktop} {
+		width: inherit;
+	}
+`;
+
 const getImageStyle = (
 	{ width, height }: Image,
 	format: Format,
@@ -71,7 +83,7 @@ const getImageStyle = (
 
 		${from.tablet} {
 			width: calc(100vw - 3.75rem);
-			height: calc((100vw - 3.75rem) * height / width);
+			height: calc((100vw - 3.75rem) * ${height / width});
 		}
 
 		${from.desktop} {
@@ -137,10 +149,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 				<figure css={[getStyles(format)]} aria-labelledby={captionId}>
 					{maybeRender(matchScores, (scores) => {
 						return (
-							<div
-								id="js-football-scores"
-								style={{ width: '100vw' }}
-							>
+							<div css={footballWrapperStyles}>
 								<FootballScores
 									league={scores.league}
 									stadium={scores.stadium}

--- a/src/components/footballScores.tsx
+++ b/src/components/footballScores.tsx
@@ -11,7 +11,6 @@ import { TeamScore } from 'components/teamScore';
 import { MatchStatusKind, TeamLocation } from 'football';
 import type { MatchStatus } from 'football';
 import type { FC } from 'react';
-import React from 'react';
 
 // ----- Component ----- //
 

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -27,7 +27,6 @@ import type {
 	Standard as StandardItem,
 } from 'item';
 import { maybeRender, pipe2 } from 'lib';
-import React from 'react';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,

--- a/src/components/teamScore.tsx
+++ b/src/components/teamScore.tsx
@@ -93,7 +93,7 @@ const TeamScore: FC<Props> = ({ team, location }) => (
 			</div>
 		</div>
 		<ul css={scorerStyles(location)}>
-			{team.scorers.map((scorer) => (
+			{team.scorers?.map((scorer) => (
 				<li key={`${scorer.player}`}>
 					{scorer.player} {scorer.timeInMinutes}&apos;{' '}
 					{scorer.additionalInfo}

--- a/src/components/teamScore.tsx
+++ b/src/components/teamScore.tsx
@@ -92,14 +92,16 @@ const TeamScore: FC<Props> = ({ team, location }) => (
 				<span css={scoreInlineStyles}>{team.score}</span>
 			</div>
 		</div>
-		<ul css={scorerStyles(location)}>
-			{team.scorers?.map((scorer) => (
-				<li key={`${scorer.player}`}>
-					{scorer.player} {scorer.timeInMinutes}&apos;{' '}
-					{scorer.additionalInfo}
-				</li>
-			))}
-		</ul>
+		{team.scorers.length > 0 && (
+			<ul css={scorerStyles(location)}>
+				{team.scorers.map((scorer) => (
+					<li key={`${scorer.player}`}>
+						{scorer.player} {scorer.timeInMinutes}&apos;{' '}
+						{scorer.additionalInfo}
+					</li>
+				))}
+			</ul>
+		)}
 	</section>
 );
 

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -17,6 +17,7 @@ import type { Body } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
 import { parse } from 'client/parser';
 import type { Contributor } from 'contributor';
+import type { MatchScores } from 'football';
 import type { MainMedia } from 'headerMedia';
 import { MainMediaKind } from 'headerMedia';
 import type { Image } from 'image';
@@ -216,6 +217,33 @@ const body: Body = [
 	},
 ];
 
+const matchScores: MatchScores = {
+	league: 'Premier League',
+	stadium: 'The King Power Stadium',
+	status: { kind: 4 },
+	homeTeam: {
+		id: '29',
+		name: 'Leicester',
+		shortCode: 'LEI',
+		crestUri:
+			'https://i.guim.co.uk/img/sport/football/crests/29.png?w=#{width}&h=#{height}&q=#{quality}&fit=bounds&sig-ignores-params=true&s=39ec5ce46e761b69ac55204fa6c0999a',
+		score: 2,
+		scorers: [
+			{ player: 'Castagne', timeInMinutes: 50 },
+			{ player: 'Iheanacho', timeInMinutes: 80 },
+		],
+	},
+	awayTeam: {
+		id: '5',
+		name: 'Crystal Palace',
+		shortCode: 'CRY',
+		crestUri:
+			'https://i.guim.co.uk/img/sport/football/crests/5.png?w=#{width}&h=#{height}&q=#{quality}&fit=bounds&sig-ignores-params=true&s=7fd29a0f99425f2f4b0c40165b4ed23b',
+		score: 1,
+		scorers: [{ player: 'Zaha', timeInMinutes: 12 }],
+	},
+};
+
 const fields = {
 	theme: Pillar.News,
 	display: Display.Standard,
@@ -299,6 +327,13 @@ const media: Item = {
 	body: galleryBody,
 };
 
+const matchReport: Item = {
+	design: Design.MatchReport,
+	football: some(matchScores),
+	...fields,
+	body: galleryBody,
+};
+
 // ----- Exports ----- //
 
 export {
@@ -312,4 +347,5 @@ export {
 	media,
 	editorial,
 	letter,
+	matchReport,
 };

--- a/src/server/footballContent.ts
+++ b/src/server/footballContent.ts
@@ -56,10 +56,10 @@ const parseFootballResponse = async (
 	selectorId: string,
 ): Promise<Result<string, FootballContent>> => {
 	if (response.status === 200) {
-		const json: FootballResponse = await response.json();
+		const json = (await response.json()) as FootballResponse;
 		return ok(json[selectorId]);
 	} else if (response.status === 400) {
-		const json: FootballError = await response.json();
+		const json = (await response.json()) as FootballError;
 		return err(json.errorMessage);
 	} else {
 		return err('Problem accessing PA API');
@@ -88,7 +88,9 @@ const teamsFromTags = (tags: Tag[]): Option<Teams> => {
 	return none;
 };
 
-const getFootballContent = async (content: Content) => {
+const getFootballContent = async (
+	content: Content,
+): Promise<FootballContent | undefined> => {
 	const teams = teamsFromTags(content.tags);
 
 	if (teams.kind === OptionKind.Some) {
@@ -117,9 +119,13 @@ const getFootballContent = async (content: Content) => {
 					if (footballContent.kind === ResultKind.Ok) {
 						return footballContent.value;
 					}
+					return undefined;
 				}
+				return undefined;
 			}
+			return undefined;
 		}
+		return undefined;
 	}
 	return undefined;
 };

--- a/src/server/footballContent.ts
+++ b/src/server/footballContent.ts
@@ -1,0 +1,127 @@
+import type { FootballContent } from '@guardian/apps-rendering-api-models/footballContent';
+import type { Content } from '@guardian/content-api-models/v1/content';
+import type { Tag } from '@guardian/content-api-models/v1/tag';
+import { err, none, ok, OptionKind, ResultKind, some } from '@guardian/types';
+import type { Option, Result } from '@guardian/types';
+import { padZero } from 'date';
+import fetch from 'node-fetch';
+import type { Response } from 'node-fetch';
+
+type Teams = [string, string];
+
+const getFootballSelector = (
+	date: Option<Date>,
+	teamA: Option<string>,
+	teamB: Option<string>,
+): Option<string> => {
+	if (
+		date.kind === OptionKind.Some &&
+		teamA.kind === OptionKind.Some &&
+		teamB.kind === OptionKind.Some
+	) {
+		// MAPI sorts these by string value
+		const teams =
+			teamA.value < teamB.value
+				? [teamA.value, teamB.value]
+				: [teamB.value, teamA.value];
+
+		const d = date.value;
+		const year = d.getUTCFullYear();
+		const month = padZero(d.getUTCMonth() + 1);
+		const day = padZero(d.getUTCDate());
+
+		return some(`${year}-${month}-${day}_${teams[0]}_${teams[1]}`);
+	}
+
+	return none;
+};
+
+const getFootballEndpoint = (selectorId: Option<string>): Option<string> => {
+	if (selectorId.kind === OptionKind.Some) {
+		return some(
+			`https://mobile.guardianapis.com/sport/football/matches?selector=${selectorId.value}`,
+		);
+	}
+	return none;
+};
+
+type FootballResponse = Record<string, FootballContent>;
+
+interface FootballError {
+	errorMessage: string;
+}
+
+const parseFootballResponse = async (
+	response: Response,
+	selectorId: string,
+): Promise<Result<string, FootballContent>> => {
+	if (response.status === 200) {
+		const json: FootballResponse = await response.json();
+		return ok(json[selectorId]);
+	} else if (response.status === 400) {
+		const json: FootballError = await response.json();
+		return err(json.errorMessage);
+	} else {
+		return err('Problem accessing PA API');
+	}
+};
+
+const teamsFromTags = (tags: Tag[]): Option<Teams> => {
+	const [teamA, teamB] = tags.reduce((ids: string[], tag: Tag) => {
+		const teamTag = tag.references.find((ref) =>
+			ref.id.startsWith('pa-football-team'),
+		);
+
+		if (teamTag !== undefined) {
+			const id = teamTag.id.split('/')[1];
+
+			return [...ids, id];
+		}
+
+		return ids;
+	}, []);
+
+	if (teamA && teamB) {
+		return some([teamA, teamB]);
+	}
+
+	return none;
+};
+
+const getFootballContent = async (content: Content) => {
+	const teams = teamsFromTags(content.tags);
+
+	if (teams.kind === OptionKind.Some) {
+		const currentTeams = teams.value;
+		const teamA = some(currentTeams[0]);
+		const teamB = some(currentTeams[1]);
+
+		const webPublicationDate = content.webPublicationDate?.iso8601;
+
+		if (webPublicationDate) {
+			const date = some(new Date(webPublicationDate));
+
+			const selectorId = getFootballSelector(date, teamA, teamB);
+
+			if (selectorId.kind === OptionKind.Some) {
+				const footballEndpoint = getFootballEndpoint(selectorId);
+
+				if (footballEndpoint.kind === OptionKind.Some) {
+					const response = await fetch(footballEndpoint.value);
+
+					const footballContent = await parseFootballResponse(
+						response,
+						selectorId.value,
+					);
+
+					if (footballContent.kind === ResultKind.Ok) {
+						return footballContent.value;
+					}
+				}
+			}
+		}
+	}
+	return undefined;
+};
+
+export { getFootballContent };


### PR DESCRIPTION
## Why are you doing this?

When developing, we were missing football match report data from the CAPI response as that data is provided separately from PA. 

This PR adds a  'show-references' parameter to the CAPI request to return football club and competition ids, which we can then parse into a new api request to PA, which provides us with match data for the corresponding teams.

We then pass that response into the apps rendering flow with the rest of the content.

We then use the new football scores data to populate a `FootballScores` component that lives in the Editions article header.

* for Editions styles need updating to match new Editions designs (😖 ) but this should provide all necessary functionality.



## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/116441589-7d1c0780-a849-11eb-96c1-fa6b5a207089.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/116441629-83aa7f00-a849-11eb-9472-4c9c855efd88.png" width="300px" /> |
