### PR TITLE
Use Dotcom For Related Item Links

### DIFF
--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -356,7 +356,7 @@ function hasSeenCards(): void {
 	void userClient.filterSeenArticles(articleIds).then((seenArticles) => {
 		seenArticles.forEach((id) => {
 			document
-				.querySelector(`.js-card[data-article-id='/${id}']`)
+				.querySelector(`.js-card[data-article-id='${id}']`)
 				?.classList.add('fade');
 		});
 	});

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -421,7 +421,7 @@ const Card: FC<Props> = ({ relatedItem, image }) => {
 			data-article-id={link}
 			css={[listStyles(type, format), cardStyles(type, format)]}
 		>
-			<a css={anchorStyles} href={`https://theguardian.com/{link}`}>
+			<a css={anchorStyles} href={`https://theguardian.com/${link}`}>
 				<section css={headingWrapperStyles}>
 					<h3 css={headingStyles(type)}>
 						{quotationComment(type, format)}

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -414,15 +414,14 @@ const Card: FC<Props> = ({ relatedItem, image }) => {
 		!Number.isNaN(parseInt(relatedItem.starRating))
 			? stars(parseInt(relatedItem.starRating))
 			: null;
-	const articleId = link.slice(1);
 
 	return (
 		<li
 			className="js-card"
-			data-article-id={articleId}
+			data-article-id={link}
 			css={[listStyles(type, format), cardStyles(type, format)]}
 		>
-			<a css={anchorStyles} href={link}>
+			<a css={anchorStyles} href={`https://theguardian.com/{link}`}>
 				<section css={headingWrapperStyles}>
 					<h3 css={headingStyles(type)}>
 						{quotationComment(type, format)}

--- a/src/relatedContent.test.ts
+++ b/src/relatedContent.test.ts
@@ -54,7 +54,7 @@ describe('parseRelatedContent', () => {
 					title: 'contentTitle',
 					lastModified: undefined,
 					headerImage: undefined,
-					link: 'https://theguardian.com/contentId',
+					link: 'contentId',
 					type: RelatedItemType.ARTICLE,
 					pillar: {
 						id: 'somePillarId',
@@ -112,10 +112,10 @@ describe('parseRelatedContent', () => {
 		]);
 
 		expect(actual.relatedItems.length).toBe(4);
-		expect(actual.relatedItems[0].link).toBe('https://theguardian.com/id1');
-		expect(actual.relatedItems[1].link).toBe('https://theguardian.com/id2');
-		expect(actual.relatedItems[2].link).toBe('https://theguardian.com/id3');
-		expect(actual.relatedItems[3].link).toBe('https://theguardian.com/id4');
+		expect(actual.relatedItems[0].link).toBe('id1');
+		expect(actual.relatedItems[1].link).toBe('id2');
+		expect(actual.relatedItems[2].link).toBe('id3');
+		expect(actual.relatedItems[3].link).toBe('id4');
 	});
 });
 

--- a/src/relatedContent.ts
+++ b/src/relatedContent.ts
@@ -77,7 +77,7 @@ const parseRelatedContent = (relatedContent: Content[]): RelatedContent => {
 					title: content.webTitle,
 					lastModified: content.fields?.lastModified,
 					headerImage: parseHeaderImage(content),
-					link: `https://theguardian.com/${content.id}`,
+					link: content.id,
 					type: parseRelatedItemType(content),
 					pillar: {
 						id: content.pillarId ?? 'pillar/news',


### PR DESCRIPTION
## Why are you doing this?

Follow on from #1277. Those changes actually only added the prefix when running locally, because they modified the mocked CAPI response. In PROD/CODE MAPI is setting the link URL.

That said, I think it makes more sense for AR to control the link `href` in any case, since it's a rendering concern. Therefore I've updated MAPI to pass through the content `id` instead (https://github.com/guardian/mobile-apps-api/pull/1707), and made changes in this PR to build the URL from that.

## Changes

- Passed through the content id for related content
- Built full URL, from id, in the component
