### PR TITLE
Fix Ad Slots On Pages With Rich Links

### DIFF
--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -11,6 +11,7 @@ import { App } from '@guardian/discussion-rendering/build/App';
 import { either } from '@guardian/types';
 import {
 	ads,
+	getAdSlots,
 	reportNativeElementPositionChanges,
 	sendTargetingParams,
 	slideshow,
@@ -24,6 +25,7 @@ import { formatDate, formatLocal, isValidDate } from 'date';
 import { handleErrors, isObject } from 'lib';
 import {
 	acquisitionsClient,
+	commercialClient,
 	discussionClient,
 	navigationClient,
 	notificationsClient,
@@ -459,6 +461,10 @@ function richLinks(): void {
 							);
 							if (placeholder && typeof image === 'string') {
 								const img = document.createElement('img');
+								img.addEventListener('load', (_) => {
+									const currentAdSlots = getAdSlots();
+									void commercialClient.updateAdverts(currentAdSlots);
+								});
 								img.setAttribute('alt', 'Related article');
 								img.setAttribute('src', image);
 								placeholder.appendChild(img);

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -463,7 +463,9 @@ function richLinks(): void {
 								const img = document.createElement('img');
 								img.addEventListener('load', (_) => {
 									const currentAdSlots = getAdSlots();
-									void commercialClient.updateAdverts(currentAdSlots);
+									void commercialClient.updateAdverts(
+										currentAdSlots,
+									);
 								});
 								img.setAttribute('alt', 'Related article');
 								img.setAttribute('src', image);

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -276,4 +276,5 @@ export {
 	videos,
 	reportNativeElementPositionChanges,
 	sendTargetingParams,
+	getAdSlots,
 };


### PR DESCRIPTION
## Why are you doing this?

Paired with @jordanterry on this work.

### TL;DR

Some changes to page layout were not being reported to the native layers, which meant ad positions weren't being updated.

### In Full

Although articles in the live apps are rendered in webviews (via apps-rendering), ads are actually native elements that are rendered on top of the webview itself. AR includes empty placeholders in the page, and reports the location of these placeholders to the native layers, so they know where to place the ads. Sometimes, if the page layout changes, AR has to re-send these locations so that the native layers can update the positions to match.

We've noticed that, occasionally, ads on the Android app are misaligned. @jordanterry discovered that this seems to happen on articles that include rich links, although it's not always consistent. Our hypothesis: when rich link images load, and the content of the page is pushed down, the change is not being reported to the native layers. Therefore the ad positions are not being updated to accommodate this reflow.

We believe the fix is to explicitly send the update message to the native layers whenever the `img` `load` event for rich links occurs.

**A Note On iOS:** This issue _should_ also occur on iOS, but it's possible that it's being hidden by other events that trigger ad updates - essentially a race condition that breaks more often one way on iOS than on Android. It was actually inconsistently reproducible on Android for this reason.

**Note:** This fixes this particular issue, but some of the client-side code is quite brittle and the problem is likely to occur again for other elements. We'll look separately at how we can make this code more robust.

## Changes

- Update ad slots on `img` load
