### PR TITLE
LIVE-1249: update layout to match new designs

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -9556,6 +9556,19 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   padding: 0.5rem;
 }
 
+@media (min-width: 740px) {
+  .emotion-7 {
+    width: 531px;
+    padding-right: 0;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-7 {
+    width: 550px;
+  }
+}
+
 .emotion-8 {
   text-indent: -10000px;
   position: absolute;
@@ -9574,110 +9587,84 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 }
 
 .emotion-10 {
-  grid-column: 1;
-  grid-row: 1;
-  text-align: center;
-  margin-right: 0.5rem;
+  grid-column: 2;
 }
 
 @media (min-width: 660px) {
   .emotion-10 {
-    grid-column: 2;
-    margin-right: 0;
+    grid-column: 1;
   }
 }
 
 .emotion-11 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.9375rem;
+  font-size: 1.0625rem;
   line-height: 1.5;
   font-weight: 700;
-  border: 1px dotted #000000;
-  border-radius: 100%;
-  display: inline-block;
-  width: 3rem;
-  height: 3rem;
-  padding-top: 0.75rem;
-  box-sizing: border-box;
-}
-
-.emotion-12 {
-  grid-column: 2;
 }
 
 @media (min-width: 660px) {
   .emotion-12 {
-    grid-column: 1;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
   }
 }
 
 .emotion-13 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 700;
-}
-
-.emotion-14 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 400;
-  font-style: normal;
-}
-
-.emotion-15 {
-  display: grid;
-  grid-template-columns: auto 1fr;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   border-top: 1px dotted #000000;
   padding-top: 0.25rem;
   margin-top: 0.75rem;
   box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 @media (min-width: 660px) {
-  .emotion-15 {
-    display: inline-grid;
+  .emotion-13 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
     width: 50%;
     vertical-align: top;
-    grid-template-columns: 1fr auto;
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
     border-right: 1px dotted #000000;
   }
 }
 
-.emotion-16 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.25rem;
-  line-height: 1.15;
-  font-weight: 700;
-  margin: 0;
-  grid-column: 2;
-  grid-row: 1;
-}
-
-@media (min-width: 660px) {
-  .emotion-16 {
-    grid-column: 1;
+@media (min-width: 740px) {
+  .emotion-13 {
+    border-right: 1px dotted #000000;
   }
 }
 
-.emotion-17 {
+.emotion-14 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 2.625rem;
   line-height: 1.15;
   font-weight: 700;
-  grid-column: 1;
-  grid-row: 1/3;
-  margin-right: 1rem;
+  margin-right: 0.5rem;
 }
 
-@media (min-width: 660px) {
-  .emotion-17 {
-    grid-column: 2;
-  }
-}
-
-.emotion-18 {
+.emotion-15 {
   border: 1px solid #000000;
   border-radius: 100%;
   display: block;
@@ -9686,13 +9673,21 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   position: relative;
 }
 
-.emotion-19 {
+.emotion-16 {
   position: absolute;
   top: 7%;
   left: 29%;
 }
 
-.emotion-20 {
+.emotion-18 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+  margin: 0;
+}
+
+.emotion-19 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.9375rem;
   line-height: 1.5;
@@ -9700,57 +9695,74 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-  grid-column: 2;
-  grid-row: 2;
 }
 
-@media (min-width: 660px) {
-  .emotion-20 {
+@media (min-width: 740px) {
+  .emotion-19 {
     grid-column: 1;
   }
 }
 
-.emotion-21 {
-  display: grid;
-  grid-template-columns: auto 1fr;
+.emotion-20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   border-top: 1px dotted #000000;
   padding-top: 0.25rem;
   margin-top: 0.75rem;
   box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 @media (min-width: 660px) {
-  .emotion-21 {
-    display: inline-grid;
+  .emotion-20 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
     width: 50%;
     vertical-align: top;
-    grid-template-columns: 1fr auto;
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
   }
 }
 
-.emotion-22 {
-  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
-  font-size: 1.25rem;
-  line-height: 1.15;
-  font-weight: 700;
-  margin: 0;
-  grid-column: 2;
-  grid-row: 1;
+@media (min-width: 740px) {
+  .emotion-20 {
+    border-right: 1px dotted #000000;
+  }
 }
 
-.emotion-23 {
+.emotion-21 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 2.625rem;
   line-height: 1.15;
   font-weight: 700;
-  grid-column: 1;
-  grid-row: 1/3;
-  margin-right: 1rem;
+  margin-right: 0.5rem;
 }
 
 @media (min-width: 660px) {
-  .emotion-23 {
-    margin-left: 1rem;
+  .emotion-21 {
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width: 660px) {
+  .emotion-24 {
+    margin-left: 0.5rem;
   }
 }
 
@@ -9762,8 +9774,6 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-  grid-column: 2;
-  grid-row: 2;
 }
 
 .emotion-27 {
@@ -10263,100 +10273,98 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
                   <div
                     className="emotion-10"
                   >
-                    <span
-                      className="emotion-11"
-                    >
-                      FT
-                    </span>
-                  </div>
-                  <div
-                    className="emotion-12"
-                  >
                     <nav
-                      className="emotion-13"
+                      className="emotion-11"
                     >
                       Premier League
                     </nav>
-                    <address
-                      className="emotion-14"
-                    >
-                      The King Power Stadium
-                    </address>
                   </div>
                 </div>
-                <section
-                  className="emotion-15"
+                <div
+                  className="emotion-12"
                 >
-                  <h3
-                    className="emotion-16"
-                  >
-                    Leicester
-                  </h3>
-                  <div
-                    className="emotion-17"
+                  <section
+                    className="emotion-13"
                   >
                     <div
-                      className="emotion-18"
+                      className="emotion-14"
                     >
-                      <span
+                      <div
+                        className="emotion-15"
+                      >
+                        <span
+                          className="emotion-16"
+                        >
+                          2
+                        </span>
+                      </div>
+                    </div>
+                    <div
+                      className="emotion-17"
+                    >
+                      <h3
+                        className="emotion-18"
+                      >
+                        Leicester
+                      </h3>
+                      <ul
                         className="emotion-19"
                       >
-                        2
-                      </span>
+                        <li>
+                          Castagne
+                           
+                          50
+                          '
+                           
+                        </li>
+                        <li>
+                          Iheanacho
+                           
+                          80
+                          '
+                           
+                        </li>
+                      </ul>
                     </div>
-                  </div>
-                  <ul
+                  </section>
+                  <section
                     className="emotion-20"
                   >
-                    <li>
-                      Castagne
-                       
-                      50
-                      '
-                       
-                    </li>
-                    <li>
-                      Iheanacho
-                       
-                      80
-                      '
-                       
-                    </li>
-                  </ul>
-                </section>
-                <section
-                  className="emotion-21"
-                >
-                  <h3
-                    className="emotion-22"
-                  >
-                    Crystal Palace
-                  </h3>
-                  <div
-                    className="emotion-23"
-                  >
                     <div
-                      className="emotion-18"
+                      className="emotion-21"
                     >
-                      <span
-                        className="emotion-19"
+                      <div
+                        className="emotion-15"
                       >
-                        1
-                      </span>
+                        <span
+                          className="emotion-16"
+                        >
+                          1
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <ul
-                    className="emotion-26"
-                  >
-                    <li>
-                      Zaha
-                       
-                      12
-                      '
-                       
-                    </li>
-                  </ul>
-                </section>
+                    <div
+                      className="emotion-24"
+                    >
+                      <h3
+                        className="emotion-18"
+                      >
+                        Crystal Palace
+                      </h3>
+                      <ul
+                        className="emotion-26"
+                      >
+                        <li>
+                          Zaha
+                           
+                          12
+                          '
+                           
+                        </li>
+                      </ul>
+                    </div>
+                  </section>
+                </div>
               </section>
             </div>
             <picture>
@@ -13950,6 +13958,315 @@ exports[`Storyshots Editions/Byline Showcase 1`] = `
     </button>
   </span>
 </div>
+`;
+
+exports[`Storyshots Editions/FootballScores Default 1`] = `
+.emotion-0 {
+  background-color: #FFE500;
+  padding: 0.5rem;
+}
+
+@media (min-width: 740px) {
+  .emotion-0 {
+    width: 531px;
+    padding-right: 0;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-0 {
+    width: 550px;
+  }
+}
+
+.emotion-1 {
+  text-indent: -10000px;
+  position: absolute;
+  margin: 0;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+}
+
+@media (min-width: 660px) {
+  .emotion-2 {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.emotion-3 {
+  grid-column: 2;
+}
+
+@media (min-width: 660px) {
+  .emotion-3 {
+    grid-column: 1;
+  }
+}
+
+.emotion-4 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+}
+
+@media (min-width: 660px) {
+  .emotion-5 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  border-top: 1px dotted #000000;
+  padding-top: 0.25rem;
+  margin-top: 0.75rem;
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+@media (min-width: 660px) {
+  .emotion-6 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 50%;
+    vertical-align: top;
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
+    border-right: 1px dotted #000000;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-6 {
+    border-right: 1px dotted #000000;
+  }
+}
+
+.emotion-7 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  margin-right: 0.5rem;
+}
+
+.emotion-8 {
+  border: 1px solid #000000;
+  border-radius: 100%;
+  display: block;
+  width: 1.5em;
+  height: 1.5em;
+  position: relative;
+}
+
+.emotion-9 {
+  position: absolute;
+  top: 7%;
+  left: 29%;
+}
+
+.emotion-11 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+  margin: 0;
+}
+
+.emotion-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  border-top: 1px dotted #000000;
+  padding-top: 0.25rem;
+  margin-top: 0.75rem;
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+@media (min-width: 660px) {
+  .emotion-12 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 50%;
+    vertical-align: top;
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-12 {
+    border-right: 1px dotted #000000;
+  }
+}
+
+.emotion-13 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 2.625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  margin-right: 0.5rem;
+}
+
+@media (min-width: 660px) {
+  .emotion-13 {
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width: 660px) {
+  .emotion-16 {
+    margin-left: 0.5rem;
+  }
+}
+
+.emotion-18 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+<section
+  className="emotion-0"
+>
+  <h2
+    className="emotion-1"
+  >
+    Scores
+  </h2>
+  <div
+    className="emotion-2"
+  >
+    <div
+      className="emotion-3"
+    >
+      <nav
+        className="emotion-4"
+      >
+        Premier League
+      </nav>
+    </div>
+  </div>
+  <div
+    className="emotion-5"
+  >
+    <section
+      className="emotion-6"
+    >
+      <div
+        className="emotion-7"
+      >
+        <div
+          className="emotion-8"
+        >
+          <span
+            className="emotion-9"
+          >
+            0
+          </span>
+        </div>
+      </div>
+      <div
+        className="emotion-10"
+      >
+        <h3
+          className="emotion-11"
+        >
+          Arsenal
+        </h3>
+      </div>
+    </section>
+    <section
+      className="emotion-12"
+    >
+      <div
+        className="emotion-13"
+      >
+        <div
+          className="emotion-8"
+        >
+          <span
+            className="emotion-9"
+          >
+            2
+          </span>
+        </div>
+      </div>
+      <div
+        className="emotion-16"
+      >
+        <h3
+          className="emotion-11"
+        >
+          Man City
+        </h3>
+        <ul
+          className="emotion-18"
+        >
+          <li>
+            Sterling
+             
+            2
+            '
+             
+            .g
+          </li>
+          <li>
+            Aguero
+             
+            30
+            '
+             
+          </li>
+        </ul>
+      </div>
+    </section>
+  </div>
+</section>
 `;
 
 exports[`Storyshots Editions/GalleryImage Default 1`] = `

--- a/src/components/editions/footballScores/footballScores.stories.tsx
+++ b/src/components/editions/footballScores/footballScores.stories.tsx
@@ -1,0 +1,53 @@
+// ----- Imports ----- //
+
+import { text, withKnobs } from '@storybook/addon-knobs';
+import type { FC } from 'react';
+import FootballScores from './index';
+
+// ----- Helpers ----- //
+
+// ----- Stories ----- //
+
+const Default: FC = () => (
+	<FootballScores
+		league={text('League', 'Premier League')}
+		homeTeam={{
+			id: '1006',
+			name: 'Arsenal',
+			shortCode: 'ARS',
+			crestUri:
+				'https://i.guim.co.uk/img/sport/football/crests/1006.png?w=#{width}&h=#{height}&q=#{quality}&fit=bounds&sig-ignores-params=true&s=245ccb3526331f781858849f18e80283',
+			score: 0,
+			scorers: [],
+		}}
+		awayTeam={{
+			id: '11',
+			name: 'Man City',
+			shortCode: 'MNC',
+			crestUri:
+				'https://i.guim.co.uk/img/sport/football/crests/11.png?w=#{width}&h=#{height}&q=#{quality}&fit=bounds&sig-ignores-params=true&s=69570ed9a99d983d2d793a0f9855f205',
+			score: 2,
+			scorers: [
+				{
+					player: 'Sterling',
+					timeInMinutes: 2,
+					additionalInfo: '.g',
+				},
+				{
+					player: 'Aguero',
+					timeInMinutes: 30,
+				},
+			],
+		}}
+	/>
+);
+
+// ----- Exports ----- //
+
+export default {
+	component: FootballScores,
+	title: 'Editions/FootballScores',
+	decorators: [withKnobs],
+};
+
+export { Default };

--- a/src/components/editions/footballScores/index.tsx
+++ b/src/components/editions/footballScores/index.tsx
@@ -1,0 +1,88 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/core';
+import type { FootballTeam } from '@guardian/apps-rendering-api-models/footballTeam';
+import { remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { brandAltBackground } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import { MatchStatusKind, TeamLocation } from 'football';
+import type { FC } from 'react';
+import { tabletContentWidth, wideContentWidth } from '../styles';
+import { TeamScore } from '../teamScore';
+
+// ----- Component ----- //
+
+interface Props {
+	league: string;
+	homeTeam: FootballTeam;
+	awayTeam: FootballTeam;
+}
+
+const styles = css`
+	background-color: ${brandAltBackground.primary};
+	padding: ${remSpace[2]};
+
+	${from.tablet} {
+		width: ${tabletContentWidth + 5}px;
+		padding-right: 0;
+	}
+
+	${from.desktop} {
+		width: ${wideContentWidth + 5}px;
+	}
+`;
+
+const matchInfoStyles = css`
+	display: grid;
+	grid-template-columns: auto 1fr;
+
+	${from.phablet} {
+		grid-template-columns: 1fr 1fr 1fr;
+	}
+`;
+
+const otherMatchStyles = css`
+	grid-column: 2;
+
+	${from.phablet} {
+		grid-column: 1;
+	}
+`;
+
+const scoreStyles = css`
+	${from.phablet} {
+		display: flex;
+	}
+`;
+
+const leagueStyles = css`
+	${textSans.medium({ fontWeight: 'bold' })}
+`;
+
+const titleStyles = css`
+	text-indent: -10000px;
+	position: absolute;
+	margin: 0;
+`;
+
+const FootballScores: FC<Props> = ({ league, homeTeam, awayTeam }) => (
+	<section css={styles}>
+		<h2 css={titleStyles}>Scores</h2>
+		<div css={matchInfoStyles}>
+			<div css={otherMatchStyles}>
+				<nav css={leagueStyles}>{league}</nav>
+			</div>
+		</div>
+		<div css={scoreStyles}>
+			<TeamScore location={TeamLocation.Home} team={homeTeam} />
+			<TeamScore location={TeamLocation.Away} team={awayTeam} />
+		</div>
+	</section>
+);
+
+// ----- Exports ----- //
+
+export { MatchStatusKind };
+
+export default FootballScores;

--- a/src/components/editions/headerMedia/index.tsx
+++ b/src/components/editions/headerMedia/index.tsx
@@ -12,7 +12,6 @@ import HeaderImageCaption, {
 	captionId,
 } from 'components/editions/headerImageCaption';
 import StarRating from 'components/editions/starRating';
-import FootballScores from 'components/footballScores';
 import { MainMediaKind } from 'headerMedia';
 import type { Image } from 'image';
 import type { Item } from 'item';
@@ -20,6 +19,7 @@ import { getFormat } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
+import FootballScores from '../footballScores';
 import { wideImageWidth } from '../styles';
 import Video from '../video';
 
@@ -152,10 +152,8 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 							<div css={footballWrapperStyles}>
 								<FootballScores
 									league={scores.league}
-									stadium={scores.stadium}
 									homeTeam={scores.homeTeam}
 									awayTeam={scores.awayTeam}
-									status={scores.status}
 								/>
 							</div>
 						);

--- a/src/components/editions/teamScore/index.tsx
+++ b/src/components/editions/teamScore/index.tsx
@@ -1,0 +1,112 @@
+import type { SerializedStyles } from '@emotion/core';
+import { css } from '@emotion/core';
+import type { FootballTeam } from '@guardian/apps-rendering-api-models/footballTeam';
+import { remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { neutral } from '@guardian/src-foundations/palette';
+import { headline, textSans } from '@guardian/src-foundations/typography';
+import { TeamLocation } from 'football';
+import type { FC } from 'react';
+
+interface Props {
+	team: FootballTeam;
+	location: TeamLocation;
+}
+
+const styles = (location: TeamLocation): SerializedStyles => css`
+	display: flex;
+	flex-direction: row;
+	border-top: 1px dotted ${neutral[0]};
+	padding-top: ${remSpace[1]};
+	margin-top: ${remSpace[3]};
+	box-sizing: border-box;
+	flex: 1;
+
+	${from.phablet} {
+		display: flex;
+		width: 50%;
+		vertical-align: top;
+		flex: 1;
+		flex-direction: column-reverse;
+		justify-content: space-between;
+
+		${location === TeamLocation.Home
+			? `border-right: 1px dotted ${neutral[0]};`
+			: ''};
+	}
+
+	${from.tablet} {
+		border-right: 1px dotted ${neutral[0]};
+	}
+`;
+
+const teamNameStyles = css`
+	${headline.xxsmall({ fontWeight: 'bold' })}
+	margin: 0;
+`;
+
+const scoreStyles = (location: TeamLocation): SerializedStyles => css`
+	${headline.large({ fontWeight: 'bold' })}
+	margin-right: ${remSpace[2]};
+
+	${from.phablet} {
+		${location === TeamLocation.Away ? `margin-left: ${remSpace[2]};` : ''}
+	}
+`;
+
+const scoreNumberStyles = css`
+	border: 1px solid ${neutral[0]};
+	border-radius: 100%;
+	display: block;
+	width: 1.5em;
+	height: 1.5em;
+	position: relative;
+`;
+
+const scoreInlineStyles = css`
+	position: absolute;
+	top: 7%;
+	left: 29%;
+`;
+
+const infoStyles = (location: TeamLocation): SerializedStyles => css`
+	${from.phablet} {
+		${location === TeamLocation.Away ? `margin-left: ${remSpace[2]};` : ''}
+	}
+`;
+
+const scorerStyles = (location: TeamLocation): SerializedStyles => css`
+	${textSans.small()}
+	list-style: none;
+	margin: 0;
+	padding: 0;
+
+	${from.tablet} {
+		${location === TeamLocation.Home ? 'grid-column: 1;' : ''}
+	}
+`;
+
+const TeamScore: FC<Props> = ({ team, location }) => (
+	<section css={styles(location)}>
+		<div css={scoreStyles(location)}>
+			<div css={scoreNumberStyles}>
+				<span css={scoreInlineStyles}>{team.score}</span>
+			</div>
+		</div>
+		<div css={infoStyles(location)}>
+			<h3 css={teamNameStyles}>{team.name}</h3>
+			{team.scorers.length > 0 && (
+				<ul css={scorerStyles(location)}>
+					{team.scorers.map((scorer) => (
+						<li key={`${scorer.player}`}>
+							{scorer.player} {scorer.timeInMinutes}&apos;{' '}
+							{scorer.additionalInfo}
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	</section>
+);
+
+export { TeamScore };

--- a/src/components/genericEmbed.tsx
+++ b/src/components/genericEmbed.tsx
@@ -30,19 +30,22 @@ interface Props {
 	embed: Generic;
 }
 
-const GenericEmbed: FC<Props> = ({ embed }) => (
-	<figure css={styles}>
-		<iframe
-			srcDoc={embed.html}
-			title={withDefault('Embed')(embed.alt)}
-			// Prevents scrollbars: covers body margin and random extra 6px
-			height={embed.height + 22}
-		/>
-		{maybeRender(embed.alt, (alt) => (
-			<figcaption css={captionStyles}>{alt}</figcaption>
-		))}
-	</figure>
-);
+const GenericEmbed: FC<Props> = ({ embed }) => {
+	console.log(embed);
+	return (
+		<figure css={styles}>
+			<iframe
+				srcDoc={embed.html}
+				title={withDefault('Embed')(embed.alt)}
+				// Prevents scrollbars: covers body margin and random extra 6px
+				height={embed.height + 22}
+			/>
+			{maybeRender(embed.alt, (alt) => (
+				<figcaption css={captionStyles}>{alt}</figcaption>
+			))}
+		</figure>
+	);
+};
 
 // ----- Exports ----- //
 

--- a/src/components/genericEmbed.tsx
+++ b/src/components/genericEmbed.tsx
@@ -30,22 +30,19 @@ interface Props {
 	embed: Generic;
 }
 
-const GenericEmbed: FC<Props> = ({ embed }) => {
-	console.log(embed);
-	return (
-		<figure css={styles}>
-			<iframe
-				srcDoc={embed.html}
-				title={withDefault('Embed')(embed.alt)}
-				// Prevents scrollbars: covers body margin and random extra 6px
-				height={embed.height + 22}
-			/>
-			{maybeRender(embed.alt, (alt) => (
-				<figcaption css={captionStyles}>{alt}</figcaption>
-			))}
-		</figure>
-	);
-};
+const GenericEmbed: FC<Props> = ({ embed }) => (
+	<figure css={styles}>
+		<iframe
+			srcDoc={embed.html}
+			title={withDefault('Embed')(embed.alt)}
+			// Prevents scrollbars: covers body margin and random extra 6px
+			height={embed.height + 22}
+		/>
+		{maybeRender(embed.alt, (alt) => (
+			<figcaption css={captionStyles}>{alt}</figcaption>
+		))}
+	</figure>
+);
 
 // ----- Exports ----- //
 


### PR DESCRIPTION
## Why are you doing this?

We've recently added the `FootballScores` component to the Editions match report header. This PR creates new Editions specific `FootballScores` components in order to accommodate the different layouts.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/117038494-9ae0e500-acff-11eb-8445-e2635745e628.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/117038540-a8966a80-acff-11eb-8b40-717261eaad8c.png" width="300px" /> |
