### PR TITLE
Raised Chromatic Diff Threshold For Article Stories

### DIFF
--- a/src/components/editions/article/article.stories.tsx
+++ b/src/components/editions/article/article.stories.tsx
@@ -161,7 +161,10 @@ export default {
 	component: Article,
 	title: 'Editions/Article',
 	decorators: [withKnobs],
-	parameters: { layout: 'fullscreen' },
+	parameters: {
+		layout: 'fullscreen',
+		chromatic: { diffThreshold: 0.25 },
+	},
 };
 
 export {


### PR DESCRIPTION
## Why are you doing this?

Chromatic's visual diff is repeatedly reporting changes to the article components. However this difference is actually down to small changes in how images are rendered between screenshots.

It's possible to reduce the sensitivity of this visual diff using the [`diffThreshold` parameter](https://www.chromatic.com/docs/threshold) (as seen in https://github.com/guardian/image-rendering/pull/137), which is what this PR does.

## Changes

- Updated the `diffThreshold` for the article stories to make the visual diff less sensitive
