### PR TITLE
Hide Empty Related Content

### DIFF
--- a/src/components/shared/relatedContent.tsx
+++ b/src/components/shared/relatedContent.tsx
@@ -43,6 +43,10 @@ const RelatedContent: FC<Props> = ({ content }) => {
 	return pipe2(
 		content,
 		map(({ title, relatedItems, resizedImages }) => {
+			if (relatedItems.length === 0) {
+				return null;
+			}
+
 			return (
 				<section>
 					<h2 css={headingStyles}>{title}</h2>


### PR DESCRIPTION
## Why are you doing this?

If there isn't any related content then we don't want to show the "Related content" header, because there won't be anything below it.

## Changes

- Don't render the related content element if the list of content is empty

## Screenshots

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/53781962/117292267-e7dfcb00-ae67-11eb-977a-90a54b01029d.jpg) | ![after](https://user-images.githubusercontent.com/53781962/117292276-ea422500-ae67-11eb-8a1f-366de0c0731a.jpg) |
