### PR TITLE
Use Dotcom Links For Related Comment Cards

### DIFF
--- a/src/components/shared/bylineCard.tsx
+++ b/src/components/shared/bylineCard.tsx
@@ -190,17 +190,16 @@ const BylineCard: FC<Props> = ({ relatedItem }) => {
 	};
 
 	const img = cardImage(relatedItem);
-	const articleId = link.slice(1);
 	const date = lastModified
 		? relativeFirstPublished(fromNullable(new Date(lastModified.iso8601)))
 		: null;
 	return (
 		<li
 			className="js-card"
-			data-article-id={articleId}
+			data-article-id={link}
 			css={[listStyles(format), cardStyles]}
 		>
-			<a css={anchorStyles} href={relatedItem.link}>
+			<a css={anchorStyles} href={`https://theguardian.com/${link}`}>
 				<section css={headingWrapperStyles}>
 					<h3 css={headingStyles}>
 						<span css={commentIconStyle}>


### PR DESCRIPTION
## Why are you doing this?

An oversight in #1284 meant that "Comment" variations of the related content cards weren't updated to use dotcom links (because they live in a separate component). This remedies that.

## Changes

- Also use dotcom links for comment cards
