### PR TITLE
Use `image-rendering` For Related Content Cards

### DIFF
--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -2,7 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
-import { breakpoints, palette, remSpace } from '@guardian/src-foundations';
+import { palette, remSpace } from '@guardian/src-foundations';
 import {
 	background,
 	neutral,
@@ -16,11 +16,12 @@ import {
 	Display,
 	fromNullable,
 	map,
+	none,
 	OptionKind,
 	withDefault,
 } from '@guardian/types';
 import type { Format, Option } from '@guardian/types';
-import Img from 'components/img';
+import { Img } from '@guardian/image-rendering';
 import { stars } from 'components/starRating';
 import { formatSeconds, makeRelativeDate } from 'date';
 import { border } from 'editorialPalette';
@@ -372,7 +373,6 @@ const cardImage = (
 	image: Option<Image>,
 	relatedItem: RelatedItem,
 ): ReactElement | null => {
-	const sizes = `(min-width: ${breakpoints.phablet}px) 620px, 100%`;
 	const format = {
 		theme: themeFromString(relatedItem.pillar.id),
 		design: Design.Article,
@@ -384,7 +384,17 @@ const cardImage = (
 		map((img) => {
 			return (
 				<div css={[fullWidthImage, imageWrapperStyles]}>
-					<Img image={img} sizes={sizes} format={format} />
+					<Img
+						image={img}
+						sizes={{
+							mediaQueries: [{ breakpoint: 'phablet', size: '620px' }],
+							default: '100%',
+						}}
+						format={format}
+						className={none}
+						supportsDarkMode
+						lightbox={none}
+					/>
 				</div>
 			);
 		}),


### PR DESCRIPTION
## Why are you doing this?

Related content cards were using the old way of rendering images, which had the side-effect of including them in the lightbox. This switches them over to using `image-rendering`.

## Changes

- Used image-rendering for related content cards
