### PR TITLE
LIVE-2368: add new EmailSignup embed type

### DIFF
--- a/src/components/embed.tsx
+++ b/src/components/embed.tsx
@@ -44,6 +44,9 @@ const EmbedComponent: FC<Props> = ({ embed, editions }) => {
 				<Instagram id={embed.id} caption={embed.caption} />
 			) : null;
 
+		case EmbedKind.EmailSignup:
+			return !editions ? <GenericEmbed embed={embed} /> : null;
+
 		case EmbedKind.Generic:
 			return <GenericEmbed embed={embed} />;
 

--- a/src/components/embedWrapper.tsx
+++ b/src/components/embedWrapper.tsx
@@ -70,6 +70,30 @@ const embedToDivProps = (embed: Embed): Record<string, string> => {
 				...(embed.tracking && { tracking: embed.tracking.toString() }),
 			};
 		}
+		case EmbedKind.EmailSignup: {
+			return {
+				kind: EmbedKind.EmailSignup,
+				...withDefault({})(
+					map<string, Record<string, string>>((alt) => {
+						return { alt };
+					})(embed.alt),
+				),
+				html: embed.html,
+				height: embed.height.toString(),
+				...(embed.mandatory && { mandatory: 'true' }),
+				...pipe2(
+					embed.source,
+					map((source) => ({ source })),
+					withDefault<Record<string, string>>({}),
+				),
+				...pipe2(
+					embed.sourceDomain,
+					map((sourceDomain) => ({ sourceDomain })),
+					withDefault<Record<string, string>>({}),
+				),
+				...(embed.tracking && { tracking: embed.tracking.toString() }),
+			};
+		}
 		case EmbedKind.Instagram: {
 			return {
 				kind: EmbedKind.Instagram,
@@ -211,7 +235,8 @@ const divElementPropsToEmbedComponentProps = (
 							)(requiredStringParam(elementProps, 'id'))(
 								requiredNumberParam(elementProps, 'width'),
 							)(requiredNumberParam(elementProps, 'height'));
-						case EmbedKind.Generic: {
+						case EmbedKind.Generic:
+						case EmbedKind.EmailSignup: {
 							return resultMap2<string, number, Generic>(
 								(html: string, height: number): Generic => ({
 									kind: EmbedKind.Generic,
@@ -299,6 +324,7 @@ const getSourceDetailsForEmbed = (embed: Embed): SourceDetails => {
 				sourceDomain: some('www.spotify.com'),
 			};
 		case EmbedKind.Generic:
+		case EmbedKind.EmailSignup:
 			return {
 				source: embed.source,
 				sourceDomain: embed.sourceDomain,

--- a/src/components/genericEmbed.tsx
+++ b/src/components/genericEmbed.tsx
@@ -5,7 +5,7 @@ import { remSpace } from '@guardian/src-foundations';
 import { text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { withDefault } from '@guardian/types';
-import type { Generic } from 'embed';
+import type { EmailSignup, Generic } from 'embed';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
@@ -27,7 +27,7 @@ const captionStyles = css`
 `;
 
 interface Props {
-	embed: Generic;
+	embed: Generic | EmailSignup;
 }
 
 const GenericEmbed: FC<Props> = ({ embed }) => (


### PR DESCRIPTION
## Why are you doing this?

Editions was rendering email-signups as generic embeds. We don't want email-signups in Editions but we need to keep generic embeds - this PR separates out email signups into their own embed type so we can mute them in Editions.

## Changes

- add `EmailSignup` type to `Embeds`
- parse generic embed html to check if iframe `data-component` attribute contains `email-embed`
- mute `EmailSignup` embeds in Editions.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/117332347-9f3c0800-ae8f-11eb-998a-eb679d7bbecb.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/117332399-b24ed800-ae8f-11eb-8402-bb0acc91517c.png" width="300px" /> |

