### PR TITLE
LIVE-2394: add conditional

### DIFF
--- a/src/components/editions/teamScore/index.tsx
+++ b/src/components/editions/teamScore/index.tsx
@@ -95,7 +95,8 @@ const TeamScore: FC<Props> = ({ team, location }) => (
 		</div>
 		<div css={infoStyles(location)}>
 			<h3 css={teamNameStyles}>{team.name}</h3>
-			{team.scorers.length > 0 && (
+			{/* eslint-disable-next-line -- value can be null */}
+			{team.scorers?.length > 0 && (
 				<ul css={scorerStyles(location)}>
 					{team.scorers.map((scorer) => (
 						<li key={`${scorer.player}`}>

--- a/src/components/teamScore.tsx
+++ b/src/components/teamScore.tsx
@@ -92,7 +92,8 @@ const TeamScore: FC<Props> = ({ team, location }) => (
 				<span css={scoreInlineStyles}>{team.score}</span>
 			</div>
 		</div>
-		{team.scorers.length > 0 && (
+		{/* eslint-disable-next-line -- value can be null */}
+		{team.scorers?.length > 0 && (
 			<ul css={scorerStyles(location)}>
 				{team.scorers.map((scorer) => (
 					<li key={`${scorer.player}`}>


### PR DESCRIPTION
## Why are you doing this?

The`FootballScore` component crashes if we have an empty `scores` field. This PR guards against that, and disables eslint for the relevant lines.

** Ideally we should probably change the types but this is a fix in the meantime
