### PR TITLE
Xenial To Bionic AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       amiEncrypted: true
       amiTags:
-        Recipe: xenial-mobile-node-ARM
+        Recipe: bionic-mobile-node-ARM
         AmigoStage: PROD
       templatePath: cloudformation.yaml
   mobile-apps-rendering:


### PR DESCRIPTION
## Why are you doing this?

Xenial is near EOL, and AR is refusing to boot on the latest bake of this AMI. We're bumping to Bionic to see if that fixes things.

## Changes

- Migrate from ubuntu xenial to bionic AMI
