### PR TITLE
LIVE-2395: add tiktok to embed types 

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -16295,124 +16295,17 @@ exports[`Storyshots Editions/Video Default 1`] = `
 
 exports[`Storyshots EmbedComponentWrapper Generic 1`] = `
 .emotion-0 {
-  width: 100%;
-  background: #F6F6F6;
-  border: 1px solid #DCDCDC;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  padding: 0.25rem 1.5rem 0.75rem;
-  margin-bottom: 0.75rem;
-  box-sizing: border-box;
-}
-
-.emotion-1 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.25rem;
-  line-height: 1.35;
-  font-weight: 700;
-  margin-bottom: 0.25rem;
-}
-
-.emotion-2 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.35;
-  font-weight: 400;
-  margin: 0px;
-}
-
-.emotion-3 {
-  margin-top: 1.25rem;
-}
-
-.emotion-4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  -webkit-transition: .3s ease-in-out;
-  transition: .3s ease-in-out;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  white-space: nowrap;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 700;
-  height: 44px;
-  min-height: 44px;
-  padding: 0 20px;
-  border-radius: 44px;
-  padding-bottom: 2px;
-  background-color: #052962;
-  color: #FFFFFF;
-  -webkit-flex-direction: row-reverse;
-  -ms-flex-direction: row-reverse;
-  flex-direction: row-reverse;
-}
-
-.emotion-4:focus {
-  outline: 0;
-}
-
-html:not(.src-focus-disabled) .emotion-4:focus {
-  box-shadow: 0 0 0 5px #00B2FF;
-}
-
-.emotion-4:hover {
-  background-color: #234B8A;
-}
-
-.emotion-4 svg {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  display: block;
-  fill: currentColor;
-  position: relative;
-  width: 30px;
-  height: auto;
-}
-
-.emotion-4 .src-button-space {
-  width: 12px;
-}
-
-.emotion-4 svg {
-  margin-left: -4px;
-}
-
-.emotion-5 {
   margin: 1rem 0;
 }
 
 @media (prefers-color-scheme: dark) {
-  .emotion-5 {
+  .emotion-0 {
     background: white;
     padding: 0.5rem;
   }
 }
 
-.emotion-6 {
+.emotion-1 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.875rem;
   line-height: 1.5;
@@ -16435,59 +16328,12 @@ html:not(.src-focus-disabled) .emotion-4:focus {
     data-source="Spotify"
     data-source-domain="embed.spotify.com"
     data-tracking="1"
-  >
-    <div
-      className="emotion-0"
-    >
-      <div
-        className="emotion-1"
-      >
-        Allow Spotify content?
-      </div>
-      <p
-        className="emotion-2"
-      >
-        This article includes content provided by
-         
-        Spotify
-        . We ask for your permission before anything is loaded, as they may be using cookies and other technologies. To view this content,
-         
-        <strong>
-          click 'Allow and continue'
-        </strong>
-        .
-      </p>
-      <div
-        className="emotion-3"
-      >
-        <button
-          className="emotion-4"
-          onClick={[Function]}
-          type="button"
-        >
-          Allow and continue
-          <div
-            className="src-button-space"
-          />
-          <svg
-            viewBox="0 0 30 30"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clipRule="evenodd"
-              d="M6 14.775l-1 1 5 7h.475l14.3-14.8-1-.975-13.3 12.05L6 14.775z"
-              fillRule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-  </div>
+  />
   <p>
     This is an example of the embed wrapper rendering a Spotify 'Generic' embed.
   </p>
   <figure
-    className="emotion-5"
+    className="emotion-0"
   >
     <iframe
       height={502}
@@ -16495,7 +16341,7 @@ html:not(.src-focus-disabled) .emotion-4:focus {
       title="Lemmy"
     />
     <figcaption
-      className="emotion-6"
+      className="emotion-1"
     >
       Lemmy
     </figcaption>
@@ -16504,113 +16350,6 @@ html:not(.src-focus-disabled) .emotion-4:focus {
 `;
 
 exports[`Storyshots EmbedComponentWrapper Instagram 1`] = `
-.emotion-0 {
-  width: 100%;
-  background: #F6F6F6;
-  border: 1px solid #DCDCDC;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  padding: 0.25rem 1.5rem 0.75rem;
-  margin-bottom: 0.75rem;
-  box-sizing: border-box;
-}
-
-.emotion-1 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.25rem;
-  line-height: 1.35;
-  font-weight: 700;
-  margin-bottom: 0.25rem;
-}
-
-.emotion-2 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.35;
-  font-weight: 400;
-  margin: 0px;
-}
-
-.emotion-3 {
-  margin-top: 1.25rem;
-}
-
-.emotion-4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  -webkit-transition: .3s ease-in-out;
-  transition: .3s ease-in-out;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  white-space: nowrap;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 700;
-  height: 44px;
-  min-height: 44px;
-  padding: 0 20px;
-  border-radius: 44px;
-  padding-bottom: 2px;
-  background-color: #052962;
-  color: #FFFFFF;
-  -webkit-flex-direction: row-reverse;
-  -ms-flex-direction: row-reverse;
-  flex-direction: row-reverse;
-}
-
-.emotion-4:focus {
-  outline: 0;
-}
-
-html:not(.src-focus-disabled) .emotion-4:focus {
-  box-shadow: 0 0 0 5px #00B2FF;
-}
-
-.emotion-4:hover {
-  background-color: #234B8A;
-}
-
-.emotion-4 svg {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  display: block;
-  fill: currentColor;
-  position: relative;
-  width: 30px;
-  height: auto;
-}
-
-.emotion-4 .src-button-space {
-  width: 12px;
-}
-
-.emotion-4 svg {
-  margin-left: -4px;
-}
-
 <div>
   <p>
     This is an example of the embed wrapper rendering a instagram 'Instagram' embed overlay.
@@ -16622,54 +16361,7 @@ html:not(.src-focus-disabled) .emotion-4:focus {
     data-id="BwwONCplEyj"
     data-kind="Instagram"
     data-tracking="1"
-  >
-    <div
-      className="emotion-0"
-    >
-      <div
-        className="emotion-1"
-      >
-        Allow Instagram content?
-      </div>
-      <p
-        className="emotion-2"
-      >
-        This article includes content provided by
-         
-        Instagram
-        . We ask for your permission before anything is loaded, as they may be using cookies and other technologies. To view this content,
-         
-        <strong>
-          click 'Allow and continue'
-        </strong>
-        .
-      </p>
-      <div
-        className="emotion-3"
-      >
-        <button
-          className="emotion-4"
-          onClick={[Function]}
-          type="button"
-        >
-          Allow and continue
-          <div
-            className="src-button-space"
-          />
-          <svg
-            viewBox="0 0 30 30"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clipRule="evenodd"
-              d="M6 14.775l-1 1 5 7h.475l14.3-14.8-1-.975-13.3 12.05L6 14.775z"
-              fillRule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-  </div>
+  />
   <p>
     This is an example of the embed wrapper rendering a instagram 'Instagram' embed overlay.
   </p>
@@ -16683,113 +16375,6 @@ html:not(.src-focus-disabled) .emotion-4:focus {
 
 exports[`Storyshots EmbedComponentWrapper Spotify 1`] = `
 .emotion-0 {
-  width: 100%;
-  background: #F6F6F6;
-  border: 1px solid #DCDCDC;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  padding: 0.25rem 1.5rem 0.75rem;
-  margin-bottom: 0.75rem;
-  box-sizing: border-box;
-}
-
-.emotion-1 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.25rem;
-  line-height: 1.35;
-  font-weight: 700;
-  margin-bottom: 0.25rem;
-}
-
-.emotion-2 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.35;
-  font-weight: 400;
-  margin: 0px;
-}
-
-.emotion-3 {
-  margin-top: 1.25rem;
-}
-
-.emotion-4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  -webkit-transition: .3s ease-in-out;
-  transition: .3s ease-in-out;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  white-space: nowrap;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 700;
-  height: 44px;
-  min-height: 44px;
-  padding: 0 20px;
-  border-radius: 44px;
-  padding-bottom: 2px;
-  background-color: #052962;
-  color: #FFFFFF;
-  -webkit-flex-direction: row-reverse;
-  -ms-flex-direction: row-reverse;
-  flex-direction: row-reverse;
-}
-
-.emotion-4:focus {
-  outline: 0;
-}
-
-html:not(.src-focus-disabled) .emotion-4:focus {
-  box-shadow: 0 0 0 5px #00B2FF;
-}
-
-.emotion-4:hover {
-  background-color: #234B8A;
-}
-
-.emotion-4 svg {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  display: block;
-  fill: currentColor;
-  position: relative;
-  width: 30px;
-  height: auto;
-}
-
-.emotion-4 .src-button-space {
-  width: 12px;
-}
-
-.emotion-4 svg {
-  margin-left: -4px;
-}
-
-.emotion-5 {
   border: none;
 }
 
@@ -16805,59 +16390,12 @@ html:not(.src-focus-disabled) .emotion-4:focus {
     data-src="https://embed.spotify.com/?uri=spotify:album:1PULmKbHeOqlkIwcDMNwD4"
     data-tracking="1"
     data-width="300"
-  >
-    <div
-      className="emotion-0"
-    >
-      <div
-        className="emotion-1"
-      >
-        Allow Spotify content?
-      </div>
-      <p
-        className="emotion-2"
-      >
-        This article includes content provided by
-         
-        Spotify
-        . We ask for your permission before anything is loaded, as they may be using cookies and other technologies. To view this content,
-         
-        <strong>
-          click 'Allow and continue'
-        </strong>
-        .
-      </p>
-      <div
-        className="emotion-3"
-      >
-        <button
-          className="emotion-4"
-          onClick={[Function]}
-          type="button"
-        >
-          Allow and continue
-          <div
-            className="src-button-space"
-          />
-          <svg
-            viewBox="0 0 30 30"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clipRule="evenodd"
-              d="M6 14.775l-1 1 5 7h.475l14.3-14.8-1-.975-13.3 12.05L6 14.775z"
-              fillRule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-  </div>
+  />
   <p>
     This is an example of the embed wrapper rendering a spotify 'Spotify' embed.
   </p>
   <iframe
-    className="emotion-5"
+    className="emotion-0"
     height={380}
     sandbox="allow-scripts"
     src="https://embed.spotify.com/?uri=spotify:user:juderogers:playlist:5FTUcQhfk54BZwcdiwE1QY"
@@ -16869,113 +16407,6 @@ html:not(.src-focus-disabled) .emotion-4:focus {
 
 exports[`Storyshots EmbedComponentWrapper Youtube 1`] = `
 .emotion-0 {
-  width: 100%;
-  background: #F6F6F6;
-  border: 1px solid #DCDCDC;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  padding: 0.25rem 1.5rem 0.75rem;
-  margin-bottom: 0.75rem;
-  box-sizing: border-box;
-}
-
-.emotion-1 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.25rem;
-  line-height: 1.35;
-  font-weight: 700;
-  margin-bottom: 0.25rem;
-}
-
-.emotion-2 {
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.35;
-  font-weight: 400;
-  margin: 0px;
-}
-
-.emotion-3 {
-  margin-top: 1.25rem;
-}
-
-.emotion-4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  -webkit-transition: .3s ease-in-out;
-  transition: .3s ease-in-out;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  white-space: nowrap;
-  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 1.0625rem;
-  line-height: 1.5;
-  font-weight: 700;
-  height: 44px;
-  min-height: 44px;
-  padding: 0 20px;
-  border-radius: 44px;
-  padding-bottom: 2px;
-  background-color: #052962;
-  color: #FFFFFF;
-  -webkit-flex-direction: row-reverse;
-  -ms-flex-direction: row-reverse;
-  flex-direction: row-reverse;
-}
-
-.emotion-4:focus {
-  outline: 0;
-}
-
-html:not(.src-focus-disabled) .emotion-4:focus {
-  box-shadow: 0 0 0 5px #00B2FF;
-}
-
-.emotion-4:hover {
-  background-color: #234B8A;
-}
-
-.emotion-4 svg {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  display: block;
-  fill: currentColor;
-  position: relative;
-  width: 30px;
-  height: auto;
-}
-
-.emotion-4 .src-button-space {
-  width: 12px;
-}
-
-.emotion-4 svg {
-  margin-left: -4px;
-}
-
-.emotion-5 {
   background: #F6F6F6;
   padding-bottom: 56.25%;
   width: 100%;
@@ -16984,7 +16415,7 @@ html:not(.src-focus-disabled) .emotion-4:focus {
   margin: 1rem 0;
 }
 
-.emotion-5 iframe {
+.emotion-0 iframe {
   border: none;
   width: 100%;
   height: 100%;
@@ -16994,7 +16425,7 @@ html:not(.src-focus-disabled) .emotion-4:focus {
 }
 
 @media (prefers-color-scheme: dark) {
-  .emotion-5 {
+  .emotion-0 {
     color: #999999;
     background-color: #333333;
   }
@@ -17012,59 +16443,12 @@ html:not(.src-focus-disabled) .emotion-4:focus {
     data-kind="YouTube"
     data-tracking="1"
     data-width="460"
-  >
-    <div
-      className="emotion-0"
-    >
-      <div
-        className="emotion-1"
-      >
-        Allow YouTube content?
-      </div>
-      <p
-        className="emotion-2"
-      >
-        This article includes content provided by
-         
-        YouTube
-        . We ask for your permission before anything is loaded, as they may be using cookies and other technologies. To view this content,
-         
-        <strong>
-          click 'Allow and continue'
-        </strong>
-        .
-      </p>
-      <div
-        className="emotion-3"
-      >
-        <button
-          className="emotion-4"
-          onClick={[Function]}
-          type="button"
-        >
-          Allow and continue
-          <div
-            className="src-button-space"
-          />
-          <svg
-            viewBox="0 0 30 30"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              clipRule="evenodd"
-              d="M6 14.775l-1 1 5 7h.475l14.3-14.8-1-.975-13.3 12.05L6 14.775z"
-              fillRule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-  </div>
+  />
   <p>
     This is an example of the embed wrapper rendering a YouTube 'YouTube' embed.
   </p>
   <div
-    className="emotion-5"
+    className="emotion-0"
   >
     <iframe
       allowFullScreen={true}

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -16295,17 +16295,124 @@ exports[`Storyshots Editions/Video Default 1`] = `
 
 exports[`Storyshots EmbedComponentWrapper Generic 1`] = `
 .emotion-0 {
+  width: 100%;
+  background: #F6F6F6;
+  border: 1px solid #DCDCDC;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  padding: 0.25rem 1.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  box-sizing: border-box;
+}
+
+.emotion-1 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.25rem;
+  line-height: 1.35;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.emotion-2 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.35;
+  font-weight: 400;
+  margin: 0px;
+}
+
+.emotion-3 {
+  margin-top: 1.25rem;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  -webkit-transition: .3s ease-in-out;
+  transition: .3s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  height: 44px;
+  min-height: 44px;
+  padding: 0 20px;
+  border-radius: 44px;
+  padding-bottom: 2px;
+  background-color: #052962;
+  color: #FFFFFF;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+}
+
+.emotion-4:focus {
+  outline: 0;
+}
+
+html:not(.src-focus-disabled) .emotion-4:focus {
+  box-shadow: 0 0 0 5px #00B2FF;
+}
+
+.emotion-4:hover {
+  background-color: #234B8A;
+}
+
+.emotion-4 svg {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  display: block;
+  fill: currentColor;
+  position: relative;
+  width: 30px;
+  height: auto;
+}
+
+.emotion-4 .src-button-space {
+  width: 12px;
+}
+
+.emotion-4 svg {
+  margin-left: -4px;
+}
+
+.emotion-5 {
   margin: 1rem 0;
 }
 
 @media (prefers-color-scheme: dark) {
-  .emotion-0 {
+  .emotion-5 {
     background: white;
     padding: 0.5rem;
   }
 }
 
-.emotion-1 {
+.emotion-6 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.875rem;
   line-height: 1.5;
@@ -16328,12 +16435,59 @@ exports[`Storyshots EmbedComponentWrapper Generic 1`] = `
     data-source="Spotify"
     data-source-domain="embed.spotify.com"
     data-tracking="1"
-  />
+  >
+    <div
+      className="emotion-0"
+    >
+      <div
+        className="emotion-1"
+      >
+        Allow Spotify content?
+      </div>
+      <p
+        className="emotion-2"
+      >
+        This article includes content provided by
+         
+        Spotify
+        . We ask for your permission before anything is loaded, as they may be using cookies and other technologies. To view this content,
+         
+        <strong>
+          click 'Allow and continue'
+        </strong>
+        .
+      </p>
+      <div
+        className="emotion-3"
+      >
+        <button
+          className="emotion-4"
+          onClick={[Function]}
+          type="button"
+        >
+          Allow and continue
+          <div
+            className="src-button-space"
+          />
+          <svg
+            viewBox="0 0 30 30"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M6 14.775l-1 1 5 7h.475l14.3-14.8-1-.975-13.3 12.05L6 14.775z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
   <p>
     This is an example of the embed wrapper rendering a Spotify 'Generic' embed.
   </p>
   <figure
-    className="emotion-0"
+    className="emotion-5"
   >
     <iframe
       height={502}
@@ -16341,7 +16495,7 @@ exports[`Storyshots EmbedComponentWrapper Generic 1`] = `
       title="Lemmy"
     />
     <figcaption
-      className="emotion-1"
+      className="emotion-6"
     >
       Lemmy
     </figcaption>
@@ -16350,6 +16504,113 @@ exports[`Storyshots EmbedComponentWrapper Generic 1`] = `
 `;
 
 exports[`Storyshots EmbedComponentWrapper Instagram 1`] = `
+.emotion-0 {
+  width: 100%;
+  background: #F6F6F6;
+  border: 1px solid #DCDCDC;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  padding: 0.25rem 1.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  box-sizing: border-box;
+}
+
+.emotion-1 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.25rem;
+  line-height: 1.35;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.emotion-2 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.35;
+  font-weight: 400;
+  margin: 0px;
+}
+
+.emotion-3 {
+  margin-top: 1.25rem;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  -webkit-transition: .3s ease-in-out;
+  transition: .3s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  height: 44px;
+  min-height: 44px;
+  padding: 0 20px;
+  border-radius: 44px;
+  padding-bottom: 2px;
+  background-color: #052962;
+  color: #FFFFFF;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+}
+
+.emotion-4:focus {
+  outline: 0;
+}
+
+html:not(.src-focus-disabled) .emotion-4:focus {
+  box-shadow: 0 0 0 5px #00B2FF;
+}
+
+.emotion-4:hover {
+  background-color: #234B8A;
+}
+
+.emotion-4 svg {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  display: block;
+  fill: currentColor;
+  position: relative;
+  width: 30px;
+  height: auto;
+}
+
+.emotion-4 .src-button-space {
+  width: 12px;
+}
+
+.emotion-4 svg {
+  margin-left: -4px;
+}
+
 <div>
   <p>
     This is an example of the embed wrapper rendering a instagram 'Instagram' embed overlay.
@@ -16361,7 +16622,54 @@ exports[`Storyshots EmbedComponentWrapper Instagram 1`] = `
     data-id="BwwONCplEyj"
     data-kind="Instagram"
     data-tracking="1"
-  />
+  >
+    <div
+      className="emotion-0"
+    >
+      <div
+        className="emotion-1"
+      >
+        Allow Instagram content?
+      </div>
+      <p
+        className="emotion-2"
+      >
+        This article includes content provided by
+         
+        Instagram
+        . We ask for your permission before anything is loaded, as they may be using cookies and other technologies. To view this content,
+         
+        <strong>
+          click 'Allow and continue'
+        </strong>
+        .
+      </p>
+      <div
+        className="emotion-3"
+      >
+        <button
+          className="emotion-4"
+          onClick={[Function]}
+          type="button"
+        >
+          Allow and continue
+          <div
+            className="src-button-space"
+          />
+          <svg
+            viewBox="0 0 30 30"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M6 14.775l-1 1 5 7h.475l14.3-14.8-1-.975-13.3 12.05L6 14.775z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
   <p>
     This is an example of the embed wrapper rendering a instagram 'Instagram' embed overlay.
   </p>
@@ -16375,6 +16683,113 @@ exports[`Storyshots EmbedComponentWrapper Instagram 1`] = `
 
 exports[`Storyshots EmbedComponentWrapper Spotify 1`] = `
 .emotion-0 {
+  width: 100%;
+  background: #F6F6F6;
+  border: 1px solid #DCDCDC;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  padding: 0.25rem 1.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  box-sizing: border-box;
+}
+
+.emotion-1 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.25rem;
+  line-height: 1.35;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.emotion-2 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.35;
+  font-weight: 400;
+  margin: 0px;
+}
+
+.emotion-3 {
+  margin-top: 1.25rem;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  -webkit-transition: .3s ease-in-out;
+  transition: .3s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  height: 44px;
+  min-height: 44px;
+  padding: 0 20px;
+  border-radius: 44px;
+  padding-bottom: 2px;
+  background-color: #052962;
+  color: #FFFFFF;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+}
+
+.emotion-4:focus {
+  outline: 0;
+}
+
+html:not(.src-focus-disabled) .emotion-4:focus {
+  box-shadow: 0 0 0 5px #00B2FF;
+}
+
+.emotion-4:hover {
+  background-color: #234B8A;
+}
+
+.emotion-4 svg {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  display: block;
+  fill: currentColor;
+  position: relative;
+  width: 30px;
+  height: auto;
+}
+
+.emotion-4 .src-button-space {
+  width: 12px;
+}
+
+.emotion-4 svg {
+  margin-left: -4px;
+}
+
+.emotion-5 {
   border: none;
 }
 
@@ -16390,12 +16805,59 @@ exports[`Storyshots EmbedComponentWrapper Spotify 1`] = `
     data-src="https://embed.spotify.com/?uri=spotify:album:1PULmKbHeOqlkIwcDMNwD4"
     data-tracking="1"
     data-width="300"
-  />
+  >
+    <div
+      className="emotion-0"
+    >
+      <div
+        className="emotion-1"
+      >
+        Allow Spotify content?
+      </div>
+      <p
+        className="emotion-2"
+      >
+        This article includes content provided by
+         
+        Spotify
+        . We ask for your permission before anything is loaded, as they may be using cookies and other technologies. To view this content,
+         
+        <strong>
+          click 'Allow and continue'
+        </strong>
+        .
+      </p>
+      <div
+        className="emotion-3"
+      >
+        <button
+          className="emotion-4"
+          onClick={[Function]}
+          type="button"
+        >
+          Allow and continue
+          <div
+            className="src-button-space"
+          />
+          <svg
+            viewBox="0 0 30 30"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M6 14.775l-1 1 5 7h.475l14.3-14.8-1-.975-13.3 12.05L6 14.775z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
   <p>
     This is an example of the embed wrapper rendering a spotify 'Spotify' embed.
   </p>
   <iframe
-    className="emotion-0"
+    className="emotion-5"
     height={380}
     sandbox="allow-scripts"
     src="https://embed.spotify.com/?uri=spotify:user:juderogers:playlist:5FTUcQhfk54BZwcdiwE1QY"
@@ -16407,6 +16869,113 @@ exports[`Storyshots EmbedComponentWrapper Spotify 1`] = `
 
 exports[`Storyshots EmbedComponentWrapper Youtube 1`] = `
 .emotion-0 {
+  width: 100%;
+  background: #F6F6F6;
+  border: 1px solid #DCDCDC;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  padding: 0.25rem 1.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  box-sizing: border-box;
+}
+
+.emotion-1 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.25rem;
+  line-height: 1.35;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.emotion-2 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.35;
+  font-weight: 400;
+  margin: 0px;
+}
+
+.emotion-3 {
+  margin-top: 1.25rem;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  -webkit-transition: .3s ease-in-out;
+  transition: .3s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 700;
+  height: 44px;
+  min-height: 44px;
+  padding: 0 20px;
+  border-radius: 44px;
+  padding-bottom: 2px;
+  background-color: #052962;
+  color: #FFFFFF;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+}
+
+.emotion-4:focus {
+  outline: 0;
+}
+
+html:not(.src-focus-disabled) .emotion-4:focus {
+  box-shadow: 0 0 0 5px #00B2FF;
+}
+
+.emotion-4:hover {
+  background-color: #234B8A;
+}
+
+.emotion-4 svg {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  display: block;
+  fill: currentColor;
+  position: relative;
+  width: 30px;
+  height: auto;
+}
+
+.emotion-4 .src-button-space {
+  width: 12px;
+}
+
+.emotion-4 svg {
+  margin-left: -4px;
+}
+
+.emotion-5 {
   background: #F6F6F6;
   padding-bottom: 56.25%;
   width: 100%;
@@ -16415,7 +16984,7 @@ exports[`Storyshots EmbedComponentWrapper Youtube 1`] = `
   margin: 1rem 0;
 }
 
-.emotion-0 iframe {
+.emotion-5 iframe {
   border: none;
   width: 100%;
   height: 100%;
@@ -16425,7 +16994,7 @@ exports[`Storyshots EmbedComponentWrapper Youtube 1`] = `
 }
 
 @media (prefers-color-scheme: dark) {
-  .emotion-0 {
+  .emotion-5 {
     color: #999999;
     background-color: #333333;
   }
@@ -16443,12 +17012,59 @@ exports[`Storyshots EmbedComponentWrapper Youtube 1`] = `
     data-kind="YouTube"
     data-tracking="1"
     data-width="460"
-  />
+  >
+    <div
+      className="emotion-0"
+    >
+      <div
+        className="emotion-1"
+      >
+        Allow YouTube content?
+      </div>
+      <p
+        className="emotion-2"
+      >
+        This article includes content provided by
+         
+        YouTube
+        . We ask for your permission before anything is loaded, as they may be using cookies and other technologies. To view this content,
+         
+        <strong>
+          click 'Allow and continue'
+        </strong>
+        .
+      </p>
+      <div
+        className="emotion-3"
+      >
+        <button
+          className="emotion-4"
+          onClick={[Function]}
+          type="button"
+        >
+          Allow and continue
+          <div
+            className="src-button-space"
+          />
+          <svg
+            viewBox="0 0 30 30"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M6 14.775l-1 1 5 7h.475l14.3-14.8-1-.975-13.3 12.05L6 14.775z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
   <p>
     This is an example of the embed wrapper rendering a YouTube 'YouTube' embed.
   </p>
   <div
-    className="emotion-0"
+    className="emotion-5"
   >
     <iframe
       allowFullScreen={true}

--- a/src/components/embed.tsx
+++ b/src/components/embed.tsx
@@ -45,6 +45,7 @@ const EmbedComponent: FC<Props> = ({ embed, editions }) => {
 			) : null;
 
 		case EmbedKind.EmailSignup:
+		case EmbedKind.TikTok:
 			return !editions ? <GenericEmbed embed={embed} /> : null;
 
 		case EmbedKind.Generic:

--- a/src/components/embedWrapper.tsx
+++ b/src/components/embedWrapper.tsx
@@ -383,6 +383,12 @@ const getSourceDetailsForEmbed = (embed: Embed): SourceDetails => {
 	}
 };
 
+const isblockedEditionsEmbed = (embed: Embed): boolean =>
+	embed.kind === EmbedKind.TikTok || embed.kind === EmbedKind.Instagram;
+
+const renderOverlay = (embed: Embed, editions: boolean): boolean =>
+	editions && !isblockedEditionsEmbed(embed);
+
 interface EmbedComponentInClickToViewProps {
 	embed: Embed;
 	editions: boolean;
@@ -394,13 +400,15 @@ const EmbedComponentInClickToView: FC<EmbedComponentInClickToViewProps> = ({
 	editions,
 	sourceDetails,
 }) => {
-	return h(ClickToView, {
-		source: sourceDetails.source,
-		sourceDomain: sourceDetails.sourceDomain,
-		children: h(EmbedComponent, { embed, editions }),
-		role: none,
-		onAccept: none,
-	});
+	return renderOverlay(embed, editions)
+		? h(ClickToView, {
+				source: sourceDetails.source,
+				sourceDomain: sourceDetails.sourceDomain,
+				children: h(EmbedComponent, { embed, editions }),
+				role: none,
+				onAccept: none,
+		  })
+		: null;
 };
 
 /**

--- a/src/components/genericEmbed.tsx
+++ b/src/components/genericEmbed.tsx
@@ -5,7 +5,7 @@ import { remSpace } from '@guardian/src-foundations';
 import { text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { withDefault } from '@guardian/types';
-import type { EmailSignup, Generic } from 'embed';
+import type { EmailSignup, Generic, TikTok } from 'embed';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
@@ -27,7 +27,7 @@ const captionStyles = css`
 `;
 
 interface Props {
-	embed: Generic | EmailSignup;
+	embed: Generic | EmailSignup | TikTok;
 }
 
 const GenericEmbed: FC<Props> = ({ embed }) => (

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -57,8 +57,7 @@ interface Instagram {
 	tracking: EmbedTracksType;
 }
 
-interface Generic {
-	kind: EmbedKind.Generic;
+interface GenericFields {
 	alt: Option<string>;
 	html: string;
 	height: number;
@@ -68,11 +67,15 @@ interface Generic {
 	tracking: EmbedTracksType;
 }
 
-interface TikTok extends Omit<Generic, 'kind'> {
+interface Generic extends GenericFields {
+	kind: EmbedKind.Generic;
+}
+
+interface TikTok extends GenericFields {
 	kind: EmbedKind.TikTok;
 }
 
-interface EmailSignup extends Omit<Generic, 'kind'> {
+interface EmailSignup extends GenericFields {
 	kind: EmbedKind.EmailSignup;
 }
 
@@ -294,7 +297,7 @@ const parseGenericEmbedKind = (parser: DocParser) => (
 ) => (
 	html: string,
 ): EmbedKind.TikTok | EmbedKind.EmailSignup | EmbedKind.Generic => {
-	if (element.embedTypeData?.source === EmbedKind.TikTok) {
+	if (element.embedTypeData?.source === 'TikTok') {
 		return EmbedKind.TikTok;
 	}
 	if (isEmailSignUp(parser)(html)) {
@@ -335,6 +338,7 @@ export type {
 	Instagram,
 	EmailSignup,
 	TikTok,
+	GenericFields,
 };
 
 export {


### PR DESCRIPTION
## Why are you doing this?

`TikTok` embeds were lacking a distinct type and always rendered as `Generic` embeds. This PR parses `generic` embeds and separates `TikTok` embeds into their own newly created type.

  
## Changes

- create new `TikTok` embed type
- parse `Generic` embed types
- block embed overlays on `TikTok` embed type

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/117798985-93629400-b249-11eb-8eba-6ccbf371deb5.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/117799017-9eb5bf80-b249-11eb-9f34-47a54c82465a.png" width="300px" /> |


