### PR TITLE
Stop Using Babel React Transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,6 @@
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.1",
-    "@babel/preset-react": "^7.12.10",
-    "@emotion/babel-plugin": "^11.1.2",
     "@emotion/jest": "^11.2.0",
     "@guardian/eslint-config-typescript": "^0.4.2",
     "@guardian/prettier": "^0.5.0",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -122,21 +122,6 @@ const serverConfig = (
 					test: /\.tsx?$/,
 					use: [
 						{
-							loader: 'babel-loader',
-							options: {
-								presets: [
-									[
-										'@babel/preset-react',
-										{
-											runtime: 'automatic',
-											importSource: '@emotion/core',
-										},
-									],
-								],
-								plugins: ['@emotion'],
-							},
-						},
-						{
 							loader: 'ts-loader',
 							options: {
 								configFile: 'config/tsconfig.server.json',
@@ -190,14 +175,6 @@ export const clientConfig: Configuration = {
 						options: {
 							presets: [
 								[
-									'@babel/preset-react',
-									{
-										runtime: 'automatic',
-										importSource: '@emotion/core',
-									},
-								],
-
-								[
 									'@babel/preset-env',
 									{
 										// Babel recommends installing corejs as a peer dependency
@@ -212,7 +189,6 @@ export const clientConfig: Configuration = {
 									},
 								],
 							],
-							plugins: ['@emotion'],
 						},
 					},
 					{


### PR DESCRIPTION
## Why are you doing this?

They're not doing anything any more. As of #1228 we're using the [TypeScript compiler](https://github.com/guardian/apps-rendering/blob/dddeb4ae1f85fa1ec16f31cb8d9ed2d89605707d/tsconfig.json#L9) to handle our React and Emotion transpilation steps. Therefore there's no need to also do this with Babel.

For more information see [the `tsconfig` docs](https://www.typescriptlang.org/tsconfig#jsx), these [other `tsconfig` docs](https://www.typescriptlang.org/tsconfig/#jsxImportSource), and the [React blog post](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) on the new JSX transform.

Thanks to @tjmw for helping me discover this! 🙈

## Changes

- Removed `@babel/preset-react` usage from webpack
- Removed `@babel/preset-react` and `@emotion/babel-plugin` from deps
