### PR TITLE
LIVE-2148: map generic instagram to structured instagram embeds

### DIFF
--- a/src/capi.ts
+++ b/src/capi.ts
@@ -112,11 +112,23 @@ const noThirdPartyEmbeds: ThirdPartyEmbeds = {
 	spotify: false,
 };
 
+const getGenericThirdPartyEmbeds = (
+	thirdPartyEmbeds: ThirdPartyEmbeds,
+	element: BlockElement,
+): ThirdPartyEmbeds => {
+	if (element.embedTypeData?.source === 'Instagram') {
+		return { ...thirdPartyEmbeds, instagram: true };
+	}
+	return thirdPartyEmbeds;
+};
+
 const checkForThirdPartyEmbed = (
 	thirdPartyEmbeds: ThirdPartyEmbeds,
 	element: BlockElement,
 ): ThirdPartyEmbeds => {
 	switch (element.type) {
+		case ElementType.EMBED:
+			return getGenericThirdPartyEmbeds(thirdPartyEmbeds, element);
 		case ElementType.INSTAGRAM:
 			return { ...thirdPartyEmbeds, instagram: true };
 		case ElementType.TWEET:

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -327,9 +327,7 @@ const parseGenericEmbedKind = (parser: DocParser) => (
 
 const extractIdFromInstagramUrl = (url: string): string => {
 	const splitUrl = url.split('/');
-	const pIndex = splitUrl.indexOf('p');
-
-	return splitUrl[pIndex + 1];
+	return splitUrl[splitUrl.length - 2];
 };
 
 const extractInstagramId = (parser: DocParser) => (


### PR DESCRIPTION
## Why are you doing this?

Ideally we'd like all `Instagram` embeds to render as structured `Instagram` embeds regardless of whether they're inputted as `Generic` embeds or structured embeds. This PR extracts the Instagram post id from a generic embed and creates a structured embed.

Two questions:
- These new embeds don't pass CSP on AR for some reason - why? From what I can tell the embed is exactly as it should be.
- the `parseGenericInstagram` function is currently returning an empty string to appease the `Instagram` type expectation - is there a better way of doing this?

## Changes

- add condition to parse `Instagram` embeds separate from `Generic` embeds
- extract `id` from generic embed `html` field
- map to new structured `Instagram` embed

## To test
- running apps rendering go to `http://localhost:8080/culture/2021/mar/18/nikki-britton-the-10-funniest-things-i-have-ever-seen-on-the-internet`
- page should contain instagram embeds
- go to `http://localhost:8080/culture/2021/mar/18/nikki-britton-the-10-funniest-things-i-have-ever-seen-on-the-internet?editions`
- page should not contain instagram embeds


