### PR TITLE
LIVE-2449 - Fix dead contributor link

### DIFF
--- a/src/components/comment/cutout.tsx
+++ b/src/components/comment/cutout.tsx
@@ -23,6 +23,7 @@ const imageStyles = css`
 	right: 0;
 	top: -48px;
 	background: none;
+	pointer-events: none;
 
 	${darkModeCss`
         background: none;


### PR DESCRIPTION
## Why are you doing this?

The Contributor name (link) is not clickable and therefore does not take you to the full list of articles by that contributor.
Currently the `Cutout` component is in front of the contributor link. 

Potentially the may have slipped through the testing net due to testing in localhost browser in full/wide view, where the cutout image background would not cover the contributor name/link.
## Changes

- Modified `imageStyles` for `Cutout` component to include `pointer-events:none`

To test ensure that in localhost the browser is set to Responsive and iPhone of Samsung

## Screenshots
Please note: the cutout image covers part of the contributors name, see screenshot:

As you can see the background of covers contributor link in `responsive` view mode (how it renders in the app)
| Default Browser | Responsive Browser |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/118660001-b3fc9200-b7e5-11eb-9307-6f2d651ba5c4.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/118659269-10ab7d00-b7e5-11eb-8737-d40b8b2cde22.png" width="300px" /> |


| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/49187886/118660603-40a75000-b7e6-11eb-981c-537c2334feab.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/49187886/118660712-587ed400-b7e6-11eb-913b-b35826cefeca.png" width="300px" /> |
