### PR TITLE
Variadic `pipe`

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -25,7 +25,7 @@ function pipe<A, B, C, D>(
 	f: (_a: A) => B,
 	g: (_b: B) => C,
 	h: (_c: C) => D,
-): D
+): D;
 function pipe<A, B, C, D>(
 	a: A,
 	f: (_a: A) => B,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -17,14 +17,38 @@ import type { ReactElement } from 'react';
 
 const compose = <A, B, C>(f: (_b: B) => C, g: (_a: A) => B) => (a: A): C =>
 	f(g(a));
-const pipe = <A, B>(a: A, f: (_a: A) => B): B => f(a);
-const pipe2 = <A, B, C>(a: A, f: (_a: A) => B, g: (_b: B) => C): C => g(f(a));
+
+function pipe<A, B>(a: A, f: (_a: A) => B): B;
+function pipe<A, B, C>(a: A, f: (_a: A) => B, g: (_b: B) => C): C;
+function pipe<A, B, C, D>(
+	a: A,
+	f: (_a: A) => B,
+	g: (_b: B) => C,
+	h: (_c: C) => D,
+): D
+function pipe<A, B, C, D>(
+	a: A,
+	f: (_a: A) => B,
+	g?: (_b: B) => C,
+	h?: (_c: C) => D,
+): unknown {
+	if (g !== undefined && h !== undefined) {
+		return h(g(f(a)));
+	} else if (g !== undefined) {
+		return g(f(a));
+	}
+
+	return f(a);
+}
+
+const pipe2 = <A, B, C>(a: A, f: (_a: A) => B, g: (_b: B) => C): C =>
+	pipe(a, f, g);
 const pipe3 = <A, B, C, D>(
 	a: A,
 	f: (_a: A) => B,
 	g: (_b: B) => C,
 	h: (_c: C) => D,
-): D => h(g(f(a)));
+): D => pipe(a, f, g, h);
 
 const identity = <A>(a: A): A => a;
 


### PR DESCRIPTION
## Why are you doing this?

@joecowton1 pointed out that having multiple variations of the `pipe` function (`pipe2`, `pipe3` etc.) can be confusing. As a result I've refactored to make a single variadic `pipe` function instead ("variadic" means that it takes a variable number of arguments). I believe this solution was also suggested a while back by @alexduf but I never got around to implementing it.

This change is achieved by making use of [TypeScript's support for overloaded functions](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads). The `fp-ts` library was a helpful reference point here for figuring out suitable type signatures, as they have some [similar functions](https://gcanti.github.io/fp-ts/modules/function.ts.html#pipe) in their API.

I've also kept `pipe2` and `pipe3` temporarily available to prevent the API of `lib` changing - this is to avoid merge conflicts with #1307. I'll make a subsequent PR to replace their usages once that's merged.

## Changes

- Made `pipe` variadic
- Re-implemented `pipe2` and `pipe3` in terms of `pipe`
