### PR TITLE
Chromatic: ignore instagram embed iframe

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -16677,6 +16677,7 @@ html:not(.src-focus-disabled) .emotion-4:focus {
     height="830"
     src="https://www.instagram.com/p/BwwONCplEyj/embed"
     title="a caption"
+    [data-chromatic="ignore"]
   />
 </div>
 `;


### PR DESCRIPTION
## Why are you doing this?

The instagram embed story is very attention seeking and needs approving all the time. Trying this to see if this helps before removing this story.

