### PR TITLE
Remove `pipe2` And `pipe3`

### DIFF
--- a/src/bodyElement.ts
+++ b/src/bodyElement.ts
@@ -20,7 +20,7 @@ import { parseAudio, parseGeneric, parseInstagram, parseVideo } from 'embed';
 import type { Embed } from 'embed';
 import type { Image as ImageData } from 'image';
 import { parseImage } from 'image';
-import { compose, pipe, pipe2 } from 'lib';
+import { compose, pipe } from 'lib';
 import type { Context } from 'types/parserContext';
 
 // ----- Types ----- //
@@ -265,7 +265,7 @@ const parse = (context: Context, atoms?: Atoms, campaigns?: Campaign[]) => (
 		}
 
 		case ElementType.IMAGE:
-			return pipe2(
+			return pipe(
 				parseImage(context)(element),
 				map<ImageData, Result<string, Image>>((image) =>
 					ok({

--- a/src/capi.ts
+++ b/src/capi.ts
@@ -14,7 +14,7 @@ import type { MainMedia } from 'headerMedia';
 import { MainMediaKind } from 'headerMedia';
 import { parseImage } from 'image';
 import { isLabs } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { Context } from 'types/parserContext';
 import { parseVideo } from 'video';
 
@@ -78,7 +78,7 @@ const articleMainMedia = (
 	context: Context,
 ): Option<MainMedia> => {
 	return (content.blocks?.main?.elements.filter(isImage) ?? [])[0]
-		? pipe2(
+		? pipe(
 				articleMainImage(content),
 				andThen(parseImage(context)),
 				map((image) => ({
@@ -86,7 +86,7 @@ const articleMainMedia = (
 					image,
 				})),
 		  )
-		: pipe2(
+		: pipe(
 				articleMainVideo(content),
 				andThen((blockElement) =>
 					parseVideo(blockElement, content.atoms),
@@ -213,7 +213,7 @@ const capiDateTimeToDate = (date: CapiDateTime): Option<Date> =>
 	dateFromString(date.iso8601);
 
 const maybeCapiDate = (date: CapiDateTime | undefined): Option<Date> =>
-	pipe2(date, fromNullable, andThen(capiDateTimeToDate));
+	pipe(date, fromNullable, andThen(capiDateTimeToDate));
 
 // ----- Exports ----- //
 

--- a/src/components/atoms/interactiveAtom.tsx
+++ b/src/components/atoms/interactiveAtom.tsx
@@ -4,7 +4,7 @@ import { remSpace } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 import type { Format, Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { createElement as h } from 'react';
 import { pageFonts } from 'styles';
@@ -52,7 +52,7 @@ const InteractiveAtom: FC<InteractiveAtomProps> = (
 	const { html, styles, js, format } = props;
 	const pillarStyles = getThemeStyles(format.theme);
 	const style = h('style', { dangerouslySetInnerHTML: { __html: styles } });
-	const script = pipe2(
+	const script = pipe(
 		js,
 		map((jsString) =>
 			h('script', { dangerouslySetInnerHTML: { __html: jsString } }),

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -8,7 +8,7 @@ import { map, withDefault } from '@guardian/types';
 import Img from 'components/img';
 import { isSingleContributor } from 'contributor';
 import type { Contributor } from 'contributor';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { getThemeStyles } from 'themeStyles';
 
@@ -44,7 +44,7 @@ const Avatar: FC<Props> = ({ contributors, ...format }: Props) => {
 		return null;
 	}
 
-	return pipe2(
+	return pipe(
 		contributor.image,
 		map((image) => (
 			<Img

--- a/src/components/byline.stories.tsx
+++ b/src/components/byline.stories.tsx
@@ -4,7 +4,7 @@ import { Design, Display, Pillar, Special, toOption } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { text, withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Byline from './byline';
@@ -22,7 +22,7 @@ const byline = (): string => text('Byline', 'Jane Smith');
 const job = (): string => text('Job Title', 'Editor of things');
 
 const mockBylineHtml = (): Option<DocumentFragment> =>
-	pipe2(
+	pipe(
 		`<a href="${profileLink()}">${byline()}</a> ${job()}`,
 		parseByline,
 		toOption,

--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -6,7 +6,7 @@ import { neutral, palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { Design, map, Special, withDefault } from '@guardian/types';
 import type { Format, Option } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement, ReactNode } from 'react';
 import { getHref } from 'renderer';
 import { darkModeCss } from 'styles';
@@ -133,7 +133,7 @@ const renderText = (format: Format, byline: DocumentFragment): ReactNode =>
 	Array.from(byline.childNodes).map((node, i) => toReact(format)(node, i));
 
 const Byline: FC<Props> = ({ bylineHtml, ...format }) =>
-	pipe2(
+	pipe(
 		bylineHtml,
 		map((byline) => (
 			<address css={getStyles(format)}>

--- a/src/components/comment/cutout.tsx
+++ b/src/components/comment/cutout.tsx
@@ -7,7 +7,7 @@ import { map, withDefault } from '@guardian/types';
 import Img from 'components/img';
 import type { Contributor } from 'contributor';
 import { isSingleContributor } from 'contributor';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { darkModeCss } from 'styles';
 
@@ -44,7 +44,7 @@ const Cutout: FC<Props> = ({ contributors, className, format }) => {
 		return null;
 	}
 
-	return pipe2(
+	return pipe(
 		contributor.image,
 		map((image) => (
 			<div css={[className, styles]}>

--- a/src/components/commentCount.tsx
+++ b/src/components/commentCount.tsx
@@ -7,7 +7,7 @@ import { border, neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import type { Format, Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles } from 'themeStyles';
@@ -55,7 +55,7 @@ const CommentCount: FC<Props> = ({ count, commentable, ...format }: Props) => {
 		return null;
 	}
 
-	return pipe2(
+	return pipe(
 		count,
 		map((count: number) => (
 			<button css={getStyles(format)}>

--- a/src/components/credit.tsx
+++ b/src/components/credit.tsx
@@ -5,7 +5,7 @@ import { remSpace } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import type { Format, Option } from '@guardian/types';
 import { Design, map, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 
 // ----- Component ----- //
@@ -21,7 +21,7 @@ const styles = css`
 `;
 
 const Credit: FC<Props> = ({ format, credit }) =>
-	pipe2(
+	pipe(
 		credit,
 		map((cred) => {
 			switch (format.design) {

--- a/src/components/dateline.tsx
+++ b/src/components/dateline.tsx
@@ -7,7 +7,7 @@ import { textSans } from '@guardian/src-foundations/typography';
 import type { Option, Theme } from '@guardian/types';
 import { map, Pillar, withDefault } from '@guardian/types';
 import { formatDate } from 'date';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { darkModeCss as darkMode } from 'styles';
 
@@ -46,7 +46,7 @@ const getDatelineStyles = (theme: Theme): SerializedStyles => {
 };
 
 const Dateline: FC<Props> = ({ date, theme }) =>
-	pipe2(
+	pipe(
 		date,
 		map((d) => (
 			<time

--- a/src/components/editions/avatar/index.tsx
+++ b/src/components/editions/avatar/index.tsx
@@ -6,7 +6,7 @@ import { Img } from '@guardian/image-rendering';
 import { map, none, some, withDefault } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 
 // ----- Component ----- //
@@ -29,7 +29,7 @@ const Avatar: FC<Props> = ({ item }) => {
 	const [contributor] = item.contributors;
 	const format = getFormat(item);
 
-	return pipe2(
+	return pipe(
 		contributor.image,
 		map((image) => (
 			<Img

--- a/src/components/editions/byline/byline.stories.tsx
+++ b/src/components/editions/byline/byline.stories.tsx
@@ -14,7 +14,7 @@ import {
 	review,
 } from 'fixtures/item';
 import type { Image } from 'image';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Byline from './index';
@@ -58,7 +58,7 @@ const byline = (): string => text('Byline', 'Jane Smith');
 const job = (): string => text('Job Title', 'Editor of things');
 
 const mockBylineHtml = (): Option<DocumentFragment> =>
-	pipe2(
+	pipe(
 		`<a href="${profileLink()}">${byline()}</a> ${job()}`,
 		parseByline,
 		toOption,

--- a/src/components/editions/galleryImage/index.tsx
+++ b/src/components/editions/galleryImage/index.tsx
@@ -8,7 +8,7 @@ import { textSans } from '@guardian/src-foundations/typography';
 import type { Format, Option } from '@guardian/types';
 import { map, none, some, withDefault } from '@guardian/types';
 import type { Image } from 'bodyElement';
-import { maybeRender, pipe2 } from 'lib';
+import { maybeRender, pipe } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
 
@@ -66,7 +66,7 @@ const getCaptionDetails = (oDoc: Option<DocumentFragment>): CaptionDetails => {
 			return details;
 		}, details);
 
-	return pipe2(
+	return pipe(
 		oDoc,
 		map(parseCaptionNode),
 		withDefault<CaptionDetails>(details),

--- a/src/components/editions/headerImageCaption.tsx
+++ b/src/components/editions/headerImageCaption.tsx
@@ -7,7 +7,7 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { SvgCamera } from '@guardian/src-icons';
 import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 
 const captionId = 'header-image-caption';
@@ -95,7 +95,7 @@ const HeaderImageCaption: FC<Props> = ({
 	iconBackgroundColor,
 	isFullWidthImage,
 }: Props) =>
-	pipe2(
+	pipe(
 		caption,
 		map((cap) => (
 			<figcaption

--- a/src/components/editions/pullquote/index.tsx
+++ b/src/components/editions/pullquote/index.tsx
@@ -5,7 +5,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { SvgQuote } from '@guardian/src-icons';
 import type { Format, Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { getThemeStyles } from 'themeStyles';
 
@@ -96,7 +96,7 @@ const Pullquote: FC<Props> = ({ quote, attribution, format }) => {
 			{quote}
 		</p>
 	);
-	const children = pipe2(
+	const children = pipe(
 		attribution,
 		map((attribution) => [
 			quoteElement,

--- a/src/components/editions/standfirst/standfirst.stories.tsx
+++ b/src/components/editions/standfirst/standfirst.stories.tsx
@@ -5,7 +5,7 @@ import type { Option } from '@guardian/types';
 import { withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
 import { analysis, article, comment, media } from 'fixtures/item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Standfirst from '.';
@@ -15,7 +15,7 @@ import Standfirst from '.';
 const parser = new DOMParser();
 const parseStandfirst = parse(parser);
 
-const standfirst: Option<DocumentFragment> = pipe2(
+const standfirst: Option<DocumentFragment> = pipe(
 	'<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>',
 	parseStandfirst,
 	toOption,

--- a/src/components/embedWrapper.tsx
+++ b/src/components/embedWrapper.tsx
@@ -26,7 +26,7 @@ import type {
 	TikTok,
 	YouTube,
 } from 'embed';
-import { pipe, pipe2, resultFromNullable, resultMap2, resultMap3 } from 'lib';
+import { pipe, resultFromNullable, resultMap2, resultMap3 } from 'lib';
 import { createElement as h } from 'react';
 import type { FC, ReactElement } from 'react';
 
@@ -48,12 +48,12 @@ const genericDivProps = (
 	html: embed.html,
 	height: embed.height.toString(),
 	...(embed.mandatory && { mandatory: 'true' }),
-	...pipe2(
+	...pipe(
 		embed.source,
 		map((source) => ({ source })),
 		withDefault<Record<string, string>>({}),
 	),
-	...pipe2(
+	...pipe(
 		embed.sourceDomain,
 		map((sourceDomain) => ({ sourceDomain })),
 		withDefault<Record<string, string>>({}),
@@ -101,7 +101,7 @@ const embedToDivProps = (embed: Embed): Record<string, string> => {
 			return {
 				kind: EmbedKind.Instagram,
 				id: embed.id,
-				...pipe2(
+				...pipe(
 					embed.caption,
 					map((caption) => ({ caption: caption })),
 					withDefault<Record<string, string>>({}),
@@ -271,7 +271,7 @@ const divElementPropsToEmbedComponentProps = (
 							)(requiredStringParam(elementProps, 'id'));
 						}
 						case EmbedKind.Generic: {
-							return pipe2(
+							return pipe(
 								elementProps,
 								parseGenericFields,
 								resultMap(
@@ -285,7 +285,7 @@ const divElementPropsToEmbedComponentProps = (
 							);
 						}
 						case EmbedKind.TikTok: {
-							return pipe2(
+							return pipe(
 								elementProps,
 								parseGenericFields,
 								resultMap(
@@ -297,7 +297,7 @@ const divElementPropsToEmbedComponentProps = (
 							);
 						}
 						case EmbedKind.EmailSignup: {
-							return pipe2(
+							return pipe(
 								elementProps,
 								parseGenericFields,
 								resultMap(

--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -7,7 +7,7 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { SvgCamera } from '@guardian/src-icons';
 import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { darkModeCss, wideContentWidth } from 'styles';
 
@@ -95,7 +95,7 @@ const HeaderImageCaption: FC<Props> = ({
 	iconColor,
 	iconBackgroundColor,
 }: Props) =>
-	pipe2(
+	pipe(
 		caption,
 		map((cap) => (
 			<figcaption

--- a/src/components/labs/article.tsx
+++ b/src/components/labs/article.tsx
@@ -14,7 +14,7 @@ import RelatedContent from 'components/shared/relatedContent';
 import Standfirst from 'components/standfirst';
 import HeaderMedia from 'headerMedia';
 import type { Item } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,
@@ -69,7 +69,7 @@ const Labs: FC<Props> = ({ item, children }) => {
 					</div>
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />
-						{pipe2(
+						{pipe(
 							item.logo,
 							map((props) => <Logo logo={props} />),
 							withDefault(<></>),

--- a/src/components/media/articleSeries.tsx
+++ b/src/components/media/articleSeries.tsx
@@ -4,7 +4,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import type { Option, Theme } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
 import type { Series } from 'capi';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import type { ThemeStyles } from 'themeStyles';
@@ -25,7 +25,7 @@ interface ArticleSeriesProps {
 }
 
 const ArticleSeries: FC<ArticleSeriesProps> = (props) =>
-	pipe2(
+	pipe(
 		props.series,
 		map((series) => (
 			<nav css={ArticleSeriesStyles(getThemeStyles(props.theme))}>

--- a/src/components/media/byline.tsx
+++ b/src/components/media/byline.tsx
@@ -10,7 +10,7 @@ import type { Option } from '@guardian/types';
 import Dateline from 'components/dateline';
 import { getFormat } from 'item';
 import type { Item } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { renderText } from '../../renderer';
 
@@ -47,7 +47,7 @@ interface Props {
 }
 
 const Byline: FC<Props> = ({ publicationDate, className, item }) => {
-	const byline = pipe2(
+	const byline = pipe(
 		item.bylineHtml,
 		map((html) => <address>{renderText(html, getFormat(item))}</address>),
 		withDefault<ReactNode>(null),

--- a/src/components/pullquote.tsx
+++ b/src/components/pullquote.tsx
@@ -5,7 +5,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { SvgQuote } from '@guardian/src-icons';
 import type { Format, Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles } from 'themeStyles';
@@ -58,7 +58,7 @@ const Pullquote: FC<Props> = ({ quote, attribution, format }) => {
 			{quote}
 		</p>
 	);
-	const children = pipe2(
+	const children = pipe(
 		attribution,
 		map((attribution) => [
 			quoteElement,

--- a/src/components/scripts.tsx
+++ b/src/components/scripts.tsx
@@ -2,7 +2,7 @@
 
 import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 
 // ----- Sub-Components ----- //
@@ -12,7 +12,7 @@ interface ClientJsProps {
 }
 
 const ClientJs: FC<ClientJsProps> = ({ src }) =>
-	pipe2(
+	pipe(
 		src,
 		map((s) => <script src={s}></script>),
 		withDefault<ReactElement | null>(null),

--- a/src/components/series.tsx
+++ b/src/components/series.tsx
@@ -9,7 +9,7 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 import type { Format } from '@guardian/types';
 import { Display, map, Special, withDefault } from '@guardian/types';
 import type { Item } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { articleWidthStyles, darkModeCss, wideContentWidth } from 'styles';
 import { getThemeStyles } from 'themeStyles';
@@ -93,7 +93,7 @@ const getStyles = ({ display, theme, design }: Format): SerializedStyles => {
 };
 
 const Series: FC<Props> = ({ item }: Props) =>
-	pipe2(
+	pipe(
 		item.series,
 		map((series) => (
 			<nav css={getStyles(item)}>

--- a/src/components/shared/bylineCard.tsx
+++ b/src/components/shared/bylineCard.tsx
@@ -14,7 +14,7 @@ import {
 	withDefault,
 } from '@guardian/types';
 import { makeRelativeDate } from 'date';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles, themeFromString } from 'themeStyles';
@@ -112,7 +112,7 @@ const bylineStyles: SerializedStyles = css`
 `;
 
 const byline = (relatedItem: RelatedItem): ReactElement | null => {
-	return pipe2(
+	return pipe(
 		fromNullable(relatedItem.byline),
 		map((byline) => {
 			return <div css={bylineStyles}>{byline}</div>;
@@ -167,7 +167,7 @@ const lineStyles = css`
 `;
 
 const relativeFirstPublished = (date: Option<Date>): ReactElement | null =>
-	pipe2(
+	pipe(
 		date,
 		map((date) => <time css={dateStyles}>{makeRelativeDate(date)}</time>),
 		withDefault<ReactElement | null>(null),

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -26,7 +26,7 @@ import { stars } from 'components/starRating';
 import { formatSeconds, makeRelativeDate } from 'date';
 import { border } from 'editorialPalette';
 import type { Image } from 'image';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles, themeFromString } from 'themeStyles';
@@ -153,7 +153,7 @@ const relativeFirstPublished = (
 	date: Option<Date>,
 	type: RelatedItemType,
 ): JSX.Element | null =>
-	pipe2(
+	pipe(
 		date,
 		map((date) => (
 			<time css={[timeStyles(type), dateStyles]}>
@@ -334,7 +334,7 @@ const durationMedia = (
 	duration: Option<string>,
 	type: RelatedItemType,
 ): ReactElement | null => {
-	return pipe2(
+	return pipe(
 		duration,
 		map((length) => {
 			const seconds = formatSeconds(length);
@@ -360,7 +360,7 @@ const cardByline = (
 		return null;
 	}
 
-	return pipe2(
+	return pipe(
 		fromNullable(byline),
 		map((byline) => {
 			return <div css={bylineStyles}>{byline}</div>;
@@ -379,7 +379,7 @@ const cardImage = (
 		display: Display.Standard,
 	};
 
-	return pipe2(
+	return pipe(
 		image,
 		map((img) => {
 			return (

--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -8,7 +8,7 @@ import { map, withDefault } from '@guardian/types';
 import Anchor from 'components/anchor';
 import { getFormat } from 'item';
 import type { Item } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles } from 'themeStyles';
@@ -60,7 +60,7 @@ const styles = (
 };
 
 const OptionalLogo = (item: Item): JSX.Element =>
-	pipe2(
+	pipe(
 		item.branding,
 		map((branding) => (
 			<Logo branding={branding} format={getFormat(item)} />

--- a/src/components/shared/relatedContent.tsx
+++ b/src/components/shared/relatedContent.tsx
@@ -7,7 +7,7 @@ import { map, withDefault } from '@guardian/types';
 import BylineCard from 'components/shared/bylineCard';
 import Card from 'components/shared/card';
 import type { ResizedRelatedContent } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 
@@ -40,7 +40,7 @@ const listStyles = css`
 const COMMENT = RelatedItemType.COMMENT;
 
 const RelatedContent: FC<Props> = ({ content }) => {
-	return pipe2(
+	return pipe(
 		content,
 		map(({ title, relatedItems, resizedImages }) => {
 			if (relatedItems.length === 0) {

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -26,7 +26,7 @@ import type {
 	Review as ReviewItem,
 	Standard as StandardItem,
 } from 'item';
-import { maybeRender, pipe2 } from 'lib';
+import { maybeRender, pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,
@@ -99,7 +99,7 @@ const Standard: FC<Props> = ({ item, children }) => {
 	);
 
 	const commentContainer = item.commentable
-		? pipe2(
+		? pipe(
 				item.internalShortId,
 				map((id) => (
 					<section

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -8,7 +8,7 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 import { Design, Display, map, Special, withDefault } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement, ReactNode } from 'react';
 import { renderStandfirstText } from 'renderer';
 import { darkModeCss as darkMode } from 'styles';
@@ -113,7 +113,7 @@ function content(standfirst: DocumentFragment, item: Item): ReactNode {
 		item.byline !== '' && standfirst.textContent?.includes(item.byline);
 
 	if (item.display === Display.Immersive && !bylineInStandfirst) {
-		return pipe2(
+		return pipe(
 			item.bylineHtml,
 			map((byline) => (
 				<>
@@ -131,7 +131,7 @@ function content(standfirst: DocumentFragment, item: Item): ReactNode {
 }
 
 const Standfirst: FC<Props> = ({ item }) =>
-	pipe2(
+	pipe(
 		item.standfirst,
 		map((standfirst) => (
 			<div css={getStyles(item)}>{content(standfirst, item)}</div>

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -7,7 +7,7 @@ import type { Option } from '@guardian/types';
 import { fromNullable, map, none, Role } from '@guardian/types';
 import { articleContributors } from 'capi';
 import type { Image } from 'image';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 
 // ------ Types ----- //
 
@@ -30,7 +30,7 @@ const tagToContributor = (salt: string) => (
 	id: contributorTag.id,
 	apiUrl: contributorTag.apiUrl,
 	name: contributorTag.webTitle,
-	image: pipe2(
+	image: pipe(
 		contributorTag.bylineLargeImageUrl,
 		fromNullable,
 		map((url) => ({

--- a/src/date.ts
+++ b/src/date.ts
@@ -2,7 +2,7 @@
 
 import type { Option } from '@guardian/types';
 import { map, none, some, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 
 // ----- Setup ----- //
 
@@ -153,7 +153,7 @@ function formatSeconds(seconds: string): Option<string> {
 }
 
 const dateToString = (date: Option<Date>): string =>
-	pipe2(
+	pipe(
 		date,
 		map((d) => d.toISOString()),
 		withDefault(''),

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -17,8 +17,6 @@ import {
 	compose,
 	parseIntOpt,
 	pipe,
-	pipe2,
-	pipe3,
 	resultFromNullable,
 } from 'lib';
 import type { DocParser } from 'types/parserContext';
@@ -107,7 +105,7 @@ const youtubeUrl = (id: string): string => {
 };
 
 const getNumericAttribute = (attr: string) => (elem: Element): Option<number> =>
-	pipe2(elem.getAttribute(attr), fromNullable, andThen(parseIntOpt));
+	pipe(elem.getAttribute(attr), fromNullable, andThen(parseIntOpt));
 
 const getAttribute = (attr: string) => (elem: Element): Option<string> =>
 	pipe(elem.getAttribute(attr), fromNullable);
@@ -123,7 +121,7 @@ const getPermalink = (blockquote: HTMLElement): Result<string, string> =>
 const parseInstagramHTML = (parser: DocParser) => (
 	html: string,
 ): Result<string, string> =>
-	pipe2(
+	pipe(
 		parser(html).querySelector('blockquote'),
 		resultFromNullable(
 			"I couldn't find a blockquote in the html for this embed",
@@ -136,7 +134,7 @@ const getHeight = getNumericAttribute('height');
 const getComponent = getAttribute('data-component');
 
 const iframeAttributes = (iframe: HTMLIFrameElement): Result<string, IFrame> =>
-	pipe2(
+	pipe(
 		iframe.getAttribute('src'),
 		resultFromNullable("This iframe didn't have a 'src' attribute"),
 		resultMap((src) => ({
@@ -150,7 +148,7 @@ const iframeAttributes = (iframe: HTMLIFrameElement): Result<string, IFrame> =>
 const parseIframe = (parser: DocParser) => (
 	html: string,
 ): Result<string, IFrame> =>
-	pipe2(
+	pipe(
 		parser(html).querySelector('iframe'),
 		resultFromNullable(
 			"I couldn't find an iframe in the html for this embed",
@@ -213,7 +211,7 @@ const getInstagramPostId = (url: URL): Result<string, string> =>
 	)(url.pathname.split('/')[2]);
 
 const parseYoutubeVideo = (element: BlockElement): Result<string, YouTube> =>
-	pipe3(
+	pipe(
 		extractVideoUrl(element),
 		resultAndThen(parseUrl),
 		resultAndThen(getYoutubeIdParam),
@@ -232,7 +230,7 @@ const parseYoutubeVideo = (element: BlockElement): Result<string, YouTube> =>
 const parseSpotifyAudio = (parser: DocParser) => (
 	element: BlockElement,
 ): Result<string, Spotify> =>
-	pipe2(
+	pipe(
 		extractAudioHtml(element),
 		resultAndThen(parseIframe(parser)),
 		resultMap(({ src, width, height }) => ({
@@ -292,7 +290,7 @@ const parseInstagram = (element: BlockElement): Result<string, Embed> => {
 		);
 	}
 
-	return pipe3(
+	return pipe(
 		extractInstagramUrl(element),
 		resultAndThen(parseUrl),
 		resultAndThen(getInstagramPostId),
@@ -333,7 +331,7 @@ const extractIdFromInstagramUrl = (url: string): string => {
 const extractInstagramId = (parser: DocParser) => (
 	html: string,
 ): Result<string, string> =>
-	pipe2(
+	pipe(
 		html,
 		parseInstagramHTML(parser),
 		resultMap(extractIdFromInstagramUrl),
@@ -342,7 +340,7 @@ const extractInstagramId = (parser: DocParser) => (
 const parseGenericInstagram = (parser: DocParser) => (
 	element: BlockElement,
 ): Result<string, Instagram> =>
-	pipe3(
+	pipe(
 		element,
 		extractGenericHtml,
 		resultAndThen(extractInstagramId(parser)),

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -13,12 +13,7 @@ import {
 	withDefault,
 } from '@guardian/types';
 import type { Option, Result } from '@guardian/types';
-import {
-	compose,
-	parseIntOpt,
-	pipe,
-	resultFromNullable,
-} from 'lib';
+import { compose, parseIntOpt, pipe, resultFromNullable } from 'lib';
 import type { DocParser } from 'types/parserContext';
 
 // ----- Types ----- //

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -22,7 +22,7 @@ import type { MainMedia } from 'headerMedia';
 import { MainMediaKind } from 'headerMedia';
 import type { Image } from 'image';
 import type { Item, Review } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import { galleryBody } from './galleryBody';
 
 // ----- Fixture ----- //
@@ -33,13 +33,13 @@ const parseHtml = parse(parser);
 const headline =
 	'Reclaimed lakes and giant airports: how Mexico City might have looked';
 
-const standfirst: Option<DocumentFragment> = pipe2(
+const standfirst: Option<DocumentFragment> = pipe(
 	'<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>',
 	parseHtml,
 	toOption,
 );
 
-const bylineHtml: Option<DocumentFragment> = pipe2(
+const bylineHtml: Option<DocumentFragment> = pipe(
 	'<a href="https://theguardian.com">Jane Smith</a> Editor of things',
 	parseHtml,
 	toOption,

--- a/src/football.ts
+++ b/src/football.ts
@@ -4,7 +4,7 @@ import type { FootballContent } from '@guardian/apps-rendering-api-models/footba
 import type { FootballTeam } from '@guardian/apps-rendering-api-models/footballTeam';
 import { andThen, fromNullable, map, map2, none, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 
 // ----- Types ----- //
 
@@ -103,12 +103,12 @@ const parseTime = (time: unknown): Option<string> => {
 };
 
 const parseMatchStatus = (status: string, time: string): Option<MatchStatus> =>
-	pipe2(
+	pipe(
 		status,
 		parseStatus,
 		andThen<MatchStatusKind, MatchStatus>((s) => {
 			if (s === MatchStatusKind.KickOff) {
-				return pipe2(
+				return pipe(
 					time,
 					parseTime,
 					map((t) => ({ kind: s, time: t })),

--- a/src/headerMedia.tsx
+++ b/src/headerMedia.tsx
@@ -4,7 +4,7 @@ import HeaderVideo from 'components/headerVideo';
 import type { Image as ImageData } from 'image';
 import type { Item } from 'item';
 import { getFormat } from 'item';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { FC } from 'react';
 import type { Video as VideoData } from 'video';
 
@@ -23,7 +23,7 @@ interface HeaderMediaProps {
 
 const HeaderMedia: FC<HeaderMediaProps> = ({ item }) => {
 	const format = getFormat(item);
-	return pipe2(
+	return pipe(
 		item.mainMedia,
 		map((media) => {
 			if (media.kind === MainMediaKind.Image) {

--- a/src/image.ts
+++ b/src/image.ts
@@ -6,7 +6,7 @@ import type { Image as ImageData } from '@guardian/image-rendering';
 import { Dpr, src, srcsets } from '@guardian/image-rendering';
 import type { Format, Option } from '@guardian/types';
 import { andThen, fromNullable, map, none, Role, some } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { ReactNode } from 'react';
 import type { Context } from 'types/parserContext';
 
@@ -30,7 +30,7 @@ const parseCredit = (
 	displayCredit: boolean | undefined,
 	credit: string | undefined,
 ): Option<string> =>
-	pipe2(
+	pipe(
 		displayCredit,
 		fromNullable,
 		andThen((display) => (display ? fromNullable(credit) : none)),
@@ -55,7 +55,7 @@ const parseImage = ({ docParser, salt }: Context) => (
 	);
 	const data = element.imageTypeData;
 
-	return pipe2(
+	return pipe(
 		masterAsset,
 		fromNullable,
 		andThen((asset) => {
@@ -79,7 +79,7 @@ const parseImage = ({ docParser, salt }: Context) => (
 				alt: fromNullable(data?.alt),
 				width: asset.typeData.width,
 				height: asset.typeData.height,
-				caption: pipe2(data?.caption, fromNullable, map(docParser)),
+				caption: pipe(data?.caption, fromNullable, map(docParser)),
 				credit: parseCredit(data?.displayCredit, data?.credit),
 				nativeCaption: fromNullable(data?.caption),
 				role: parseRole(data?.role),

--- a/src/item.test.ts
+++ b/src/item.test.ts
@@ -22,7 +22,7 @@ import {
 } from '@guardian/types';
 import { JSDOM } from 'jsdom';
 import { Content } from '@guardian/content-api-models/v1/content';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import { articleContentWith } from 'helperTest';
 import { EmbedKind } from 'embed';
 
@@ -188,7 +188,7 @@ const f = (content: Content) =>
 	fromCapi({ docParser: JSDOM.fragment, salt: 'mockSalt' })({ content });
 
 const getFirstBody = (item: Review | Standard) =>
-	pipe2(
+	pipe(
 		item.body[0],
 		toOption,
 		withDefault<BodyElement>({
@@ -347,7 +347,7 @@ describe('interactive elements', () => {
 			},
 		};
 		const item = f(articleContentWith(interactiveElement)) as Standard;
-		const element = pipe2(
+		const element = pipe(
 			item.body[0],
 			toOption,
 			withDefault<BodyElement>({
@@ -368,7 +368,7 @@ describe('interactive elements', () => {
 			},
 		};
 		const item = f(articleContentWith(interactiveElement)) as Standard;
-		const element = pipe2(
+		const element = pipe(
 			item.body[0],
 			toOption,
 			withDefault<BodyElement>({
@@ -593,7 +593,7 @@ describe('audio elements', () => {
 			},
 		};
 		const item = f(articleContentWith(audioElement)) as Standard;
-		pipe2(
+		pipe(
 			item.body[0],
 			resultAndThen((element) =>
 				element.kind === ElementKind.Embed &&
@@ -659,7 +659,7 @@ describe('video elements', () => {
 			},
 		};
 		const item = f(articleContentWith(videoElement)) as Standard;
-		pipe2(
+		pipe(
 			item.body[0],
 			resultAndThen((element) =>
 				element.kind === ElementKind.Embed &&

--- a/src/item.ts
+++ b/src/item.ts
@@ -37,7 +37,7 @@ import { parseMatchScores } from 'football';
 import type { MainMedia } from 'headerMedia';
 import type { Image } from 'image';
 import { parseCardImage } from 'image';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import { parseMany as parseLiveBlocks } from 'liveBlock';
 import { themeFromString } from 'themeStyles';
@@ -178,13 +178,13 @@ const itemFields = (
 		theme: themeFromString(content.pillarId),
 		display: getDisplay(content),
 		headline: content.fields?.headline ?? '',
-		standfirst: pipe2(
+		standfirst: pipe(
 			content.fields?.standfirst,
 			fromNullable,
 			map(context.docParser),
 		),
 		byline: content.fields?.byline ?? '',
-		bylineHtml: pipe2(
+		bylineHtml: pipe(
 			content.fields?.bylineHtml,
 			fromNullable,
 			map(context.docParser),
@@ -200,7 +200,7 @@ const itemFields = (
 		branding: fromNullable(branding),
 		internalShortId: fromNullable(content.fields?.internalShortId),
 		commentCount: fromNullable(commentCount),
-		relatedContent: pipe2(
+		relatedContent: pipe(
 			relatedContent,
 			fromNullable,
 			map((relatedContent) => ({

--- a/src/lib.test.tsx
+++ b/src/lib.test.tsx
@@ -12,8 +12,6 @@ import {
 	maybeRender,
 	memoise,
 	pipe,
-	pipe2,
-	pipe3,
 	toArray,
 } from './lib';
 import 'whatwg-fetch';
@@ -56,7 +54,7 @@ describe('pipe', () => {
 	expect(result).toBe(b);
 });
 
-describe('pipe2', () => {
+describe('pipe', () => {
 	type A = number;
 	type B = string;
 	type C = boolean;
@@ -68,14 +66,14 @@ describe('pipe2', () => {
 	const f = jest.fn<B, [A]>((a: A): B => b);
 	const g = jest.fn<C, [B]>((b: B): C => c);
 
-	const result = pipe2<A, B, C>(a, f, g);
+	const result = pipe<A, B, C>(a, f, g);
 
 	expect(f).toHaveBeenCalledWith(a);
 	expect(g).toHaveBeenCalledWith(b);
 	expect(result).toBe(c);
 });
 
-describe('pipe3', () => {
+describe('pipe', () => {
 	type A = number;
 	type B = string;
 	type C = boolean;
@@ -90,7 +88,7 @@ describe('pipe3', () => {
 	const g = jest.fn<C, [B]>((b: B): C => c);
 	const h = jest.fn<D, [C]>((c: C): D => d);
 
-	const result = pipe3<A, B, C, D>(a, f, g, h);
+	const result = pipe<A, B, C, D>(a, f, g, h);
 
 	expect(f).toHaveBeenCalledWith(a);
 	expect(g).toHaveBeenCalledWith(b);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -41,15 +41,6 @@ function pipe<A, B, C, D>(
 	return f(a);
 }
 
-const pipe2 = <A, B, C>(a: A, f: (_a: A) => B, g: (_b: B) => C): C =>
-	pipe(a, f, g);
-const pipe3 = <A, B, C, D>(
-	a: A,
-	f: (_a: A) => B,
-	g: (_b: B) => C,
-	h: (_c: C) => D,
-): D => pipe(a, f, g, h);
-
 const identity = <A>(a: A): A => a;
 
 // The nodeType for ELEMENT_NODE has the value 1.
@@ -147,8 +138,6 @@ const fold = <A, B>(f: (value: A) => B, ifNone: B) => (opt: Option<A>): B => {
 export {
 	compose,
 	pipe,
-	pipe2,
-	pipe3,
 	identity,
 	isElement,
 	toArray,

--- a/src/relatedContent.ts
+++ b/src/relatedContent.ts
@@ -13,7 +13,7 @@ import {
 	isLive,
 	isVideo,
 } from 'item';
-import { pipe, pipe2 } from 'lib';
+import { pipe } from 'lib';
 
 const parseRelatedItemType = (content: Content): RelatedItemType => {
 	const { tags } = content;
@@ -48,7 +48,7 @@ const parseHeaderImage = (content: Content): Image | undefined => {
 				(asset) => asset.typeData?.isMaster,
 			);
 			const data = element.imageTypeData;
-			return pipe2(
+			return pipe(
 				masterAsset,
 				fromNullable,
 				map((asset) => ({

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -66,7 +66,7 @@ import LiveEventLink from 'components/liveEventLink';
 import Paragraph from 'components/paragraph';
 import Pullquote from 'components/pullquote';
 import RichLink from 'components/richLink';
-import { isElement, pipe, pipe2 } from 'lib';
+import { isElement, pipe } from 'lib';
 import { createElement as h } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
@@ -92,7 +92,7 @@ const transformHref = (href: string): string => {
 		'invalid url',
 	);
 
-	return pipe2(
+	return pipe(
 		toOption(url),
 		map((url) => {
 			const path = url.pathname.split('/');
@@ -114,7 +114,7 @@ const getHref = (node: Node): Option<string> =>
 	pipe(
 		getAttrs(node),
 		andThen((attrs) =>
-			pipe2(
+			pipe(
 				attrs.getNamedItem('href'),
 				fromNullable,
 				map((attr) => transformHref(attr.value)),

--- a/src/server/csp.ts
+++ b/src/server/csp.ts
@@ -7,7 +7,7 @@ import type { BodyElement } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
 import type { ThirdPartyEmbeds } from 'capi';
 import type { Item } from 'item';
-import { compose, pipe2 } from 'lib';
+import { compose, pipe } from 'lib';
 
 // ----- Types ----- //
 
@@ -27,7 +27,7 @@ const extractInteractiveAssets = (elements: BodyElement[]): Assets =>
 			if (elem.kind === ElementKind.InteractiveAtom) {
 				return {
 					styles: [...styles, elem.css],
-					scripts: pipe2(
+					scripts: pipe(
 						elem.js,
 						map((js) => [...scripts, js]),
 						withDefault(scripts),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -19,7 +19,7 @@ import express from 'express';
 import { MainMediaKind } from 'headerMedia';
 import { fromCapi } from 'item';
 import { JSDOM } from 'jsdom';
-import { pipe2, toArray } from 'lib';
+import { pipe, toArray } from 'lib';
 import { logger } from 'logger';
 import type { Response } from 'node-fetch';
 import fetch from 'node-fetch';
@@ -117,7 +117,7 @@ const askCapiFor = (articleId: string): CapiReturn =>
 
 function resourceList(script: Option<string>): string[] {
 	const emptyList: string[] = [];
-	return pipe2(script, map(toArray), withDefault(emptyList));
+	return pipe(script, map(toArray), withDefault(emptyList));
 }
 
 async function serveArticle(

--- a/src/server/ssmConfig.ts
+++ b/src/server/ssmConfig.ts
@@ -1,6 +1,6 @@
 import type { Option } from '@guardian/types';
 import { map, none, some, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 import { App, Stack, Stage } from './appIdentity';
 import { ssm } from './aws';
 
@@ -44,7 +44,7 @@ async function getState(): Promise<Config> {
 }
 
 async function fetchConfig(): Promise<Config> {
-	return pipe2(
+	return pipe(
 		state,
 		map((s) => Promise.resolve(s)),
 		withDefault(getState()),

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -10,7 +10,7 @@ import {
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import type { Format, Option } from '@guardian/types';
 import { Design, map, none, some, withDefault } from '@guardian/types';
-import { pipe2 } from 'lib';
+import { pipe } from 'lib';
 
 export const sidePadding = css`
 	padding-left: ${remSpace[2]};
@@ -190,12 +190,12 @@ export const fontFace = (
 ): string => `
   @font-face {
     font-family: ${family};
-    ${pipe2(
+    ${pipe(
 		style,
 		map((s: string) => `font-style: ${s};`),
 		withDefault(''),
 	)}
-    ${pipe2(
+    ${pipe(
 		weight,
 		map((w: number | string) => `font-weight: ${w};`),
 		withDefault(''),


### PR DESCRIPTION
## Why are you doing this?

A variadic version of `pipe` was added in #1310. This follows up on that by removing `pipe2` and `pipe3` and replacing all their usages with `pipe` instead.

## Changes

- Removed `pipe2` and `pipe3`
- Replaced all usages with `pipe`
