### PR TITLE
LIVE-2448: Replace remSpace[2] (8px) with remSpace[3]

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -199,7 +199,7 @@ exports[`Storyshots CommentCount Default 1`] = `
   border: none;
   background: none;
   border-left: 1px solid #DCDCDC;
-  padding-top: 0.5rem;
+  padding-top: 0.75rem;
   color: #C70000;
 }
 
@@ -312,8 +312,8 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 .emotion-4 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -404,7 +404,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -452,7 +452,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -719,10 +719,10 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 }
 
 .emotion-20 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-20 iframe {
@@ -732,7 +732,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 
 .emotion-20 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -743,8 +743,8 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 
   .emotion-20 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -1525,8 +1525,8 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 .emotion-4 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -1617,7 +1617,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -1665,7 +1665,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -1964,10 +1964,10 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 }
 
 .emotion-23 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-23 iframe {
@@ -1977,7 +1977,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 
 .emotion-23 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -1988,8 +1988,8 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 
   .emotion-23 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -2805,8 +2805,8 @@ exports[`Storyshots Editions/Article Default 1`] = `
 }
 
 .emotion-4 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -2897,7 +2897,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -2945,7 +2945,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -3160,10 +3160,10 @@ exports[`Storyshots Editions/Article Default 1`] = `
 }
 
 .emotion-20 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-20 iframe {
@@ -3173,7 +3173,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
 
 .emotion-20 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -3184,8 +3184,8 @@ exports[`Storyshots Editions/Article Default 1`] = `
 
   .emotion-20 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -3966,8 +3966,8 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-4 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -4058,7 +4058,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -4105,7 +4105,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   font-weight: 700;
   color: #E05E00;
   font-size: 1.0625rem;
-  padding: 0.25rem 0 0.5rem;
+  padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
 }
 
@@ -4124,7 +4124,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -4339,10 +4339,10 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 }
 
 .emotion-21 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-21 iframe {
@@ -4352,7 +4352,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 
 .emotion-21 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -4363,8 +4363,8 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 
   .emotion-21 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -5150,8 +5150,8 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 }
 
 .emotion-4 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -5242,7 +5242,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -5290,7 +5290,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -5505,10 +5505,10 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 }
 
 .emotion-20 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-20 iframe {
@@ -5518,7 +5518,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 
 .emotion-20 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -5529,8 +5529,8 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 
   .emotion-20 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -6336,7 +6336,7 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -6376,8 +6376,8 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
 }
 
 .emotion-9 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -6408,7 +6408,7 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GT Guardian Titlepiece,Georgia,serif;
   font-size: 2.625rem;
@@ -6687,10 +6687,10 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
 }
 
 .emotion-22 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-22 iframe {
@@ -6700,7 +6700,7 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
 
 .emotion-22 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -6711,8 +6711,8 @@ exports[`Storyshots Editions/Article Gallery 1`] = `
 
   .emotion-22 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -7199,7 +7199,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -7270,7 +7270,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -7359,8 +7359,8 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   justify-content: space-between;
   padding-bottom: 1rem;
   color: #121212;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -7481,8 +7481,8 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   justify-content: space-between;
   padding-bottom: 1rem;
   margin: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   border-bottom: 1px solid #DCDCDC;
 }
 
@@ -7592,10 +7592,10 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 }
 
 .emotion-22 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-22 iframe {
@@ -7605,7 +7605,7 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 
 .emotion-22 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -7616,8 +7616,8 @@ exports[`Storyshots Editions/Article Interview 1`] = `
 
   .emotion-22 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -8487,7 +8487,7 @@ exports[`Storyshots Editions/Article Letter 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -8534,7 +8534,7 @@ exports[`Storyshots Editions/Article Letter 1`] = `
   font-weight: 700;
   color: #E05E00;
   font-size: 1.0625rem;
-  padding: 0.25rem 0 0.5rem;
+  padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
 }
 
@@ -8553,7 +8553,7 @@ exports[`Storyshots Editions/Article Letter 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -8723,10 +8723,10 @@ exports[`Storyshots Editions/Article Letter 1`] = `
 }
 
 .emotion-17 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-17 iframe {
@@ -8736,7 +8736,7 @@ exports[`Storyshots Editions/Article Letter 1`] = `
 
 .emotion-17 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -8747,8 +8747,8 @@ exports[`Storyshots Editions/Article Letter 1`] = `
 
   .emotion-17 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -9516,8 +9516,8 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 }
 
 .emotion-4 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -9553,7 +9553,7 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 
 .emotion-7 {
   background-color: #FFE500;
-  padding: 0.5rem;
+  padding: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -9661,7 +9661,7 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   font-size: 2.625rem;
   line-height: 1.15;
   font-weight: 700;
-  margin-right: 0.5rem;
+  margin-right: 0.75rem;
 }
 
 .emotion-15 {
@@ -9751,18 +9751,18 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   font-size: 2.625rem;
   line-height: 1.15;
   font-weight: 700;
-  margin-right: 0.5rem;
+  margin-right: 0.75rem;
 }
 
 @media (min-width: 660px) {
   .emotion-21 {
-    margin-left: 0.5rem;
+    margin-left: 0.75rem;
   }
 }
 
 @media (min-width: 660px) {
   .emotion-24 {
-    margin-left: 0.5rem;
+    margin-left: 0.75rem;
   }
 }
 
@@ -9846,7 +9846,7 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -9893,7 +9893,7 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   font-weight: 700;
   color: #0084C6;
   font-size: 1.0625rem;
-  padding: 0.25rem 0 0.5rem;
+  padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
 }
 
@@ -9912,7 +9912,7 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -10127,10 +10127,10 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 }
 
 .emotion-42 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-42 iframe {
@@ -10140,7 +10140,7 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 
 .emotion-42 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -10151,8 +10151,8 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 
   .emotion-42 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -10728,8 +10728,8 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 .emotion-4 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -10820,7 +10820,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -10904,7 +10904,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -11119,10 +11119,10 @@ exports[`Storyshots Editions/Article Review 1`] = `
 }
 
 .emotion-26 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-26 iframe {
@@ -11132,7 +11132,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
 
 .emotion-26 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -11143,8 +11143,8 @@ exports[`Storyshots Editions/Article Review 1`] = `
 
   .emotion-26 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -11999,8 +11999,8 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 .emotion-4 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -12019,7 +12019,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -12126,7 +12126,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -12360,10 +12360,10 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 }
 
 .emotion-20 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .emotion-20 iframe {
@@ -12373,7 +12373,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 
 .emotion-20 figcaption {
   background: #FFFFFF;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -12384,8 +12384,8 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 
   .emotion-20 p {
     margin: 0;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 }
 
@@ -13634,8 +13634,8 @@ exports[`Storyshots Editions/Byline Interview 1`] = `
   justify-content: space-between;
   padding-bottom: 1rem;
   margin: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   border-bottom: 1px solid #DCDCDC;
 }
 
@@ -13963,7 +13963,7 @@ exports[`Storyshots Editions/Byline Showcase 1`] = `
 exports[`Storyshots Editions/FootballScores Default 1`] = `
 .emotion-0 {
   background-color: #FFE500;
-  padding: 0.5rem;
+  padding: 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -14071,7 +14071,7 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
   font-size: 2.625rem;
   line-height: 1.15;
   font-weight: 700;
-  margin-right: 0.5rem;
+  margin-right: 0.75rem;
 }
 
 .emotion-8 {
@@ -14145,18 +14145,18 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
   font-size: 2.625rem;
   line-height: 1.15;
   font-weight: 700;
-  margin-right: 0.5rem;
+  margin-right: 0.75rem;
 }
 
 @media (min-width: 660px) {
   .emotion-13 {
-    margin-left: 0.5rem;
+    margin-left: 0.75rem;
   }
 }
 
 @media (min-width: 660px) {
   .emotion-16 {
-    margin-left: 0.5rem;
+    margin-left: 0.75rem;
   }
 }
 
@@ -14420,7 +14420,7 @@ exports[`Storyshots Editions/HeaderMedia Full Screen 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -14595,7 +14595,7 @@ exports[`Storyshots Editions/HeaderMedia Image 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -14799,7 +14799,7 @@ exports[`Storyshots Editions/HeaderMedia With Star Rating 1`] = `
   max-height: 999px;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.8);
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow: hidden;
   padding-right: 3rem;
   z-index: 1;
@@ -15012,7 +15012,7 @@ exports[`Storyshots Editions/Headline Analysis 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -15064,7 +15064,7 @@ exports[`Storyshots Editions/Headline Comment 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -15145,7 +15145,7 @@ exports[`Storyshots Editions/Headline Default 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -15192,7 +15192,7 @@ exports[`Storyshots Editions/Headline Feature 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -15246,7 +15246,7 @@ exports[`Storyshots Editions/Headline Interview 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -15349,7 +15349,7 @@ exports[`Storyshots Editions/Headline Media 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GT Guardian Titlepiece,Georgia,serif;
   font-size: 2.625rem;
@@ -15395,7 +15395,7 @@ exports[`Storyshots Editions/Headline Review 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -15442,7 +15442,7 @@ exports[`Storyshots Editions/Headline Showcase 1`] = `
   box-sizing: border-box;
   border-top: 1px solid #DCDCDC;
   padding-bottom: 1rem;
-  padding-right: 0.5rem;
+  padding-right: 0.75rem;
   margin: 0;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.5rem;
@@ -15589,7 +15589,7 @@ exports[`Storyshots Editions/Series Default 1`] = `
   font-weight: 700;
   color: #C70000;
   font-size: 1.0625rem;
-  padding: 0.25rem 0 0.5rem;
+  padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
 }
 
@@ -15615,7 +15615,7 @@ exports[`Storyshots Editions/Series Immersive 1`] = `
   font-weight: 700;
   color: #C70000;
   font-size: 1.0625rem;
-  padding: 0.25rem 0 0.5rem;
+  padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
   position: absolute;
   left: 0;
@@ -15623,7 +15623,7 @@ exports[`Storyshots Editions/Series Immersive 1`] = `
   border: 0;
   color: #FFFFFF;
   background-color: #C70000;
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -15648,7 +15648,7 @@ exports[`Storyshots Editions/Series Interview 1`] = `
   font-weight: 700;
   color: #A1845C;
   font-size: 1.0625rem;
-  padding: 0.25rem 0 0.5rem;
+  padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
   position: absolute;
   left: 0;
@@ -15656,7 +15656,7 @@ exports[`Storyshots Editions/Series Interview 1`] = `
   border: 0;
   color: #FFFFFF;
   background-color: #A1845C;
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem 0.75rem;
 }
 
 @media (min-width: 740px) {
@@ -16408,7 +16408,7 @@ html:not(.src-focus-disabled) .emotion-4:focus {
 @media (prefers-color-scheme: dark) {
   .emotion-5 {
     background: white;
-    padding: 0.5rem;
+    padding: 0.75rem;
   }
 }
 
@@ -17114,7 +17114,7 @@ exports[`Storyshots Follow Default 1`] = `
 exports[`Storyshots FootballScores Default 1`] = `
 .emotion-0 {
   background-color: #FFE500;
-  padding: 0.5rem;
+  padding: 0.75rem;
 }
 
 .emotion-1 {
@@ -17138,7 +17138,7 @@ exports[`Storyshots FootballScores Default 1`] = `
   grid-column: 1;
   grid-row: 1;
   text-align: center;
-  margin-right: 0.5rem;
+  margin-right: 0.75rem;
 }
 
 @media (min-width: 660px) {
@@ -17418,8 +17418,8 @@ exports[`Storyshots Footer Default 1`] = `
   font-size: 0.9375rem;
   line-height: 1.35;
   font-weight: 400;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
   padding-top: 1rem;
   padding-bottom: 1.5rem;
 }
@@ -17485,8 +17485,8 @@ exports[`Storyshots Footer With Ccpa 1`] = `
   font-size: 0.9375rem;
   line-height: 1.35;
   font-weight: 400;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
   padding-top: 1rem;
   padding-bottom: 1.5rem;
 }
@@ -17555,8 +17555,8 @@ exports[`Storyshots Headline Analysis 1`] = `
   background-color: #FFFFFF;
   padding-bottom: 2.25rem;
   margin: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 2.125rem;
   line-height: 1.35;
@@ -17625,8 +17625,8 @@ exports[`Storyshots Headline Default 1`] = `
   background-color: #FFFFFF;
   padding-bottom: 2.25rem;
   margin: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   font-size: 34px;
 }
 
@@ -17680,8 +17680,8 @@ exports[`Storyshots Headline Feature 1`] = `
   background-color: #FFFFFF;
   padding-bottom: 2.25rem;
   margin: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 2.125rem;
   line-height: 1.15;
@@ -17739,8 +17739,8 @@ exports[`Storyshots Headline Labs 1`] = `
   background-color: #FFFFFF;
   padding-bottom: 2.25rem;
   margin: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 2.125rem;
   line-height: 1.35;
@@ -17798,8 +17798,8 @@ exports[`Storyshots Headline Review 1`] = `
   background-color: #FFFFFF;
   padding-bottom: 2.25rem;
   margin: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   font-size: 34px;
 }
 
@@ -18027,13 +18027,13 @@ exports[`Storyshots Rich Link Default 1`] = `
 
 .emotion-1 {
   background: #F6F6F6;
-  padding: 0.5rem;
+  padding: 0.75rem;
   border-top: solid 1px #999999;
   -webkit-transition: all 0.2s ease;
   transition: all 0.2s ease;
   float: left;
   clear: left;
-  margin: 0.5rem 1rem 0.5rem 0;
+  margin: 0.75rem 1rem 0.75rem 0;
   width: 8.75rem;
 }
 
@@ -18209,7 +18209,7 @@ exports[`Storyshots Rich Link Default 1`] = `
 
 .emotion-1 .js-image img {
   width: calc(100% + 1rem);
-  margin: -0.5rem 0 0 -0.5rem;
+  margin: -0.75rem 0 0 -0.75rem;
 }
 
 .emotion-1 button {
@@ -18235,7 +18235,7 @@ exports[`Storyshots Rich Link Default 1`] = `
   border: solid 1px #121212;
   padding: 4px;
   display: inline-block;
-  margin-right: 0.5rem;
+  margin-right: 0.75rem;
   -webkit-transition: all 0.2s ease;
   transition: all 0.2s ease;
 }
@@ -18313,7 +18313,7 @@ exports[`Storyshots Rich Link Default 1`] = `
 
 exports[`Storyshots Standfirst Comment 1`] = `
 .emotion-0 {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
   color: #121212;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -18323,7 +18323,7 @@ exports[`Storyshots Standfirst Comment 1`] = `
 
 .emotion-0 p,
 .emotion-0 ul {
-  margin: 0.5rem 0;
+  margin: 0.75rem 0;
 }
 
 .emotion-0 address {
@@ -18353,7 +18353,7 @@ exports[`Storyshots Standfirst Comment 1`] = `
 
 exports[`Storyshots Standfirst Default 1`] = `
 .emotion-0 {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
   color: #121212;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.0625rem;
@@ -18364,7 +18364,7 @@ exports[`Storyshots Standfirst Default 1`] = `
 
 .emotion-0 p,
 .emotion-0 ul {
-  margin: 0.5rem 0;
+  margin: 0.75rem 0;
 }
 
 .emotion-0 address {
@@ -18394,7 +18394,7 @@ exports[`Storyshots Standfirst Default 1`] = `
 
 exports[`Storyshots Standfirst Feature 1`] = `
 .emotion-0 {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
   color: #121212;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -18404,7 +18404,7 @@ exports[`Storyshots Standfirst Feature 1`] = `
 
 .emotion-0 p,
 .emotion-0 ul {
-  margin: 0.5rem 0;
+  margin: 0.75rem 0;
 }
 
 .emotion-0 address {
@@ -18434,7 +18434,7 @@ exports[`Storyshots Standfirst Feature 1`] = `
 
 exports[`Storyshots Standfirst Review 1`] = `
 .emotion-0 {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
   color: #121212;
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 1.25rem;
@@ -18444,7 +18444,7 @@ exports[`Storyshots Standfirst Review 1`] = `
 
 .emotion-0 p,
 .emotion-0 ul {
-  margin: 0.5rem 0;
+  margin: 0.75rem 0;
 }
 
 .emotion-0 address {
@@ -18599,7 +18599,7 @@ exports[`Storyshots Tags Default 1`] = `
   margin-bottom: 0;
   display: block;
   list-style: none;
-  padding: 0.5rem 0 1rem 0;
+  padding: 0.75rem 0 1rem 0;
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 1.0625rem;
   line-height: 1.5;
@@ -18614,7 +18614,7 @@ exports[`Storyshots Tags Default 1`] = `
 }
 
 .emotion-1 {
-  margin: 0.5rem 0.5rem 0 0;
+  margin: 0.75rem 0.75rem 0 0;
   display: inline-block;
 }
 

--- a/src/components/atoms/interactiveAtom.tsx
+++ b/src/components/atoms/interactiveAtom.tsx
@@ -35,7 +35,7 @@ const atomCss = `
     @media (prefers-color-scheme: dark) {
         body {
             background: white;
-            padding: ${remSpace[2]} !important;
+            padding: ${remSpace[3]} !important;
         } 
     }`;
 const atomScript = `

--- a/src/components/body.tsx
+++ b/src/components/body.tsx
@@ -34,7 +34,7 @@ interface Props {
 const notImplemented = (
 	<p
 		css={css`
-			padding: 0 ${remSpace[2]};
+			padding: 0 ${remSpace[3]};
 		`}
 	>
 		Content format not implemented yet

--- a/src/components/bodyImageHalfWidth.tsx
+++ b/src/components/bodyImageHalfWidth.tsx
@@ -21,7 +21,7 @@ const styles = css`
 
 	+ .halfWidth,
 	+ .halfWidth + .halfWidth + .halfWidth {
-		margin-left: ${remSpace[2]};
+		margin-left: ${remSpace[3]};
 	}
 
 	+ .halfWidth + .halfWidth {

--- a/src/components/bodyImageThumbnail.tsx
+++ b/src/components/bodyImageThumbnail.tsx
@@ -22,7 +22,7 @@ const styles = css`
 	margin: 0 ${remSpace[3]} 0 0;
 
 	${from.wide} {
-		margin-left: calc(-${size} - ${remSpace[3]} - ${remSpace[2]});
+		margin-left: calc(-${size} - ${remSpace[3]} - ${remSpace[3]});
 		margin-right: 0;
 		padding: 0;
 	}

--- a/src/components/calloutForm.tsx
+++ b/src/components/calloutForm.tsx
@@ -80,7 +80,7 @@ const descriptionStyles = css`
 
 	p {
 		${body.small({ lineHeight: 'tight' })};
-		margin: ${remSpace[2]} 0;
+		margin: ${remSpace[3]} 0;
 	}
 `;
 
@@ -111,7 +111,7 @@ const speechBubbleStyles = (kicker: string): SerializedStyles => css`
 `;
 
 const formStyles = css`
-	margin: ${remSpace[4]} ${remSpace[2]} ${remSpace[9]} ${remSpace[2]};
+	margin: ${remSpace[4]} ${remSpace[3]} ${remSpace[9]} ${remSpace[3]};
 `;
 
 const formAnchor = (kicker: string): SerializedStyles => css`
@@ -119,8 +119,8 @@ const formAnchor = (kicker: string): SerializedStyles => css`
 	text-decoration: none;
 	${textSans.small()};
 	position: absolute;
-	bottom: ${remSpace[2]};
-	right: ${remSpace[2]};
+	bottom: ${remSpace[3]};
+	right: ${remSpace[3]};
 `;
 
 const renderField = ({

--- a/src/components/comment/article.tsx
+++ b/src/components/comment/article.tsx
@@ -52,10 +52,10 @@ const BorderStyles = css`
 
 const topBorder = css`
 	border-top: solid 1px ${neutral[86]};
-	margin-top: ${remSpace[2]};
+	margin-top: ${remSpace[3]};
 
 	${from.wide} {
-		margin-top: ${remSpace[2]};
+		margin-top: ${remSpace[3]};
 	}
 
 	${darkModeCss`

--- a/src/components/commentCount.tsx
+++ b/src/components/commentCount.tsx
@@ -24,7 +24,7 @@ const styles = (colour: string): SerializedStyles => css`
 	border: none;
 	background: none;
 	border-left: 1px solid ${border.secondary};
-	padding-top: ${remSpace[2]};
+	padding-top: ${remSpace[3]};
 	color: ${colour};
 	${darkModeCss`
         border-left: 1px solid ${neutral[20]};

--- a/src/components/editions/article/index.tsx
+++ b/src/components/editions/article/index.tsx
@@ -53,8 +53,8 @@ const headerStyles = css`
 `;
 
 const bodyStyles = css`
-	padding-top: ${remSpace[2]};
-	padding-bottom: ${remSpace[2]};
+	padding-top: ${remSpace[3]};
+	padding-bottom: ${remSpace[3]};
 	iframe {
 		width: 100%;
 		border: none;
@@ -62,7 +62,7 @@ const bodyStyles = css`
 
 	figcaption {
 		background: ${background.primary};
-		padding-bottom: ${remSpace[2]};
+		padding-bottom: ${remSpace[3]};
 	}
 
 	${from.tablet} {
@@ -71,8 +71,8 @@ const bodyStyles = css`
 
 		p {
 			margin: 0;
-			padding-top: ${remSpace[2]};
-			padding-bottom: ${remSpace[2]};
+			padding-top: ${remSpace[3]};
+			padding-bottom: ${remSpace[3]};
 		}
 	}
 

--- a/src/components/editions/byline/index.tsx
+++ b/src/components/editions/byline/index.tsx
@@ -30,8 +30,8 @@ import {
 // ----- Template Specific Styles ----- //
 
 const interviewStyles = css`
-	padding-left: ${remSpace[2]};
-	padding-right: ${remSpace[2]};
+	padding-left: ${remSpace[3]};
+	padding-right: ${remSpace[3]};
 
 	${from.tablet} {
 		box-sizing: border-box;
@@ -49,14 +49,14 @@ const interviewStyles = css`
 `;
 
 const immersiveStyles = css`
-	padding-left: ${remSpace[2]};
-	padding-right: ${remSpace[2]};
+	padding-left: ${remSpace[3]};
+	padding-right: ${remSpace[3]};
 	box-sizing: border-box;
 	background-color: ${neutral[7]};
 
 	${from.tablet} {
 		padding-left: 0;
-		padding-right: ${remSpace[2]};
+		padding-right: ${remSpace[3]};
 		margin-left: ${remSpace[6]};
 		width: ${tabletImmersiveWidth}px;
 	}

--- a/src/components/editions/footballScores/index.tsx
+++ b/src/components/editions/footballScores/index.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 const styles = css`
 	background-color: ${brandAltBackground.primary};
-	padding: ${remSpace[2]};
+	padding: ${remSpace[3]};
 
 	${from.tablet} {
 		width: ${tabletContentWidth + 5}px;

--- a/src/components/editions/header/index.tsx
+++ b/src/components/editions/header/index.tsx
@@ -125,8 +125,8 @@ const immersiveHeadlineStyles = (item: Item): SerializedStyles => {
 };
 
 const immersiveStandfirstStyles = css`
-	padding-left: ${remSpace[2]};
-	padding-right: ${remSpace[2]};
+	padding-left: ${remSpace[3]};
+	padding-right: ${remSpace[3]};
 
 	${from.tablet} {
 		padding-left: ${tabletArticleMargin}px;

--- a/src/components/editions/headerImageCaption.tsx
+++ b/src/components/editions/headerImageCaption.tsx
@@ -41,7 +41,7 @@ const HeaderImageCaptionStyles = (
 		max-height: 999px;
 		height: 100%;
 		background-color: rgba(0, 0, 0, 0.8);
-		padding: ${remSpace[2]};
+		padding: ${remSpace[3]};
 		overflow: hidden;
 		padding-right: ${remSpace[12]};
 		z-index: 1;

--- a/src/components/editions/headline/index.tsx
+++ b/src/components/editions/headline/index.tsx
@@ -52,7 +52,7 @@ const headlineWrapperStyles = css`
 
 const immersiveStyles = css`
 	border: 0;
-	padding-left: ${remSpace[2]};
+	padding-left: ${remSpace[3]};
 	padding-top: 0.0625rem;
 	padding-bottom: ${remSpace[6]};
 	background-color: ${neutral[7]};
@@ -122,7 +122,7 @@ const getSharedStyles = (format: Format): SerializedStyles => css`
 	box-sizing: border-box;
 	border-top: 1px solid ${border.secondary};
 	padding-bottom: ${remSpace[4]};
-	padding-right: ${remSpace[2]};
+	padding-right: ${remSpace[3]};
 	margin: 0;
 `;
 

--- a/src/components/editions/series/index.tsx
+++ b/src/components/editions/series/index.tsx
@@ -20,7 +20,7 @@ const styles = (kicker: string): SerializedStyles => css`
 	${titlepiece.small()}
 	color: ${kicker};
 	font-size: 1.0625rem;
-	padding: ${remSpace[1]} 0 ${remSpace[2]};
+	padding: ${remSpace[1]} 0 ${remSpace[3]};
 	box-sizing: border-box;
 
 	${from.tablet} {
@@ -35,7 +35,7 @@ const interviewStyles = (kicker: string): SerializedStyles => css`
 	border: 0;
 	color: ${neutral[100]};
 	background-color: ${kicker};
-	padding: ${remSpace[2]} ${remSpace[3]};
+	padding: ${remSpace[3]} ${remSpace[3]};
 `;
 
 interface Props {

--- a/src/components/editions/styles.ts
+++ b/src/components/editions/styles.ts
@@ -23,8 +23,8 @@ export const tabletImmersiveWidth = tabletBorderWidth;
 export const wideImmersiveWidth = wideBorderWidth;
 
 export const sidePadding = css`
-	padding-left: ${remSpace[2]};
-	padding-right: ${remSpace[2]};
+	padding-left: ${remSpace[3]};
+	padding-right: ${remSpace[3]};
 
 	${from.tablet} {
 		padding-left: 0;

--- a/src/components/editions/teamScore/index.tsx
+++ b/src/components/editions/teamScore/index.tsx
@@ -47,10 +47,10 @@ const teamNameStyles = css`
 
 const scoreStyles = (location: TeamLocation): SerializedStyles => css`
 	${headline.large({ fontWeight: 'bold' })}
-	margin-right: ${remSpace[2]};
+	margin-right: ${remSpace[3]};
 
 	${from.phablet} {
-		${location === TeamLocation.Away ? `margin-left: ${remSpace[2]};` : ''}
+		${location === TeamLocation.Away ? `margin-left: ${remSpace[3]};` : ''}
 	}
 `;
 
@@ -71,7 +71,7 @@ const scoreInlineStyles = css`
 
 const infoStyles = (location: TeamLocation): SerializedStyles => css`
 	${from.phablet} {
-		${location === TeamLocation.Away ? `margin-left: ${remSpace[2]};` : ''}
+		${location === TeamLocation.Away ? `margin-left: ${remSpace[3]};` : ''}
 	}
 `;
 

--- a/src/components/footballScores.tsx
+++ b/src/components/footballScores.tsx
@@ -24,7 +24,7 @@ interface Props {
 
 const styles = css`
 	background-color: ${brandAltBackground.primary};
-	padding: ${remSpace[2]};
+	padding: ${remSpace[3]};
 `;
 
 const matchInfoStyles = css`
@@ -40,7 +40,7 @@ const matchStatusStyles = css`
 	grid-column: 1;
 	grid-row: 1;
 	text-align: center;
-	margin-right: ${remSpace[2]};
+	margin-right: ${remSpace[3]};
 
 	${from.phablet} {
 		grid-column: 2;

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -14,8 +14,8 @@ import { darkModeCss } from 'styles';
 const styles = css`
 	border-width: 0 1px;
 	${textSans.small({ lineHeight: 'regular' })};
-	margin-left: ${remSpace[2]};
-	margin-right: ${remSpace[2]};
+	margin-left: ${remSpace[3]};
+	margin-right: ${remSpace[3]};
 	padding-top: ${remSpace[4]};
 	padding-bottom: ${remSpace[6]};
 

--- a/src/components/genericEmbed.tsx
+++ b/src/components/genericEmbed.tsx
@@ -17,7 +17,7 @@ const styles = css`
 
 	${darkModeCss`
         background: white;
-        padding: ${remSpace[2]};
+        padding: ${remSpace[3]};
     `}
 `;
 

--- a/src/components/headerImage.tsx
+++ b/src/components/headerImage.tsx
@@ -37,7 +37,7 @@ const Caption: FC<CaptionProps> = ({ format, image }: CaptionProps) => {
 // ----- Component ----- //
 
 const styles = css`
-	margin: 0 0 ${remSpace[2]} 0;
+	margin: 0 0 ${remSpace[3]} 0;
 	position: relative;
 
 	${from.wide} {

--- a/src/components/headerImageCaption.tsx
+++ b/src/components/headerImageCaption.tsx
@@ -44,7 +44,7 @@ const HeaderImageCaptionStyles = (
 		min-height: 44px;
 		max-height: 999px;
 		background-color: rgba(0, 0, 0, 0.8);
-		padding: ${remSpace[2]};
+		padding: ${remSpace[3]};
 		overflow: hidden;
 		padding-right: ${remSpace[12]};
 		z-index: 1;

--- a/src/components/headerVideo.tsx
+++ b/src/components/headerVideo.tsx
@@ -31,7 +31,7 @@ const backgroundColour = (format: Format): string => {
 };
 
 const styles = (format: Format): SerializedStyles => css`
-	margin: 0 0 ${remSpace[2]} 0;
+	margin: 0 0 ${remSpace[3]} 0;
 	position: relative;
 	display: block;
 	width: 100%;

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -33,7 +33,7 @@ const styles = (format: Format): SerializedStyles => css`
 const immersiveStyles = css`
 	${headline.medium({ fontWeight: 'bold' })}
 	font-weight: 700;
-	padding: ${remSpace[1]} ${remSpace[2]} ${remSpace[6]} ${remSpace[2]};
+	padding: ${remSpace[1]} ${remSpace[3]} ${remSpace[6]} ${remSpace[3]};
 	margin: calc(80vh - 5rem) 0 0;
 	position: relative;
 	display: inline-block;
@@ -52,9 +52,9 @@ const immersiveStyles = css`
 	${from.wide} {
 		width: 100%;
 		margin-left: calc(
-			((100% - ${wideContentWidth}px) / 2) - ${remSpace[2]}
+			((100% - ${wideContentWidth}px) / 2) - ${remSpace[3]}
 		);
-		padding-left: ${remSpace[2]};
+		padding-left: ${remSpace[3]};
 
 		span {
 			display: block;

--- a/src/components/labs/logo.tsx
+++ b/src/components/labs/logo.tsx
@@ -22,7 +22,7 @@ const styles = css`
 	${darkModeCss`
         color: ${neutral[60]};
         img {
-            padding: ${remSpace[2]};
+            padding: ${remSpace[3]};
             background: ${neutral[86]};
         }
 

--- a/src/components/liveEventLink.tsx
+++ b/src/components/liveEventLink.tsx
@@ -27,7 +27,7 @@ const liveEventLinkStyles: SerializedStyles = css`
 		div {
 			background: #b84376;
 			color: white;
-			padding: ${remSpace[2]} ${remSpace[9]} ${remSpace[2]} ${remSpace[2]};
+			padding: ${remSpace[3]} ${remSpace[9]} ${remSpace[3]} ${remSpace[3]};
 
 			svg {
 				fill: currentColor;
@@ -39,11 +39,11 @@ const liveEventLinkStyles: SerializedStyles = css`
 		}
 
 		section {
-			padding: ${remSpace[2]};
+			padding: ${remSpace[3]};
 			${textSans.xsmall()};
 
 			h1 {
-				margin: 0 0 ${remSpace[2]} 0;
+				margin: 0 0 ${remSpace[3]} 0;
 				${headline.xxxsmall({ fontWeight: 'bold' })}
 				hyphens: auto;
 			}
@@ -68,7 +68,7 @@ const liveEventLinkStyles: SerializedStyles = css`
 
 	float: left;
 	clear: left;
-	margin: ${remSpace[2]} ${remSpace[4]} ${remSpace[2]} 0;
+	margin: ${remSpace[3]} ${remSpace[4]} ${remSpace[3]} 0;
 
 	width: ${richLinkWidth};
 

--- a/src/components/media/articleBody.tsx
+++ b/src/components/media/articleBody.tsx
@@ -25,7 +25,7 @@ const ArticleBodyDarkStyles = ({
     }
     p:last-child {
         margin-bottom: 0;
-        padding-bottom: ${remSpace[2]};
+        padding-bottom: ${remSpace[3]};
     }
 `;
 

--- a/src/components/media/byline.tsx
+++ b/src/components/media/byline.tsx
@@ -18,7 +18,7 @@ import { renderText } from '../../renderer';
 
 const styles: SerializedStyles = css`
 	.author {
-		margin: ${remSpace[2]} 0 ${remSpace[3]} 0;
+		margin: ${remSpace[3]} 0 ${remSpace[3]} 0;
 		color: ${neutral[86]};
 
 		.follow,

--- a/src/components/media/tags.tsx
+++ b/src/components/media/tags.tsx
@@ -11,18 +11,18 @@ const tagsStyles = (background: string = neutral[20]): SerializedStyles => css`
 
 	display: block;
 	list-style: none;
-	padding: ${remSpace[2]} 0 ${remSpace[3]} 0;
+	padding: ${remSpace[3]} 0 ${remSpace[3]} 0;
 	${textSans.medium()}
 
 	li {
-		margin: ${remSpace[2]} ${remSpace[2]} ${remSpace[1]} 0;
+		margin: ${remSpace[3]} ${remSpace[3]} ${remSpace[1]} 0;
 		display: inline-block;
 		padding: ${remSpace[1]} 0;
 
 		a {
 			text-decoration: none;
 			white-space: nowrap;
-			padding: ${remSpace[2]} ${remSpace[3]};
+			padding: ${remSpace[3]} ${remSpace[3]};
 			border-radius: 30px;
 			text-overflow: ellipsis;
 			max-width: 18.75rem;

--- a/src/components/pullquote.tsx
+++ b/src/components/pullquote.tsx
@@ -24,7 +24,7 @@ const quoteStyles = (format: Format): SerializedStyles => {
 	const { kicker, inverted } = getThemeStyles(format.theme);
 
 	return css`
-		margin: ${remSpace[4]} 0 ${remSpace[2]} 0;
+		margin: ${remSpace[4]} 0 ${remSpace[3]} 0;
 
 		svg {
 			margin-bottom: -0.6rem;

--- a/src/components/richLink.tsx
+++ b/src/components/richLink.tsx
@@ -54,7 +54,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 
 	return css`
 		background: ${backgroundColor};
-		padding: ${remSpace[2]};
+		padding: ${remSpace[3]};
 		border-top: solid 1px ${neutral[60]};
 		transition: all 0.2s ease;
 
@@ -80,7 +80,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 
 		.js-image img {
 			width: calc(100% + ${remSpace[4]});
-			margin: -${remSpace[2]} 0 0 -${remSpace[2]};
+			margin: -${remSpace[3]} 0 0 -${remSpace[3]};
 		}
 
 		button {
@@ -99,7 +99,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 			border: solid 1px ${neutral[7]};
 			padding: 4px;
 			display: inline-block;
-			margin-right: ${remSpace[2]};
+			margin-right: ${remSpace[3]};
 			transition: all 0.2s ease;
 		}
 
@@ -117,7 +117,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 
 		float: left;
 		clear: left;
-		margin: ${remSpace[2]} ${remSpace[4]} ${remSpace[2]} 0;
+		margin: ${remSpace[3]} ${remSpace[4]} ${remSpace[3]} 0;
 
 		width: ${richLinkWidth};
 		${from.wide} {

--- a/src/components/series.tsx
+++ b/src/components/series.tsx
@@ -25,7 +25,7 @@ const immersiveStyles = (
 	{ kicker }: ThemeStyles,
 	isLabs: boolean,
 ): SerializedStyles => css`
-	padding: ${remSpace[1]} ${remSpace[2]};
+	padding: ${remSpace[1]} ${remSpace[3]};
 	background-color: ${isLabs ? palette.labs[300] : kicker};
 	position: absolute;
 	left: 0;
@@ -39,7 +39,7 @@ const immersiveStyles = (
 
 	${from.wide} {
 		margin-left: calc(
-			((100% - ${wideContentWidth}px) / 2) - ${remSpace[2]}
+			((100% - ${wideContentWidth}px) / 2) - ${remSpace[3]}
 		);
 	}
 `;

--- a/src/components/shared/bylineCard.tsx
+++ b/src/components/shared/bylineCard.tsx
@@ -58,7 +58,7 @@ const bylineImage = css`
 	contain: paint;
 	background-color: ${opinion[400]};
 	float: right;
-	margin: 0 ${remSpace[2]} 0 0;
+	margin: 0 ${remSpace[3]} 0 0;
 	position: relative;
 
 	img {
@@ -81,13 +81,13 @@ const anchorStyles = css`
 `;
 
 const headingWrapperStyles = css`
-	padding: ${remSpace[2]};
+	padding: ${remSpace[3]};
 	min-height: 10rem;
 `;
 
 const headingStyles: SerializedStyles = css`
 	${headline.xxsmall()}
-	margin: 0 0 ${remSpace[2]} 0;
+	margin: 0 0 ${remSpace[3]} 0;
 `;
 
 const cardStyles: SerializedStyles = css`
@@ -143,7 +143,7 @@ const dateStyles = css`
 	display: inline-block;
 	vertical-align: top;
 	float: right;
-	margin-right: ${remSpace[2]};
+	margin-right: ${remSpace[3]};
 	align-self: flex-end;
 `;
 
@@ -159,7 +159,7 @@ const lineStyles = css`
 	background-size: 1px calc(0.75rem + 1px);
 	height: calc(0.75rem + 1px);
 	flex-grow: 1;
-	margin-right: ${remSpace[2]};
+	margin-right: ${remSpace[3]};
 	align-self: flex-end;
 	${darkModeCss`
         background-image: repeating-linear-gradient(${neutral[20]}, ${neutral[20]} 1px, transparent 1px, transparent 0.25rem);

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -106,7 +106,7 @@ const timeStyles = (type: RelatedItemType): SerializedStyles => {
 };
 
 const durationStyles = css`
-	margin-left: ${remSpace[2]};
+	margin-left: ${remSpace[3]};
 `;
 
 const dateStyles = css`
@@ -122,7 +122,7 @@ const anchorStyles = css`
 `;
 
 const headingWrapperStyles = css`
-	padding: ${remSpace[2]};
+	padding: ${remSpace[3]};
 	min-height: 10rem;
 `;
 
@@ -130,12 +130,12 @@ const headingStyles = (type: RelatedItemType): SerializedStyles => {
 	if (type === RelatedItemType.ADVERTISEMENT_FEATURE) {
 		return css`
 			${textSans.medium({ lineHeight: 'regular' })}
-			margin: 0 0 ${remSpace[2]} 0;
+			margin: 0 0 ${remSpace[3]} 0;
 		`;
 	} else {
 		return css`
 			${headline.xxsmall()}
-			margin: 0 0 ${remSpace[2]} 0;
+			margin: 0 0 ${remSpace[3]} 0;
 		`;
 	}
 };
@@ -322,7 +322,7 @@ const quotationComment = (
 };
 
 const metadataStyles: SerializedStyles = css`
-	padding: 0 ${remSpace[2]};
+	padding: 0 ${remSpace[3]};
 	min-height: 2rem;
 `;
 

--- a/src/components/shared/epic.tsx
+++ b/src/components/shared/epic.tsx
@@ -17,12 +17,12 @@ import { darkModeCss } from 'styles';
 const styles: SerializedStyles = css`
 	& > div {
 		${from.wide} {
-			margin: ${remSpace[2]} 0;
+			margin: ${remSpace[3]} 0;
 		}
 
 		border-top: 1px solid ${brandAltBackground.primary};
 		background: ${neutral[97]};
-		padding: ${remSpace[2]};
+		padding: ${remSpace[3]};
 		${body.medium()}
 		clear: left;
 	}
@@ -33,7 +33,7 @@ const styles: SerializedStyles = css`
 	}
 
 	button {
-		margin: 0 ${remSpace[2]} ${remSpace[2]} 0;
+		margin: 0 ${remSpace[3]} ${remSpace[3]} 0;
 	}
 
 	.button-container {
@@ -84,7 +84,7 @@ const styles: SerializedStyles = css`
 		background-color: #ffe500;
 		color: #052962;
 
-		margin: 0 ${remSpace[2]} ${remSpace[2]} 0;
+		margin: 0 ${remSpace[3]} ${remSpace[3]} 0;
 	}
 `;
 

--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -31,7 +31,7 @@ const styles = (
 		img {
 			content: url('${lightModeImage}');
 			display: block;
-			margin: ${remSpace[2]} 0;
+			margin: ${remSpace[3]} 0;
 			max-height: 60px;
 		}
 

--- a/src/components/standard/article.tsx
+++ b/src/components/standard/article.tsx
@@ -72,7 +72,7 @@ const itemStyles = (item: Item): SerializedStyles => {
 					display: inline-block;
 					font-weight: 900;
 					float: left;
-					margin-right: ${remSpace[2]};
+					margin-right: ${remSpace[3]};
 
 					${darkModeCss`
                         color: ${inverted};

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -30,12 +30,12 @@ const darkStyles: SerializedStyles = darkMode`
 `;
 
 const styles: SerializedStyles = css`
-	margin-bottom: ${remSpace[2]};
+	margin-bottom: ${remSpace[3]};
 	color: ${text.primary};
 
 	p,
 	ul {
-		margin: ${remSpace[2]} 0;
+		margin: ${remSpace[3]} 0;
 	}
 
 	address {

--- a/src/components/tags.tsx
+++ b/src/components/tags.tsx
@@ -28,7 +28,7 @@ const styles = css`
 	margin-bottom: 0;
 	display: block;
 	list-style: none;
-	padding: ${remSpace[2]} 0 ${remSpace[4]} 0;
+	padding: ${remSpace[3]} 0 ${remSpace[4]} 0;
 	${textSans.medium()}
 
 	${darkModeCss`
@@ -38,7 +38,7 @@ const styles = css`
 `;
 
 const tagStyles = css`
-	margin: ${remSpace[2]} ${remSpace[2]} 0 0;
+	margin: ${remSpace[3]} ${remSpace[3]} 0 0;
 	display: inline-block;
 `;
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -133,7 +133,7 @@ const transform = (text: string, format: Format): ReactElement | string => {
 
 const listStyles: SerializedStyles = css`
 	list-style: none;
-	margin: ${remSpace[2]} 0;
+	margin: ${remSpace[3]} 0;
 	padding-left: 0;
 	clear: both;
 `;
@@ -149,7 +149,7 @@ const listItemStyles = (format: Format): SerializedStyles[] => {
 			border-radius: 0.5rem;
 			height: 1rem;
 			width: 1rem;
-			margin-right: ${remSpace[2]};
+			margin-right: ${remSpace[3]};
 			background-color: ${neutral[86]};
 			margin-left: -${remSpace[6]};
 			vertical-align: middle;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -13,8 +13,8 @@ import { Design, map, none, some, withDefault } from '@guardian/types';
 import { pipe2 } from 'lib';
 
 export const sidePadding = css`
-	padding-left: ${remSpace[2]};
-	padding-right: ${remSpace[2]};
+	padding-left: ${remSpace[3]};
+	padding-right: ${remSpace[3]};
 
 	${from.wide} {
 		padding-left: 0;
@@ -88,7 +88,7 @@ export const lineStyles = css`
 
 export const onwardStyles: SerializedStyles = css`
 	background: ${neutral[97]};
-	margin: ${remSpace[2]};
+	margin: ${remSpace[3]};
 
 	${darkModeCss`
         background: ${background.inverse};
@@ -127,7 +127,7 @@ export const adStyles = (format: Format): SerializedStyles => {
 
 			.ad-labels {
 				${textSans.xsmall()}
-				padding: ${remSpace[2]};
+				padding: ${remSpace[3]};
 				float: left;
 				width: calc(100% - ${remSpace[4]});
 
@@ -149,7 +149,7 @@ export const adStyles = (format: Format): SerializedStyles => {
 			}
 
 			.upgrade-banner {
-				padding: ${remSpace[2]};
+				padding: ${remSpace[3]};
 				background-color: ${brandAltBackground.primary};
 
 				h1 {
@@ -163,7 +163,7 @@ export const adStyles = (format: Format): SerializedStyles => {
 			}
 
 			${until.phablet} {
-				margin: 1em -${remSpace[2]};
+				margin: 1em -${remSpace[3]};
 			}
 
 			${from.desktop} {


### PR DESCRIPTION
## Why are you doing this?

There has been a discussion on aligning our spacings to the guardian design, by changing our 8px spacing values with 12px. In our codebase that means remSpace[2] -> remSpace [3]

One snag that I found through chromatic is the wrapping text around the avatar in Editions Opinion headline needs fixing, I've created a ticket here https://theguardian.atlassian.net/browse/LIVE-2491




## Changes

- remSpace[2] to remSpace[3]

## Screenshots

Best to have a look via the chromatic storybook build.
