### PR TITLE
Chromatic mobile and tablet viewport + fix fonts

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -6,114 +6,114 @@
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 400;
-		src: url('/assets/fonts/GuardianTextEgyptian-Reg.ttf');
+		src: url('/fonts/GuardianTextEgyptian-Reg.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 400;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextEgyptian-RegItalic.ttf');
+		src: url('/fonts/GuardianTextEgyptian-RegItalic.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 700;
-		src: url('/assets/fonts/GuardianTextEgyptian-Bold.ttf');
+		src: url('/fonts/GuardianTextEgyptian-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 700;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
+		src: url('/fonts/GuardianTextEgyptian-BoldItalic.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: bold;
-		src: url('/assets/fonts/GuardianTextEgyptian-Bold.ttf');
+		src: url('/fonts/GuardianTextEgyptian-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: bold;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
+		src: url('/fonts/GuardianTextEgyptian-BoldItalic.ttf');
 	}
 
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 400;
-		src: url('/assets/fonts/GuardianTextSans-Regular.ttf');
+		src: url('/fonts/GuardianTextSans-Regular.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 400;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextSans-RegularItalic.ttf');
+		src: url('/fonts/GuardianTextSans-RegularItalic.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 700;
-		src: url('/assets/fonts/GuardianTextSans-Bold.ttf');
+		src: url('/fonts/GuardianTextSans-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 700;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextSans-BoldItalic.ttf');
+		src: url('/fonts/GuardianTextSans-BoldItalic.ttf');
 	}
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 300;
-		src: url('/assets/fonts/GHGuardianHeadline-Light.ttf');
+		src: url('/fonts/GHGuardianHeadline-Light.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 300;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-LightItalic.ttf');
+		src: url('/fonts/GHGuardianHeadline-LightItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 400;
-		src: url('/assets/fonts/GHGuardianHeadline-Regular.ttf');
+		src: url('/fonts/GHGuardianHeadline-Regular.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 400;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-RegularItalic.ttf');
+		src: url('/fonts/GHGuardianHeadline-RegularItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 500;
-		src: url('/assets/fonts/GHGuardianHeadline-Medium.ttf');
+		src: url('/fonts/GHGuardianHeadline-Medium.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 500;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-MediumItalic.ttf');
+		src: url('/fonts/GHGuardianHeadline-MediumItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 600;
-		src: url('/assets/fonts/GHGuardianHeadline-Semibold.ttf');
+		src: url('/fonts/GHGuardianHeadline-Semibold.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 600;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf');
+		src: url('/fonts/GHGuardianHeadline-SemiboldItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 700;
-		src: url('/assets/fonts/GHGuardianHeadline-Bold.ttf');
+		src: url('/fonts/GHGuardianHeadline-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 700;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-BoldItalic.ttf');
+		src: url('/fonts/GHGuardianHeadline-BoldItalic.ttf');
 	}
 
 	body {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,24 @@
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Reg.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-RegItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Bold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Bold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-RegularItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-Bold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-BoldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Light.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-LightItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-RegularItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Medium.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-MediumItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Semibold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Bold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-BoldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+
 <style>
 	html {
 		background: white;

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,24 +1,3 @@
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Reg.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-RegItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Bold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Bold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-RegularItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-Bold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-BoldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Light.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-LightItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-RegularItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Medium.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-MediumItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Semibold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Bold.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-<link rel="preload" href="https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-BoldItalic.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-
 <style>
 	html {
 		background: white;

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -6,114 +6,114 @@
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 400;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Reg.ttf');
+		src: url('/assets/fonts/GuardianTextEgyptian-Reg.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 400;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-RegItalic.ttf');
+		src: url('/assets/fonts/GuardianTextEgyptian-RegItalic.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 700;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Bold.ttf');
+		src: url('/assets/fonts/GuardianTextEgyptian-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 700;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
+		src: url('/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: bold;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Bold.ttf');
+		src: url('/assets/fonts/GuardianTextEgyptian-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: bold;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
+		src: url('/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
 	}
 
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 400;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-Regular.ttf');
+		src: url('/assets/fonts/GuardianTextSans-Regular.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 400;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-RegularItalic.ttf');
+		src: url('/assets/fonts/GuardianTextSans-RegularItalic.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 700;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-Bold.ttf');
+		src: url('/assets/fonts/GuardianTextSans-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 700;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-BoldItalic.ttf');
+		src: url('/assets/fonts/GuardianTextSans-BoldItalic.ttf');
 	}
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 300;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Light.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-Light.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 300;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-LightItalic.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-LightItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 400;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Regular.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-Regular.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 400;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-RegularItalic.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-RegularItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 500;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Medium.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-Medium.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 500;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-MediumItalic.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-MediumItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 600;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Semibold.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-Semibold.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 600;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 700;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Bold.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 700;
 		font-style: italic;
-		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-BoldItalic.ttf');
+		src: url('/assets/fonts/GHGuardianHeadline-BoldItalic.ttf');
 	}
 
 	body {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -6,114 +6,114 @@
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 400;
-		src: url('/assets/fonts/GuardianTextEgyptian-Reg.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Reg.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 400;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextEgyptian-RegItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-RegItalic.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 700;
-		src: url('/assets/fonts/GuardianTextEgyptian-Bold.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: 700;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: bold;
-		src: url('/assets/fonts/GuardianTextEgyptian-Bold.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Egyptian Web';
 		font-weight: bold;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextEgyptian-BoldItalic.ttf');
 	}
 
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 400;
-		src: url('/assets/fonts/GuardianTextSans-Regular.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-Regular.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 400;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextSans-RegularItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-RegularItalic.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 700;
-		src: url('/assets/fonts/GuardianTextSans-Bold.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'Guardian Text Sans Web';
 		font-weight: 700;
 		font-style: italic;
-		src: url('/assets/fonts/GuardianTextSans-BoldItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GuardianTextSans-BoldItalic.ttf');
 	}
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 300;
-		src: url('/assets/fonts/GHGuardianHeadline-Light.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Light.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 300;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-LightItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-LightItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 400;
-		src: url('/assets/fonts/GHGuardianHeadline-Regular.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Regular.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 400;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-RegularItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-RegularItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 500;
-		src: url('/assets/fonts/GHGuardianHeadline-Medium.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Medium.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 500;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-MediumItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-MediumItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 600;
-		src: url('/assets/fonts/GHGuardianHeadline-Semibold.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Semibold.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 600;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-SemiboldItalic.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 700;
-		src: url('/assets/fonts/GHGuardianHeadline-Bold.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-Bold.ttf');
 	}
 	@font-face {
 		font-family: 'GH Guardian Headline';
 		font-weight: 700;
 		font-style: italic;
-		src: url('/assets/fonts/GHGuardianHeadline-BoldItalic.ttf');
+		src: url('https://mobile.guardianapis.com/assets/fonts/GHGuardianHeadline-BoldItalic.ttf');
 	}
 
 	body {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:server:prod": "webpack --config webpack.config.ts --config-name server --env production",
     "build:client:prod": "webpack --config webpack.config.ts --config-name clientProduction",
     "storybook": "start-storybook -s ./ -p 8181 --ci",
-    "build-storybook": "build-storybook -o dist",
+    "build-storybook": "build-storybook -o dist -s ./assets",
     "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:client": "webpack --config webpack.config.ts --config-name client",
     "build:server:prod": "webpack --config webpack.config.ts --config-name server --env production",
     "build:client:prod": "webpack --config webpack.config.ts --config-name clientProduction",
-    "storybook": "start-storybook -s ./ -p 8181 --ci",
+    "storybook": "start-storybook -s ./assets -p 8181 --ci",
     "build-storybook": "build-storybook -o dist -s ./assets",
     "deploy-storybook": "storybook-to-ghpages && ./.storybook/pushFonts.sh"
   },

--- a/src/components/editions/article/article.stories.tsx
+++ b/src/components/editions/article/article.stories.tsx
@@ -1,5 +1,6 @@
 // ----- Imports ----- //
 import type { Tag } from '@guardian/content-api-models/v1/tag';
+import { breakpoints } from '@guardian/src-foundations';
 import { Display, Pillar } from '@guardian/types';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import {
@@ -163,7 +164,10 @@ export default {
 	decorators: [withKnobs],
 	parameters: {
 		layout: 'fullscreen',
-		chromatic: { diffThreshold: 0.25 },
+		chromatic: {
+			diffThreshold: 0.25,
+			viewports: [breakpoints.mobile, breakpoints.tablet],
+		},
 	},
 };
 


### PR DESCRIPTION
## Why are you doing this?
Currently our chromatic screenshots don't present them in a mobile viewport, which would be helpful since this is an apps project. 

Changes:
- Add the mobile and tablet viewport to chromatic article story.
- The fonts were broken in Chromatic so I updated the references to static storybook fonts and set the static folder for `build-storybook`.