### PR TITLE
Add Dependabot For GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       directory: '/' # Location of package manifests
       schedule:
           interval: 'daily'
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'daily'


### PR DESCRIPTION
## Why are you doing this?

Using dependabot to keep GH Actions up-to-date.

## Changes

- Added dependabot for GH Actions
