### PR TITLE
SPIKE: add format params

### DIFF
--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -22,6 +22,7 @@ import { createElement as h } from 'react';
 import { renderToString } from 'react-dom/server';
 import { csp } from 'server/csp';
 import { pageFonts } from 'styles';
+import { overideFormatValues } from './formatOverride';
 
 // ----- Types ----- //
 
@@ -107,8 +108,10 @@ function render(
 	imageSalt: string,
 	request: RenderingRequest,
 	getAssetLocation: (assetName: string) => string,
+	formatParams?: string[],
 ): Page {
-	const item = fromCapi({ docParser, salt: imageSalt })(request);
+	const capiResponse = fromCapi({ docParser, salt: imageSalt })(request);
+	const item = overideFormatValues(capiResponse, formatParams);
 	const body = renderBody(item);
 	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
 

--- a/src/server/formatOverride.ts
+++ b/src/server/formatOverride.ts
@@ -1,0 +1,15 @@
+import type { Item } from 'item';
+
+export const overideFormatValues = (
+	item: Item,
+	formatParams?: string[],
+): Item => {
+	if (formatParams) {
+		const design = parseInt(formatParams[0]);
+		const display = parseInt(formatParams[1]);
+		const theme = parseInt(formatParams[2]);
+
+		return { ...item, design, display, theme };
+	}
+	return item;
+};

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -22,6 +22,7 @@ import type { ReactElement } from 'react';
 import { renderToString } from 'react-dom/server';
 import { csp } from 'server/csp';
 import { pageFonts } from 'styles';
+import { overideFormatValues } from './formatOverride';
 
 // ----- Types ----- //
 
@@ -156,8 +157,10 @@ function render(
 	imageSalt: string,
 	request: RenderingRequest,
 	getAssetLocation: (assetName: string) => string,
+	formatParams?: string[],
 ): Page {
-	const item = fromCapi({ docParser, salt: imageSalt })(request);
+	const capiResponse = fromCapi({ docParser, salt: imageSalt })(request);
+	const item = overideFormatValues(capiResponse, formatParams);
 	const clientScript = map(getAssetLocation)(scriptName(item));
 	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
 	const body = renderBody(item, request);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -124,6 +124,7 @@ async function serveArticle(
 	request: RenderingRequest,
 	res: ExpressResponse,
 	isEditions = false,
+	formatParams?: string[],
 ): Promise<void> {
 	const imageSalt = await getConfigValue('apis.img.salt');
 
@@ -136,6 +137,7 @@ async function serveArticle(
 		imageSalt,
 		request,
 		getAssetLocation,
+		formatParams,
 	);
 
 	res.set('Link', getPrefetchHeader(resourceList(clientScript)));
@@ -178,11 +180,12 @@ async function serveArticlePost(
 		const renderingRequest = await mapiDecoder(req.body);
 		const richLinkDetails = req.query.richlink === '';
 		const isEditions = req.query.editions === '';
+		const formatParams = req.query.format as string[] | undefined;
 
 		if (richLinkDetails) {
 			void serveRichLinkDetails(renderingRequest, res);
 		} else {
-			void serveArticle(renderingRequest, res, isEditions);
+			void serveArticle(renderingRequest, res, isEditions, formatParams);
 		}
 	} catch (e) {
 		logger.error(`This error occurred`, e);
@@ -202,6 +205,7 @@ async function serveEditionsArticlePost(
 		const renderingRequest: RenderingRequest = {
 			content,
 		};
+
 		void serveArticle(renderingRequest, res, true);
 	} catch (e) {
 		logger.error('This error occurred', e);
@@ -237,11 +241,17 @@ async function serveArticleGet(
 				};
 
 				const richLinkDetails = req.query.richlink === '';
+				const formatParams = req.query.format as string[] | undefined;
 
 				if (richLinkDetails) {
 					void serveRichLinkDetails(mockedRenderingRequest, res);
 				} else {
-					void serveArticle(mockedRenderingRequest, res, isEditions);
+					void serveArticle(
+						mockedRenderingRequest,
+						res,
+						isEditions,
+						formatParams,
+					);
 				}
 			},
 		)(capiContent);


### PR DESCRIPTION
## Why are you doing this?

Adding the ability to override `Format` values using query parameters.

This will be required as part of the `4mats` project lead by @faresite https://github.com/guardian/4mats

## Changes

- Add check for `format` query parameter
- Add `formatOverride` function to apply params to capi item responses.


