### PR TITLE
LIVE-1905: Rich link hyphenation bug on Android

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -18245,6 +18245,8 @@ exports[`Storyshots Rich Link Default 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #121212;
+  max-width: 100%;
+  word-wrap: break-word;
 }
 
 .emotion-1 a h1 {

--- a/src/components/richLink.tsx
+++ b/src/components/richLink.tsx
@@ -107,6 +107,8 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 			display: inline-block;
 			text-decoration: none;
 			color: ${neutral[7]};
+			max-width: 100%;
+			word-wrap: break-word;
 
 			h1 {
 				margin: 0 0 ${remSpace[4]} 0;


### PR DESCRIPTION
## Why are you doing this?

A bug has been found on Android where the rich link is overlapping with the content because of a long word. As shown in this screenshot.

![Screenshot 2021-06-02 at 16 12 54](https://user-images.githubusercontent.com/12860328/120506020-725f1000-c3bd-11eb-8c9d-157bfe6a70e5.png)


The long word is not at fault here but a hyphenation issue on Chrome for Android that doesn't work if the word is attached to a special character like a colon `:` . Without the special character, the hyphenation works fine as shown here:
![Screenshot 2021-06-02 at 16 04 11](https://user-images.githubusercontent.com/12860328/120506181-9589bf80-c3bd-11eb-8b0b-c5dfb36d949b.png)

I have found an Android chromium issue that seems to be related where hyphenation wasn't working at all https://bugs.chromium.org/p/chromium/issues/detail?id=813414

My feeling is that this is a chromium bug that needs to be fixed and slapping an awful hack to fix it wouldn't be the best option, assuming this doesn't happen very often. Although I'm happy to be challenged at that. As a fix I have introduced `word-wrap: break-word` which gets applied when the hyphenation doesn't work, like in the following screenshot:
![Screenshot 2021-06-02 at 16 03 38](https://user-images.githubusercontent.com/12860328/120506589-f87b5680-c3bd-11eb-91e5-953f31e7a8c9.png)

As you can see, the hyphenation doesn't work but it does break the word when, leaving other hyphenation working correctly. This is not pretty, but when the chromium bug gets fixed this should work as expected. if I don't find it raised already, I'll try and raise it myself.

Before committing to this solution however I'd welcome some thoughts or better solutions. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- Adds the word-wrap css rule and clamps max width of the headline at 100%.

