### PR TITLE
Live 2477 :  Editions Inline JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33453,6 +33453,12 @@
         }
       }
     },
+    "webpack-stats-plugin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-1.0.3.tgz",
+      "integrity": "sha512-tV/SQHl6lKfBahJcNDmz8JG1rpWPB9NEDQSMIoL74oVAotdxYljpgIsgLzgc1N9QrtA9KEA0moJVwQtNZv2aDA==",
+      "dev": true
+    },
     "webpack-virtual-modules": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "webpack-dev-server": "^3.11.2",
     "webpack-manifest-plugin": "^3.0.0",
     "webpack-node-externals": "^2.5.2",
+    "webpack-stats-plugin": "^1.0.3",
     "whatwg-fetch": "^3.6.1",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.2"

--- a/src/components/scripts.tsx
+++ b/src/components/scripts.tsx
@@ -23,14 +23,16 @@ const ClientJs: FC<ClientJsProps> = ({ src }) =>
 interface Props {
 	clientScript: Option<string>;
 	twitter: boolean;
+	inlineClientJS?: string;
 }
 
-const Scripts: FC<Props> = ({ clientScript, twitter }) => (
+const Scripts: FC<Props> = ({ clientScript, twitter, inlineClientJS }) => (
 	<>
 		<ClientJs src={clientScript} />
-		{twitter ? (
+		{twitter && (
 			<script src="https://platform.twitter.com/widgets.js"></script>
-		) : null}
+		)}
+		{inlineClientJS && <script>${inlineClientJS}</script>}
 	</>
 );
 

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -94,7 +94,6 @@ const buildHtml = (
 	head: string,
 	body: string,
 	scripts: ReactElement,
-	inlineJS: string,
 ): string => `
     <!DOCTYPE html>
     <html lang="en">
@@ -105,7 +104,6 @@ const buildHtml = (
         <body>
 			${body}
 			${renderToString(scripts)}
-			<script>${inlineJS}</script>
         </body>
     </html>
 `;
@@ -136,11 +134,12 @@ function render(
 		<Scripts
 			clientScript={clientScript}
 			twitter={thirdPartyEmbeds.twitter}
+			inlineClientJS={inlineJS}
 		/>
 	);
 
 	return {
-		html: buildHtml(head, body.html, scripts, inlineJS),
+		html: buildHtml(head, body.html, scripts),
 		clientScript: none,
 	};
 }

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -65,7 +65,7 @@ function renderHead(
 		item,
 		{
 			scripts: [atomScript, inlineJS],
-			styles: [itemStyles, atomCss],
+			styles: [generalStyles, itemStyles, atomCss],
 		},
 		thirdPartyEmbeds,
 		inlineStyles,

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -57,14 +57,14 @@ function renderHead(
 	itemStyles: string,
 	emotionIds: string[],
 	inlineStyles: boolean,
-	clientJS: string,
+	inlineJS: string,
 ): string {
 	const generalStyles = styles;
 	const isEditions = true;
 	const cspString = csp(
 		item,
 		{
-			scripts: [atomScript, clientJS],
+			scripts: [atomScript, inlineJS],
 			styles: [itemStyles, atomCss],
 		},
 		thirdPartyEmbeds,
@@ -94,7 +94,7 @@ const buildHtml = (
 	head: string,
 	body: string,
 	scripts: ReactElement,
-	clientJS: string,
+	inlineJS: string,
 ): string => `
     <!DOCTYPE html>
     <html lang="en">
@@ -105,7 +105,7 @@ const buildHtml = (
         <body>
 			${body}
 			${renderToString(scripts)}
-			<script>${clientJS}</script>
+			<script>${inlineJS}</script>
         </body>
     </html>
 `;
@@ -114,7 +114,7 @@ function render(
 	imageSalt: string,
 	request: RenderingRequest,
 	getAssetLocation: (assetName: string) => string,
-	clientJS: string,
+	inlineJS: string,
 ): Page {
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
 	const body = renderBody(item);
@@ -127,7 +127,7 @@ function render(
 		body.css,
 		body.ids,
 		false,
-		clientJS,
+		inlineJS,
 	);
 
 	const clientScript = map(getAssetLocation)(some('editions.js'));
@@ -140,7 +140,7 @@ function render(
 	);
 
 	return {
-		html: buildHtml(head, body.html, scripts, clientJS),
+		html: buildHtml(head, body.html, scripts, inlineJS),
 		clientScript: none,
 	};
 }

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -57,14 +57,15 @@ function renderHead(
 	itemStyles: string,
 	emotionIds: string[],
 	inlineStyles: boolean,
+	clientJS: string,
 ): string {
 	const generalStyles = styles;
 	const isEditions = true;
 	const cspString = csp(
 		item,
 		{
-			scripts: [atomScript],
-			styles: [generalStyles, itemStyles, atomCss],
+			scripts: [atomScript, clientJS],
+			styles: [itemStyles, atomCss],
 		},
 		thirdPartyEmbeds,
 		inlineStyles,
@@ -93,6 +94,7 @@ const buildHtml = (
 	head: string,
 	body: string,
 	scripts: ReactElement,
+	clientJS: string,
 ): string => `
     <!DOCTYPE html>
     <html lang="en">
@@ -103,6 +105,7 @@ const buildHtml = (
         <body>
 			${body}
 			${renderToString(scripts)}
+			<script>${clientJS}</script>
         </body>
     </html>
 `;
@@ -111,6 +114,7 @@ function render(
 	imageSalt: string,
 	request: RenderingRequest,
 	getAssetLocation: (assetName: string) => string,
+	clientJS: string,
 ): Page {
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
 	const body = renderBody(item);
@@ -123,6 +127,7 @@ function render(
 		body.css,
 		body.ids,
 		false,
+		clientJS,
 	);
 
 	const clientScript = map(getAssetLocation)(some('editions.js'));
@@ -135,7 +140,7 @@ function render(
 	);
 
 	return {
-		html: buildHtml(head, body.html, scripts),
+		html: buildHtml(head, body.html, scripts, clientJS),
 		clientScript: none,
 	};
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -130,12 +130,20 @@ async function serveArticle(
 	if (imageSalt === undefined) {
 		throw new Error('Could not get image salt');
 	}
+	let clientJS = '';
+	if (isEditions) {
+		const response = await fetch(
+			`https://mobile.guardianapis.com/assets/editions.85f38e7a42ef77cfc2a0.js`,
+		);
+		clientJS = await response.text();
+	}
 
 	const renderer = isEditions ? renderEditions : render;
 	const { html, clientScript } = renderer(
 		imageSalt,
 		request,
 		getAssetLocation,
+		clientJS,
 	);
 
 	res.set('Link', getPrefetchHeader(resourceList(clientScript)));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -138,7 +138,7 @@ async function serveArticle(
 	let inlineJS = '';
 	if (isEditions) {
 		const hashResponse = await fetch(
-			`https://mobile.code.dev-guardianapis.com/assets/hashed-names.json`,
+			`https://mobile.guardianapis.com/assets/hashed-names.json`,
 		);
 
 		const hashedNames = (await hashResponse.json()) as HashNames;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -135,7 +135,7 @@ async function serveArticle(
 		throw new Error('Could not get image salt');
 	}
 
-	let clientJS = '';
+	let inlineJS = '';
 	if (isEditions) {
 		const hashResponse = await fetch(
 			`https://mobile.code.dev-guardianapis.com/assets/hashed-names.json`,
@@ -145,7 +145,7 @@ async function serveArticle(
 		const response = await fetch(
 			`https://mobile.guardianapis.com/assets/${hashedNames.jsBundleName}`,
 		);
-		clientJS = await response.text();
+		inlineJS = await response.text();
 	}
 
 	const renderer = isEditions ? renderEditions : render;
@@ -153,7 +153,7 @@ async function serveArticle(
 		imageSalt,
 		request,
 		getAssetLocation,
-		clientJS,
+		inlineJS,
 	);
 
 	res.set('Link', getPrefetchHeader(resourceList(clientScript)));
@@ -176,10 +176,10 @@ async function serveRichLinkDetails(
 
 	const image =
 		item.mainMedia.kind === OptionKind.Some &&
-		item.mainMedia.value.kind === MainMediaKind.Image
+			item.mainMedia.value.kind === MainMediaKind.Image
 			? {
-					image: item.mainMedia.value.image.src,
-			  }
+				image: item.mainMedia.value.image.src,
+			}
 			: {};
 
 	const response = { pillar: renderingRequest.content.pillarName, ...image };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -120,6 +120,10 @@ function resourceList(script: Option<string>): string[] {
 	return pipe(script, map(toArray), withDefault(emptyList));
 }
 
+interface HashNames {
+	jsBundleName: string[];
+}
+
 async function serveArticle(
 	request: RenderingRequest,
 	res: ExpressResponse,
@@ -130,10 +134,16 @@ async function serveArticle(
 	if (imageSalt === undefined) {
 		throw new Error('Could not get image salt');
 	}
+
 	let clientJS = '';
 	if (isEditions) {
+		const hashResponse = await fetch(
+			`https://mobile.code.dev-guardianapis.com/assets/hashed-names.json`,
+		);
+
+		const hashedNames = (await hashResponse.json()) as HashNames;
 		const response = await fetch(
-			`https://mobile.guardianapis.com/assets/editions.85f38e7a42ef77cfc2a0.js`,
+			`https://mobile.guardianapis.com/assets/${hashedNames.jsBundleName}`,
 		);
 		clientJS = await response.text();
 	}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -249,7 +249,6 @@ const clientConfigProduction = {
 		path: path.resolve(__dirname, 'dist/assets'),
 		publicPath: '',
 		filename: '[name].[contenthash].js',
-
 	},
 	resolve: clientResolveProd,
 };

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -239,7 +239,6 @@ const clientConfigProduction = {
 		new StatsWriterPlugin({
 			filename: "hashed-names.json",
 			transform: function (data: { assetsByChunkName: { editions: any; }; }) {
-				console.log('StatsWriterPlugin:: ', data)
 				return JSON.stringify({
 					jsBundleName: data.assetsByChunkName.editions,
 				});
@@ -250,6 +249,7 @@ const clientConfigProduction = {
 		path: path.resolve(__dirname, 'dist/assets'),
 		publicPath: '',
 		filename: '[name].[contenthash].js',
+
 	},
 	resolve: clientResolveProd,
 };

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,6 +12,7 @@ import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
 import nodeExternals from 'webpack-node-externals';
 import { renederedItemsAssetsCss } from './config/rendered-items-assets-styles';
 import { WebpackPluginInstance } from 'webpack';
+const { StatsWriterPlugin } = require("webpack-stats-plugin");
 
 // ----- Plugins ----- //
 
@@ -99,10 +100,10 @@ const serverConfig = (
 		externals: isProd
 			? []
 			: [
-					nodeExternals({
-						allowlist: [/@guardian/],
-					}),
-			  ],
+				nodeExternals({
+					allowlist: [/@guardian/],
+				}),
+			],
 
 		node: {
 			__dirname: false,
@@ -234,6 +235,15 @@ const clientConfigProduction = {
 		}),
 		new webpack.ProvidePlugin({
 			Buffer: ['buffer', 'Buffer'],
+		}),
+		new StatsWriterPlugin({
+			filename: "hashed-names.json",
+			transform: function (data: { assetsByChunkName: { editions: any; }; }) {
+				console.log('StatsWriterPlugin:: ', data)
+				return JSON.stringify({
+					jsBundleName: data.assetsByChunkName.editions,
+				});
+			},
 		}),
 	],
 	output: {


### PR DESCRIPTION
## Why are you doing this?
Editions articles are currently served and downloaded without its js file. There is a [larger body of work](https://theguardian.atlassian.net/browse/LIVE-2483?atlOrigin=eyJpIjoiY2M4ZGFiNjQ3NzY1NDVkMzliODhkNTYyYWUxNzdlOWEiLCJwIjoiaiJ9) going on to bundle the .js with the .html but as a temporary work around we are inlining the js into the article body. As the .js file has a hashed name, we have also introduced a webpack plugin to generate a key/value object from the hashed file names so we can refer to the file dynamically.
