### PR TITLE
LIVE-2529: Fix swipe bug

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -129,7 +129,7 @@ export const adStyles = (format: Format): SerializedStyles => {
 				${textSans.xsmall()}
 				padding: ${remSpace[3]};
 				float: left;
-				width: calc(100% - ${remSpace[4]});
+				width: calc(100% - ${remSpace[3]} - ${remSpace[3]});
 
 				h1 {
 					margin: 0;


### PR DESCRIPTION
## Why are you doing this?

The article swipe bug returned after this PR https://github.com/guardian/apps-rendering/pull/1314 , this PR hopefully fixes it. I have created a ticket to think of a way to prevent this from happening in the future.

### Changes:
- update ad labels width with the new spacing

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot 2021-06-03 at 16 16 05](https://user-images.githubusercontent.com/12860328/120669130-1791eb00-c487-11eb-8569-705f5bfc624b.png) | ![Screenshot 2021-06-03 at 16 16 26](https://user-images.githubusercontent.com/12860328/120669180-224c8000-c487-11eb-8ebe-0d3f7efb2ae2.png)
 |
