### PR TITLE
Remove custom font-weight on interview headline

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -7315,7 +7315,6 @@ exports[`Storyshots Editions/Article Interview 1`] = `
   font-size: 1.5rem;
   line-height: 1.35;
   font-weight: 500;
-  font-weight: 400;
   background-color: #121212;
   color: #FFFFFF;
   white-space: pre-wrap;
@@ -7331,7 +7330,6 @@ exports[`Storyshots Editions/Article Interview 1`] = `
     font-size: 1.75rem;
     line-height: 1.35;
     font-weight: 500;
-    font-weight: 400;
   }
 }
 
@@ -7341,7 +7339,6 @@ exports[`Storyshots Editions/Article Interview 1`] = `
     font-size: 2.125rem;
     line-height: 1.35;
     font-weight: 500;
-    font-weight: 400;
   }
 }
 
@@ -15291,7 +15288,6 @@ exports[`Storyshots Editions/Headline Interview 1`] = `
   font-size: 1.5rem;
   line-height: 1.35;
   font-weight: 500;
-  font-weight: 400;
   background-color: #121212;
   color: #FFFFFF;
   white-space: pre-wrap;
@@ -15307,7 +15303,6 @@ exports[`Storyshots Editions/Headline Interview 1`] = `
     font-size: 1.75rem;
     line-height: 1.35;
     font-weight: 500;
-    font-weight: 400;
   }
 }
 
@@ -15317,7 +15312,6 @@ exports[`Storyshots Editions/Headline Interview 1`] = `
     font-size: 2.125rem;
     line-height: 1.35;
     font-weight: 500;
-    font-weight: 400;
   }
 }
 

--- a/src/components/editions/headline/index.tsx
+++ b/src/components/editions/headline/index.tsx
@@ -71,18 +71,12 @@ const interviewStyles = css`
 
 const interviewFontStyles = css`
 	${headline.xsmall({ lineHeight: 'regular' })}
-	font-weight: 400;
-
 	${from.mobileMedium} {
 		${headline.small({ lineHeight: 'regular' })}
-		font-weight: 400;
 	}
-
 	${from.tablet} {
 		${headline.medium({ lineHeight: 'regular' })}
-		font-weight: 400;
 	}
-
 	background-color: ${neutral[7]};
 	color: ${neutral[100]};
 	white-space: pre-wrap;


### PR DESCRIPTION
## Why are you doing this?

Remove Editions custom font weight 400 from `interview` headline inline with design updates