### PR TITLE
LIVE-2568: add switch for fonts dev vs prod

### DIFF
--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -21,7 +21,7 @@ import type { ReactElement } from 'react';
 import { createElement as h } from 'react';
 import { renderToString } from 'react-dom/server';
 import { csp } from 'server/csp';
-import { editionsPageFonts } from 'styles';
+import { editionsPageFonts, pageFonts } from 'styles';
 
 // ----- Types ----- //
 
@@ -37,7 +37,7 @@ const docParser = JSDOM.fragment.bind(null);
 // ----- Functions ----- //
 
 const styles = `
-	${editionsPageFonts}
+	${process.env.NODE_ENV === 'production' ? editionsPageFonts : pageFonts}
 
 	html {
 		margin: 0;


### PR DESCRIPTION
## Why are you doing this?

Fonts were broken when working on editions locally.


## Changes

- Add switch to use different font path locally


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/121225846-d84a0c80-c881-11eb-8022-e86c248de9af.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/121225893-e1d37480-c881-11eb-930b-75d617893e1f.png" width="300px" /> |
