### PR TITLE
LIVE-2575: Bump bridget to 1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2812,9 +2812,9 @@
       }
     },
     "@guardian/bridget": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-1.10.0.tgz",
-      "integrity": "sha512-O+FRXyw8kC4OGRQqar+D/4/B+FGI20Xt5T6IaRq7KFPhCqqqu6fjvI70zQimfzPJixtvPcqpVPXd3wviSasmBg=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@guardian/bridget/-/bridget-1.11.0.tgz",
+      "integrity": "sha512-gzGnrJHmGTQHGBcnmgDsn//17qBZ+DOXzL/QILfyqqRlgFvEbjRxtqTdDZ6oqsW3dytHv0i+7MIswWvp9BaA3g=="
     },
     "@guardian/content-api-models": {
       "version": "17.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@emotion/server": "^11.0.0",
     "@guardian/apps-rendering-api-models": "^0.11.2",
     "@guardian/atoms-rendering": "^12.2.0",
-    "@guardian/bridget": "^1.10.0",
+    "@guardian/bridget": "^1.11.0",
     "@guardian/content-api-models": "^17.0.0",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^4.6.1",

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -83,6 +83,7 @@ function getAdSlots(): AdSlot[] {
 		return new AdSlot({
 			rect: getRect(slotPosition),
 			targetingParams,
+			isSquare: false,
 		});
 	});
 }


### PR DESCRIPTION
## Why are you doing this?
To accomodate a different format of ads (like Teads) we are going to send an `isSquare` field with each AdSlot. For now we're just going to send false until it can be implemented all round.

Tested with an app version without the latest bridget and ads seem to still work 👍

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- Bump Bridget to 1.11.0
- Send `false` for `isSquare` 

