### PR TITLE
Live 2628 move apps rendering to public subnet

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -93,10 +93,7 @@ Resources:
       SecurityGroups:
         - !Ref DefaultVpcSecurityGroup
         - !Ref LoadBalancerToEc2SecurityGroup
-      Subnets:
-        - subnet-bf5ba6da
-        - subnet-80544cf4
-#      Subnets: !Split [ ',', !ImportValue MobileAppsApiVPC-Subnets]
+      Subnets: !Split [ ',', !ImportValue MobileAppsApiVPC-PublicSubnets]
       Tags:
         - Key: App
           Value: !Ref App
@@ -156,9 +153,7 @@ Resources:
   AutoscalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      # AvailabilityZones: !GetAZs
-      AvailabilityZones:
-        - eu-west-1a
+      AvailabilityZones: !GetAZs
       HealthCheckGracePeriod: 300
       HealthCheckType: ELB
       LaunchConfigurationName: !Ref LaunchConfig
@@ -181,9 +176,7 @@ Resources:
         - Key: App
           PropagateAtLaunch: true
           Value: !Ref App
-      # VPCZoneIdentifier: !Split [ ',', !ImportValue MobileAppsApiVPC-Subnets]
-      VPCZoneIdentifier:
-        - subnet-bf5ba6da
+      VPCZoneIdentifier: !Split [ ',', !ImportValue MobileAppsApiVPC-PublicSubnets]
 
   DistributionInstanceProfile:
     Type: AWS::IAM::InstanceProfile

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -182,7 +182,8 @@ Resources:
           PropagateAtLaunch: true
           Value: !Ref App
       # VPCZoneIdentifier: !Split [ ',', !ImportValue MobileAppsApiVPC-Subnets]
-      VPCZoneIdentifier: subnet-bf5ba6da
+      VPCZoneIdentifier:
+        - subnet-bf5ba6da
 
   DistributionInstanceProfile:
     Type: AWS::IAM::InstanceProfile

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -95,6 +95,7 @@ Resources:
         - !Ref LoadBalancerToEc2SecurityGroup
       Subnets:
         - subnet-bf5ba6da
+        - subnet-80544cf4
 #      Subnets: !Split [ ',', !ImportValue MobileAppsApiVPC-Subnets]
       Tags:
         - Key: App

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -93,7 +93,9 @@ Resources:
       SecurityGroups:
         - !Ref DefaultVpcSecurityGroup
         - !Ref LoadBalancerToEc2SecurityGroup
-      Subnets: !Split [ ',', !ImportValue MobileAppsApiVPC-Subnets]
+      Subnets:
+        - subnet-bf5ba6da
+#      Subnets: !Split [ ',', !ImportValue MobileAppsApiVPC-Subnets]
       Tags:
         - Key: App
           Value: !Ref App
@@ -153,7 +155,9 @@ Resources:
   AutoscalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      AvailabilityZones: !GetAZs
+      # AvailabilityZones: !GetAZs
+      AvailabilityZones:
+        - eu-west-1a
       HealthCheckGracePeriod: 300
       HealthCheckType: ELB
       LaunchConfigurationName: !Ref LaunchConfig
@@ -176,7 +180,8 @@ Resources:
         - Key: App
           PropagateAtLaunch: true
           Value: !Ref App
-      VPCZoneIdentifier: !Split [ ',', !ImportValue MobileAppsApiVPC-Subnets]
+      # VPCZoneIdentifier: !Split [ ',', !ImportValue MobileAppsApiVPC-Subnets]
+      VPCZoneIdentifier: subnet-bf5ba6da
 
   DistributionInstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
## Why are you doing this?
This PR updates the public subnets used for the apps-rendering `load balancer` & `auto scaling group`. 

The steps to prepare the env for this change is as followed:
1- remove one subnet that is not used from load balancer and auto scaling group, then update availability zone in auto scaling group to match the subnets and update stack in AWS
2- manually increase desired capacity in auto scaling group to 2 (to create new instance in the new subnet)
3- run command to terminate the instance with old subnet: aws --profile mobile autoscaling terminate-instance-in-auto-scaling-group --should-decrement-desired-capacity --region eu-west-1 --instance-id i-0babb7a85d0aab8a5
4- When old subnet is not in use any more, remove the old subnet from cloud formation and update stack
5- add the remaining new subnets and update availability zone 


