### PR TITLE
LIVE-2631: Fix list item bullet spacing

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -149,7 +149,7 @@ const listItemStyles = (format: Format): SerializedStyles[] => {
 			border-radius: 0.5rem;
 			height: 1rem;
 			width: 1rem;
-			margin-right: ${remSpace[3]};
+			margin-right: ${remSpace[2]};
 			background-color: ${neutral[86]};
 			margin-left: -${remSpace[6]};
 			vertical-align: middle;


### PR DESCRIPTION
## Why are you doing this?

https://theguardian.atlassian.net/plugins/servlet/mobile?originPath=%2Fbrowse%2FLIVE-2631#issue/LIVE-2631

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- update spacing from remSpace[3] to remSpace[2] for list item padding

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot 2021-06-28 at 10 34 47](https://user-images.githubusercontent.com/12860328/123614733-82bbac80-d7fc-11eb-842d-ff6149df1695.png) | ![Screenshot 2021-06-28 at 10 34 56](https://user-images.githubusercontent.com/12860328/123614782-8d764180-d7fc-11eb-8a5e-11a138caef2f.png) |
