### PR TITLE
LIVE-2639: Newsletter sign up 

### DIFF
--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -498,15 +498,17 @@ function hydrateClickToView(): void {
 function resizeEmailSignups(): void {
 	const isIframe = (elem: Element): elem is HTMLIFrameElement =>
 		elem.tagName === 'IFRAME';
-	const emailSignupIframe = document.querySelector('.js-email-signup');
-	if (emailSignupIframe && isIframe(emailSignupIframe)) {
-		const innerIframe = emailSignupIframe.contentDocument?.querySelector(
-			'iframe',
-		);
-		if (innerIframe) {
-			innerIframe.style.width = '100%';
+	const emailSignupIframes = document.querySelectorAll('.js-email-signup');
+	Array.from(emailSignupIframes).forEach((emailSignupIframe) => {
+		if (isIframe(emailSignupIframe)) {
+			const innerIframe = emailSignupIframe.contentDocument?.querySelector(
+				'iframe',
+			);
+			if (innerIframe) {
+				innerIframe.style.width = '100%';
+			}
 		}
-	}
+	});
 }
 
 setup();

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -12,7 +12,6 @@ import { either } from '@guardian/types';
 import {
 	ads,
 	getAdSlots,
-	iframes,
 	reportNativeElementPositionChanges,
 	sendTargetingParams,
 	slideshow,
@@ -496,11 +495,23 @@ function hydrateClickToView(): void {
 		);
 }
 
+function resizeEmailSignups(): void {
+	const emailSignupIframe = document.querySelector(
+		'iframe.js-email-signup',
+	) as HTMLIFrameElement;
+	const innerIframe = emailSignupIframe.contentDocument?.querySelector(
+		'iframe',
+	);
+	if (innerIframe) {
+		innerIframe.style.width = '100%';
+	}
+}
+
 setup();
 sendTargetingParams();
 ads();
 videos();
-iframes();
+resizeEmailSignups();
 reportNativeElementPositionChanges();
 topics();
 slideshow();

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -12,6 +12,7 @@ import { either } from '@guardian/types';
 import {
 	ads,
 	getAdSlots,
+	iframes,
 	reportNativeElementPositionChanges,
 	sendTargetingParams,
 	slideshow,
@@ -499,6 +500,7 @@ setup();
 sendTargetingParams();
 ads();
 videos();
+iframes();
 reportNativeElementPositionChanges();
 topics();
 slideshow();

--- a/src/client/article.ts
+++ b/src/client/article.ts
@@ -496,14 +496,16 @@ function hydrateClickToView(): void {
 }
 
 function resizeEmailSignups(): void {
-	const emailSignupIframe = document.querySelector(
-		'iframe.js-email-signup',
-	) as HTMLIFrameElement;
-	const innerIframe = emailSignupIframe.contentDocument?.querySelector(
-		'iframe',
-	);
-	if (innerIframe) {
-		innerIframe.style.width = '100%';
+	const isIframe = (elem: Element): elem is HTMLIFrameElement =>
+		elem.tagName === 'IFRAME';
+	const emailSignupIframe = document.querySelector('.js-email-signup');
+	if (emailSignupIframe && isIframe(emailSignupIframe)) {
+		const innerIframe = emailSignupIframe.contentDocument?.querySelector(
+			'iframe',
+		);
+		if (innerIframe) {
+			innerIframe.style.width = '100%';
+		}
 	}
 }
 

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -271,23 +271,10 @@ function sendTargetingParams(): void {
 	void analyticsClient.sendTargetingParams(targetingParams);
 }
 
-function iframes(): void {
-	const emailSignupIframe = document.querySelector(
-		'iframe.js-email-signup',
-	) as HTMLIFrameElement;
-	const innerIframe = emailSignupIframe.contentDocument?.querySelector(
-		'iframe',
-	);
-	if (innerIframe) {
-		innerIframe.style.width = '100%';
-	}
-}
-
 export {
 	ads,
 	slideshow,
 	videos,
-	iframes,
 	reportNativeElementPositionChanges,
 	sendTargetingParams,
 	getAdSlots,

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -271,10 +271,23 @@ function sendTargetingParams(): void {
 	void analyticsClient.sendTargetingParams(targetingParams);
 }
 
+function iframes(): void {
+	const emailSignupIframe = document.querySelector(
+		'iframe.js-email-signup',
+	) as HTMLIFrameElement;
+	const innerIframe = emailSignupIframe.contentDocument?.querySelector(
+		'iframe',
+	);
+	if (innerIframe) {
+		innerIframe.style.width = '100%';
+	}
+}
+
 export {
 	ads,
 	slideshow,
 	videos,
+	iframes,
 	reportNativeElementPositionChanges,
 	sendTargetingParams,
 	getAdSlots,

--- a/src/components/genericEmbed.tsx
+++ b/src/components/genericEmbed.tsx
@@ -6,6 +6,7 @@ import { text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { withDefault } from '@guardian/types';
 import type { EmailSignup, Generic, TikTok } from 'embed';
+import { EmbedKind } from 'embed';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
@@ -37,6 +38,9 @@ const GenericEmbed: FC<Props> = ({ embed }) => (
 			title={withDefault('Embed')(embed.alt)}
 			// Prevents scrollbars: covers body margin and random extra 6px
 			height={embed.height + 22}
+			className={
+				embed.kind === EmbedKind.EmailSignup ? 'js-email-signup' : ''
+			}
 		/>
 		{maybeRender(embed.alt, (alt) => (
 			<figcaption css={captionStyles}>{alt}</figcaption>

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -115,7 +115,7 @@ const videoElement: BodyElement = {
 		height: 300,
 		width: 500,
 		tracking: EmbedTracksType.DOES_NOT_TRACK,
-	}
+	},
 };
 
 const audioElement: BodyElement = {
@@ -126,7 +126,7 @@ const audioElement: BodyElement = {
 		height: 300,
 		width: 500,
 		tracking: EmbedTracksType.DOES_NOT_TRACK,
-	}
+	},
 };
 
 const liveEventElement = (): BodyElement => ({
@@ -360,7 +360,7 @@ describe('Renders different types of elements', () => {
 		const nodes = render(embedElement);
 		const embed = nodes.flat()[0];
 		expect(getHtml(embed)).toContain(
-			'<iframe srcDoc="&lt;section&gt;Embed&lt;/section&gt;" title="Embed" height="322"></iframe>',
+			'<iframe srcDoc="&lt;section&gt;Embed&lt;/section&gt;" title="Embed" height="322" class=""></iframe>',
 		);
 	});
 
@@ -534,7 +534,7 @@ describe('Renders different types of Editions elements', () => {
 		const nodes = renderEditions(embedElement);
 		const embed = nodes.flat()[0];
 		expect(getHtml(embed)).toContain(
-			'<iframe srcDoc="&lt;section&gt;Embed&lt;/section&gt;" title="Embed" height="322"></iframe>',
+			'<iframe srcDoc="&lt;section&gt;Embed&lt;/section&gt;" title="Embed" height="322" class=""></iframe>',
 		);
 	});
 


### PR DESCRIPTION
## Why are you doing this?

https://theguardian.atlassian.net/browse/LIVE-2639

@prisalcalde @benwuersching I'm aware this is not the desired design, however we don't have much control over it as it's coming from inside an embed .. it's an iframe inside an iframe which is not flexible at all when it comes styling it from our side. The reason it doesn't split on bigger viewports is because our body text doesn't get wide enough for the inner iframe. 
We can definitely create a separate ticket to think about what can be done, potentially from the source. But it's a bigger task than we can do right now, apologies as I understand it seems like it should be straight forward, but it's not. For now, we're just fixing it so it's usable without any overlapping text issues, like in the screenshot.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/12860328/123640058-b3114400-d818-11eb-8cf7-99cc55773d3c.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/12860328/123640089-ba385200-d818-11eb-80c6-fb13d39ef1fd.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/12860328/123640074-b6a4cb00-d818-11eb-9413-c2ccd4dc1838.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/12860328/123640353-fd92c080-d818-11eb-8263-4d443e37f40e.png" width="300px" /> |
