### PR TITLE
LIVE-2648: Caption style fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2901,8 +2901,28 @@
       }
     },
     "@guardian/image-rendering": {
-      "version": "github:guardian/image-rendering#1167f8bc1f1b7f65ba883e4678e10190abbabb05",
-      "from": "github:guardian/image-rendering#1167f8bc"
+      "version": "github:guardian/image-rendering#58ab596e61a027f05fafe20425c3b4366644094a",
+      "from": "github:guardian/image-rendering#58ab596e61a027f05fafe20425c3b4366644094a",
+      "requires": {
+        "@emotion/babel-plugin": "^11.1.2",
+        "@emotion/react": "^11.1.5",
+        "@guardian/src-foundations": "^3.3.0",
+        "@guardian/types": "github:guardian/types#semver:^4.0.0",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
+        "typescript": "^4.3.4"
+      },
+      "dependencies": {
+        "@guardian/types": {
+          "version": "github:guardian/types#bd66bdfe8358701163053fdeb4efbee2d94a6185",
+          "from": "github:guardian/types#semver:^4.0.0"
+        },
+        "typescript": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+          "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew=="
+        }
+      }
     },
     "@guardian/node-riffraff-artifact": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2901,8 +2901,8 @@
       }
     },
     "@guardian/image-rendering": {
-      "version": "github:guardian/image-rendering#58ab596e61a027f05fafe20425c3b4366644094a",
-      "from": "github:guardian/image-rendering#58ab596e61a027f05fafe20425c3b4366644094a",
+      "version": "git+https://github.com/guardian/image-rendering.git#7c0facbbcd5b739f609aa80b11c0b9d63bd04695",
+      "from": "git+https://github.com/guardian/image-rendering.git#v7.0.0",
       "requires": {
         "@emotion/babel-plugin": "^11.1.2",
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@guardian/content-api-models": "^17.0.0",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^4.6.1",
-    "@guardian/image-rendering": "github:guardian/image-rendering#58ab596e61a027f05fafe20425c3b4366644094a",
+    "@guardian/image-rendering": "git+https://github.com/guardian/image-rendering.git#v7.0.0",
     "@guardian/node-riffraff-artifact": "^0.2.0",
     "@guardian/renditions": "^0.1.4",
     "@guardian/src-brand": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@guardian/content-api-models": "^17.0.0",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^4.6.1",
-    "@guardian/image-rendering": "github:guardian/image-rendering#1167f8bc",
+    "@guardian/image-rendering": "github:guardian/image-rendering#58ab596e61a027f05fafe20425c3b4366644094a",
     "@guardian/node-riffraff-artifact": "^0.2.0",
     "@guardian/renditions": "^0.1.4",
     "@guardian/src-brand": "^3.3.0",

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -8501,7 +8501,7 @@ exports[`Storyshots Editions/Article Letter 1`] = `
 .emotion-6 {
   width: 100vw;
   height: calc(100vw * 0.6);
-  background-color: #F6F6F6;
+  background-color: #DCDCDC;
   color: #999999;
   display: block;
   display: block;
@@ -8863,7 +8863,7 @@ exports[`Storyshots Editions/Article Letter 1`] = `
 .emotion-21 {
   width: 100%;
   height: calc(100% * 1.25);
-  background-color: #F6F6F6;
+  background-color: #DCDCDC;
   color: #999999;
   display: block;
 }
@@ -10273,11 +10273,17 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 
 .emotion-45 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5;
+  font-size: 0.75rem;
+  line-height: 1.35;
   font-weight: 400;
   padding-top: 0.5rem;
   color: #767676;
+}
+
+@media (prefers-color-scheme: dark) {
+  .emotion-45 {
+    color: #999999;
+  }
 }
 
 .emotion-46 {


### PR DESCRIPTION
## Why are you doing this?

@JamieB-gu made this PR implementing the caption design fixes https://github.com/guardian/image-rendering/pull/287

This PR simply tests the fix by bumping image-rendering to that PR's commit version.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->



## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/12860328/123651778-ae05c200-d823-11eb-8f87-082ec1c9a6cc.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/12860328/123651819-b52cd000-d823-11eb-8742-0f8b7fd0a9fb.png" width="300px" /> |
