### PR TITLE
LIVE-2666: add dropcaps to editions body

### DIFF
--- a/src/components/editions/article/index.tsx
+++ b/src/components/editions/article/index.tsx
@@ -10,6 +10,7 @@ import { Design, Display, partition } from '@guardian/types';
 import type { Item } from 'item';
 import type { FC } from 'react';
 import { renderEditionsAll } from 'renderer';
+import { getThemeStyles } from 'themeStyles';
 import Header from '../header';
 import {
 	articleMarginStyles,
@@ -109,6 +110,31 @@ const headerBackgroundStyles = (format: Format): SerializedStyles => css`
 	background-color: ${headerBackgroundColour(format)};
 `;
 
+const itemStyles = (item: Item): SerializedStyles => {
+	const { kicker } = getThemeStyles(item.theme);
+
+	switch (item.display) {
+		case Display.Immersive:
+			return css`
+				> p:first-of-type:first-letter,
+				> hr + p:first-letter {
+					color: ${kicker};
+					display: inline-block;
+					vertical-align: text-top;
+					line-height: 5.625rem;
+					font-size: 6.8125rem;
+					display: inline-block;
+					font-weight: 900;
+					float: left;
+					margin-right: ${remSpace[3]};
+				}
+			`;
+
+		default:
+			return css``;
+	}
+};
+
 const getSectionStyles = (item: Format): SerializedStyles[] => {
 	if (
 		item.design === Design.Interview ||
@@ -152,7 +178,7 @@ const Article: FC<Props> = ({ item }) => {
 								: null,
 						]}
 					>
-						<section css={bodyStyles}>
+						<section css={[bodyStyles, itemStyles(item)]}>
 							{renderEditionsAll(item, partition(item.body).oks)}
 						</section>
 					</div>


### PR DESCRIPTION
## Why are you doing this?

We were missing dropcaps on Editions.

## Changes

- add styles


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/123664695-7ac93000-d82f-11eb-9db5-d4e6ee9ac090.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/123664767-8ddc0000-d82f-11eb-9dae-18bd1e671338.png" width="300px" /> |
