### PR TITLE
Live 2632 offline header videos

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -15732,6 +15732,84 @@ exports[`Storyshots Editions/Headline Showcase 1`] = `
 </div>
 `;
 
+exports[`Storyshots Editions/Placeholder Default 1`] = `
+.emotion-0 {
+  width: 100%;
+  position: relative;
+  padding-bottom: 56.25%;
+  background-color: #333333;
+  color: #F6F6F6;
+}
+
+.emotion-1 {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%, -50%);
+  -moz-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 290px;
+}
+
+@media (min-width: 740px) {
+  .emotion-2 {
+    width: 300px;
+  }
+}
+
+.emotion-2 svg {
+  height: 33px;
+  fill: #F6F6F6;
+  stroke: #F6F6F6;
+}
+
+.emotion-3 {
+  text-align: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0.5rem 0;
+}
+
+<div
+  className="emotion-0"
+>
+  <div
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <svg
+        viewBox="0 0 40 33"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M29.9 12.64a7.27 7.27 0 112.82 14H20.95c-1.12.05-5.43.04-8.92.03l2.75-2.76h17.96a4.55 4.55 0 10-3.64-7.27 5.68 5.68 0 00-3.37-3.67l2.05-2.06c.8.45 1.52 1.03 2.14 1.73zM25.18 9.96l8.2-8.2L31.61 0l-8.8 8.8A9.39 9.39 0 0014.26 3a9.6 9.6 0 00-9.63 9.55C1.94 13.74 0 16.5 0 19.36a7.29 7.29 0 005.26 7L.5 31.1l1.77 1.77 6.23-6.23 14.1-14.1 2.58-2.59zm-10.9-4.23c3.1 0 5.56 2.34 6.36 5.25L7.7 23.9h-.43a4.52 4.52 0 01-4.54-4.55c0-2.08 1.68-4 3.63-4.54l.82 1.82 1.1-.37-.06-.15a10.2 10.2 0 01-.86-3.57 6.86 6.86 0 016.91-6.82z"
+        />
+      </svg>
+      <p
+        className="emotion-3"
+      >
+        Sorry, we couldn’t load this video. Please ensure you’re online in order to watch it.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Editions/PullQuote Default 1`] = `
 .emotion-0 {
   width: 10.875rem;

--- a/src/components/editions/placeholder/index.tsx
+++ b/src/components/editions/placeholder/index.tsx
@@ -1,0 +1,76 @@
+// ----- Imports ----- //
+import { css } from '@emotion/react';
+import { remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import * as Palette from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import type { FC } from 'react';
+
+// ----- Styles ----- //
+
+const placeholderStyles = css`
+	width: 100%;
+	position: relative;
+	padding-bottom: 56.25%;
+	background-color: ${Palette.neutral[20]};
+	color: ${Palette.neutral[97]};
+`;
+
+const centerStyles = css`
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+`;
+
+const wrapperStyles = css`
+	display: flex;
+	flex-direction: column;
+	width: 290px;
+
+	${from.tablet} {
+		width: 300px;
+	}
+
+	svg {
+		height: 33px;
+		fill: ${Palette.neutral[97]};
+		stroke: ${Palette.neutral[97]};
+	}
+`;
+
+const textStyles = css`
+	text-align: center;
+	${textSans.small()};
+	margin: ${remSpace[2]} 0;
+`;
+
+// ----- Component ----- //
+
+// replace this with "SvgOfflineCloud" import from Source when available
+const SvgOfflineCloud = (): JSX.Element => (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 33">
+		<path d="M29.9 12.64a7.27 7.27 0 112.82 14H20.95c-1.12.05-5.43.04-8.92.03l2.75-2.76h17.96a4.55 4.55 0 10-3.64-7.27 5.68 5.68 0 00-3.37-3.67l2.05-2.06c.8.45 1.52 1.03 2.14 1.73zM25.18 9.96l8.2-8.2L31.61 0l-8.8 8.8A9.39 9.39 0 0014.26 3a9.6 9.6 0 00-9.63 9.55C1.94 13.74 0 16.5 0 19.36a7.29 7.29 0 005.26 7L.5 31.1l1.77 1.77 6.23-6.23 14.1-14.1 2.58-2.59zm-10.9-4.23c3.1 0 5.56 2.34 6.36 5.25L7.7 23.9h-.43a4.52 4.52 0 01-4.54-4.55c0-2.08 1.68-4 3.63-4.54l.82 1.82 1.1-.37-.06-.15a10.2 10.2 0 01-.86-3.57 6.86 6.86 0 016.91-6.82z" />
+	</svg>
+);
+
+interface Props {
+	text: string;
+}
+
+const Placeholder: FC<Props> = ({ text }) => {
+	return (
+		<div css={placeholderStyles}>
+			<div css={centerStyles}>
+				<div css={wrapperStyles}>
+					<SvgOfflineCloud />
+					<p css={textStyles}>{text}</p>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+// ----- Exports ----- //
+
+export default Placeholder;

--- a/src/components/editions/placeholder/placeholder.stories.tsx
+++ b/src/components/editions/placeholder/placeholder.stories.tsx
@@ -1,0 +1,20 @@
+// ----- Imports ----- //
+
+import type { ReactElement } from 'react';
+import Placeholder from './index';
+
+// ----- Stories ----- //
+
+const text =
+	'Sorry, we couldn’t load this video. Please ensure you’re online in order to watch it.';
+
+const Default = (): ReactElement => <Placeholder text={text} />;
+
+// ----- Exports ----- //
+
+export default {
+	component: Placeholder,
+	title: 'Editions/Placeholder',
+};
+
+export { Default };

--- a/src/components/editions/utils/useOnlineStatus.tsx
+++ b/src/components/editions/utils/useOnlineStatus.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+const PING_RESOURCE = '/ping.txt';
+const TIMEOUT_TIME_MS = 3000;
+const onlinePollingInterval = 10000;
+
+const timeout = (
+	time: number,
+	promise: Promise<Response>,
+): Promise<Response> => {
+	return new Promise(function (resolve, reject) {
+		setTimeout(() => {
+			reject(new Error('Request timed out.'));
+		}, time);
+		promise.then(resolve, reject);
+	});
+};
+
+const checkOnlineStatus = async (): Promise<boolean> => {
+	const controller = new AbortController();
+	const { signal } = controller;
+
+	// If the browser has no network connection return offline
+	if (!navigator.onLine) return navigator.onLine;
+
+	try {
+		await timeout(
+			TIMEOUT_TIME_MS,
+			fetch(PING_RESOURCE, {
+				method: 'GET',
+				signal,
+			}),
+		);
+		return true;
+	} catch (error) {
+		console.error(error);
+		controller.abort();
+	}
+	return false;
+};
+
+const useOnlineStatus = (): boolean => {
+	const [onlineStatus, setOnlineStatus] = useState<boolean>(true);
+
+	const checkStatus = async (): Promise<void> => {
+		const online = await checkOnlineStatus();
+		setOnlineStatus(online);
+	};
+
+	useEffect(() => {
+		window.addEventListener('offline', () => {
+			setOnlineStatus(false);
+		});
+
+		const id = setInterval((): void => {
+			void checkStatus();
+		}, onlinePollingInterval);
+
+		return (): void => {
+			window.removeEventListener('offline', () => {
+				setOnlineStatus(false);
+			});
+			return clearInterval(id);
+		};
+	}, []);
+
+	return onlineStatus;
+};
+
+export default useOnlineStatus;

--- a/src/components/editions/video/index.tsx
+++ b/src/components/editions/video/index.tsx
@@ -1,6 +1,8 @@
 // ----- Imports ----- //
 import { css } from '@emotion/react';
 import type { FC } from 'react';
+import Placeholder from '../placeholder';
+import useOnlineStatus from '../utils/useOnlineStatus';
 
 // ----- Styles ----- //
 
@@ -26,7 +28,11 @@ interface Props {
 }
 
 const Video: FC<Props> = ({ title, atomId }) => {
-	return (
+	const online = useOnlineStatus();
+	const text =
+		'Sorry, we couldn’t load this video. Please ensure you’re online in order to watch it.';
+
+	return online ? (
 		<div css={videoWrapperStyles}>
 			<iframe
 				title={title}
@@ -37,6 +43,8 @@ const Video: FC<Props> = ({ title, atomId }) => {
 				src={`https://embed.theguardian.com/embed/atom/media/${atomId}#noadsaf`}
 			></iframe>
 		</div>
+	) : (
+		<Placeholder text={text} />
 	);
 };
 


### PR DESCRIPTION
## Why are you doing this?

If a user is offline (and the header video is not already cached), the user will see an error message.

This PR creates a hook to check the online status based on this approach: https://levelup.gitconnected.com/useonlinestatus-a-react-hook-to-know-when-your-app-is-offline-2d06e4e536a

It also creates a placeholder component. It currently uses an inline svg, there is an open PR to add the correct icon to Source after which we should import the SVG from there: https://github.com/guardian/source/pull/840


## Changes

- create `useOnlineStatus` hook
- create `Placeholder` component
- render placeholder in `video` component if offline

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/123988429-ecd07f00-d9bf-11eb-98e1-1a0a0f2387b3.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/123988543-04a80300-d9c0-11eb-8cba-862fbc3675d5.png" width="300px" /> |
