### PR TITLE
LIVE-2679: Fix follow icon cropping

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -17335,6 +17335,7 @@ exports[`Storyshots Follow Default 1`] = `
   background: none;
   margin-left: 0;
   margin-top: 0.25rem;
+  min-height: 1.5rem;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -17387,6 +17388,7 @@ exports[`Storyshots Follow Default 1`] = `
   >
     <svg
       className="follow-icon"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle

--- a/src/components/follow.tsx
+++ b/src/components/follow.tsx
@@ -32,6 +32,7 @@ const styles = ({ theme }: Format): SerializedStyles => {
 		background: none;
 		margin-left: 0;
 		margin-top: ${remSpace[1]};
+		min-height: 1.5rem;
 
 		${darkModeCss`
 			color: ${inverted};

--- a/src/components/followStatus.tsx
+++ b/src/components/followStatus.tsx
@@ -13,7 +13,11 @@ type IconProps = Props;
 const FollowIcon: FC<IconProps> = ({ isFollowing }) => {
 	if (isFollowing) {
 		return (
-			<svg xmlns="http://www.w3.org/2000/svg" className="following-icon">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				className="following-icon"
+				viewBox="0 0 24 24"
+			>
 				<path
 					fillRule="evenodd"
 					clipRule="evenodd"
@@ -23,7 +27,11 @@ const FollowIcon: FC<IconProps> = ({ isFollowing }) => {
 		);
 	} else {
 		return (
-			<svg xmlns="http://www.w3.org/2000/svg" className="follow-icon">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				className="follow-icon"
+				viewBox="0 0 24 24"
+			>
 				<circle cx="12" cy="12" r="12" />
 				<path
 					fillRule="evenodd"


### PR DESCRIPTION
## Why are you doing this?

https://theguardian.atlassian.net/browse/LIVE-2679

There were two reasons for this to happen, a) the viewbox was missing so the svg elements didn't know what to scale towards. b) the button min-height didn't accommodate the height of the svg itself.


## Changes

- Add min height to the follow button (Same height as the svg)
- add the svg viewbox



## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/12860328/124439526-6fb35a00-dd71-11eb-88c8-794ced3fcf25.png " width="100px" /> | <img src="https://user-images.githubusercontent.com/12860328/124439561-79d55880-dd71-11eb-928c-41839f0958a5.png" width="100px" /> |
