### PR TITLE
Extract Lists From Renderer

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -18309,6 +18309,99 @@ exports[`Storyshots HorizontalRule Default 1`] = `
 />
 `;
 
+exports[`Storyshots List Default 1`] = `
+.emotion-0 {
+  list-style: none;
+  margin: 0.75rem 0;
+  padding-left: 0;
+  clear: both;
+}
+
+.emotion-1 {
+  padding-left: 1.5rem;
+  padding-bottom: 0.375rem;
+}
+
+.emotion-1::before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.5rem;
+  height: 1rem;
+  width: 1rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.5rem;
+  vertical-align: middle;
+}
+
+.emotion-1>p:first-of-type {
+  display: inline;
+  padding: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .emotion-1::before {
+    background-color: #767676;
+  }
+}
+
+<ul
+  className="emotion-0"
+>
+  <li
+    className="emotion-1"
+  >
+    A bullet point
+  </li>
+  <li
+    className="emotion-1"
+  >
+    A bullet point
+  </li>
+  <li
+    className="emotion-1"
+  >
+    A bullet point
+  </li>
+</ul>
+`;
+
+exports[`Storyshots ListItem Default 1`] = `
+.emotion-0 {
+  padding-left: 1.5rem;
+  padding-bottom: 0.375rem;
+}
+
+.emotion-0::before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.5rem;
+  height: 1rem;
+  width: 1rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.5rem;
+  vertical-align: middle;
+}
+
+.emotion-0>p:first-of-type {
+  display: inline;
+  padding: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .emotion-0::before {
+    background-color: #767676;
+  }
+}
+
+<li
+  className="emotion-0"
+>
+  A bullet point
+</li>
+`;
+
 exports[`Storyshots Paragraph Default 1`] = `
 .emotion-0 {
   font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;

--- a/src/components/list.stories.tsx
+++ b/src/components/list.stories.tsx
@@ -1,0 +1,33 @@
+// ----- Imports ----- //
+
+import { Design, Display, Pillar } from '@guardian/types';
+import type { FC } from 'react';
+import List from './list';
+import ListItem from './listItem';
+
+// ----- Setup ----- //
+
+const listItem = (
+	<ListItem
+		format={{
+			design: Design.Article,
+			display: Display.Standard,
+			theme: Pillar.News,
+		}}
+	>
+		A bullet point
+	</ListItem>
+);
+
+// ----- Stories ----- //
+
+const Default: FC = () => <List>{[listItem, listItem, listItem]}</List>;
+
+// ----- Exports ----- //
+
+export default {
+	component: List,
+	title: 'List',
+};
+
+export { Default };

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -1,0 +1,25 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { remSpace } from '@guardian/src-foundations';
+import type { FC, ReactNode } from 'react';
+
+// ----- Component ----- //
+
+const styles: SerializedStyles = css`
+	list-style: none;
+	margin: ${remSpace[3]} 0;
+	padding-left: 0;
+	clear: both;
+`;
+
+interface Props {
+	children: ReactNode;
+}
+
+const List: FC<Props> = ({ children }) => <ul css={styles}>{children}</ul>;
+
+// ----- Exports ----- //
+
+export default List;

--- a/src/components/listItem.stories.tsx
+++ b/src/components/listItem.stories.tsx
@@ -1,0 +1,29 @@
+// ----- Imports ----- //
+
+import { Design, Display, Pillar } from '@guardian/types';
+import type { FC } from 'react';
+import { selectDesign, selectPillar } from 'storybookHelpers';
+import ListItem from './listItem';
+
+// ----- Stories ----- //
+
+const Default: FC = () => (
+	<ListItem
+		format={{
+			design: selectDesign(Design.Article),
+			display: Display.Standard,
+			theme: selectPillar(Pillar.News),
+		}}
+	>
+		A bullet point
+	</ListItem>
+);
+
+// ----- Exports ----- //
+
+export default {
+	component: ListItem,
+	title: 'ListItem',
+};
+
+export { Default };

--- a/src/components/listItem.tsx
+++ b/src/components/listItem.tsx
@@ -1,0 +1,68 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { remSpace } from '@guardian/src-foundations';
+import { neutral } from '@guardian/src-foundations/palette';
+import type { Format } from '@guardian/types';
+import { Design } from '@guardian/types';
+import type { FC, ReactNode } from 'react';
+import { darkModeCss } from 'styles';
+
+// ----- Component ----- //
+
+const baseStyles = css`
+	padding-left: ${remSpace[6]};
+	padding-bottom: 0.375rem;
+
+	&::before {
+		display: inline-block;
+		content: '';
+		border-radius: 0.5rem;
+		height: 1rem;
+		width: 1rem;
+		margin-right: ${remSpace[2]};
+		background-color: ${neutral[86]};
+		margin-left: -${remSpace[6]};
+		vertical-align: middle;
+	}
+
+	> p:first-of-type {
+		display: inline;
+		padding: 0;
+	}
+
+	${darkModeCss`
+        &::before {
+            background-color: ${neutral[46]};
+        }
+    `}
+`;
+
+const mediaStyles = css`
+	&::before {
+		background-color: ${neutral[46]};
+	}
+`;
+
+const styles = (format: Format): SerializedStyles => {
+	switch (format.design) {
+		case Design.Media:
+			return css(baseStyles, mediaStyles);
+		default:
+			return baseStyles;
+	}
+};
+
+interface Props {
+	format: Format;
+	children: ReactNode;
+}
+
+const ListItem: FC<Props> = ({ format, children }) => (
+	<li css={styles(format)}>{children}</li>
+);
+
+// ----- Exports ----- //
+
+export default ListItem;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -62,6 +62,8 @@ import Video from 'components/editions/video';
 import { EmbedComponentWrapper } from 'components/embedWrapper';
 import HorizontalRule from 'components/horizontalRule';
 import Interactive from 'components/interactive';
+import List from 'components/list';
+import ListItem from 'components/listItem';
 import LiveEventLink from 'components/liveEventLink';
 import Paragraph from 'components/paragraph';
 import Pullquote from 'components/pullquote';
@@ -129,66 +131,6 @@ const transform = (text: string, format: Format): ReactElement | string => {
 		return h(HorizontalRule, null, null);
 	}
 	return text;
-};
-
-const listStyles: SerializedStyles = css`
-	list-style: none;
-	margin: ${remSpace[3]} 0;
-	padding-left: 0;
-	clear: both;
-`;
-
-const listItemStyles = (format: Format): SerializedStyles[] => {
-	const baseStyles = css`
-		padding-left: ${remSpace[6]};
-		padding-bottom: 0.375rem;
-
-		&::before {
-			display: inline-block;
-			content: '';
-			border-radius: 0.5rem;
-			height: 1rem;
-			width: 1rem;
-			margin-right: ${remSpace[2]};
-			background-color: ${neutral[86]};
-			margin-left: -${remSpace[6]};
-			vertical-align: middle;
-		}
-
-		> p:first-of-type {
-			display: inline;
-			padding: 0;
-		}
-
-		${darkModeCss`
-            &::before {
-                background-color: ${neutral[46]};
-            }
-        `}
-	`;
-
-	const mediaStyles = css`
-		&::before {
-			background-color: ${neutral[46]};
-		}
-	`;
-
-	const liveblogStyles = css`
-		${darkModeCss`
-            &::before {
-                background-color: ${neutral[86]};
-            }
-        `}
-	`;
-
-	switch (format.design) {
-		case Design.Media:
-			return [baseStyles, mediaStyles];
-		case Design.LiveBlog:
-			return [baseStyles, liveblogStyles];
-		default:
-			return [baseStyles];
-	}
 };
 
 const HeadingTwoStyles = (format: Format): SerializedStyles => {
@@ -295,9 +237,9 @@ const textElement = (format: Format, supportsDarkMode = true) => (
 		case 'BR':
 			return h('br', { key }, null);
 		case 'UL':
-			return styledH('ul', { css: listStyles }, children);
+			return h(List, { children });
 		case 'LI':
-			return styledH('li', { css: listItemStyles(format) }, children);
+			return h(ListItem, { format, children });
 		case 'MARK':
 			return styledH('mark', { key }, children);
 		default:
@@ -327,9 +269,9 @@ const standfirstTextElement = (format: Format) => (
 		case 'STRONG':
 			return h('strong', { key }, children);
 		case 'UL':
-			return styledH('ul', { css: listStyles }, children);
+			return h(List, { children });
 		case 'LI':
-			return styledH('li', { css: listItemStyles(format) }, children);
+			return h(ListItem, { format, children });
 		case 'A': {
 			const colour = linkColourFromFormat(format);
 			const styles = css`

--- a/src/storybookHelpers.ts
+++ b/src/storybookHelpers.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Pillar } from '@guardian/types';
+import { Design, Pillar } from '@guardian/types';
 import { select } from '@storybook/addon-knobs';
 
 // ----- Helpers ----- //
@@ -16,6 +16,29 @@ const pillarOptions = {
 const selectPillar = (initial: Pillar): Pillar =>
 	select('Pillar', pillarOptions, initial);
 
+const designOptions = {
+	Article: Design.Article,
+	Media: Design.Media,
+	Review: Design.Review,
+	Analysis: Design.Analysis,
+	Comment: Design.Comment,
+	Letter: Design.Letter,
+	Feature: Design.Feature,
+	LiveBlog: Design.LiveBlog,
+	DeadBlog: Design.DeadBlog,
+	Recipe: Design.Recipe,
+	MatchReport: Design.MatchReport,
+	Interview: Design.Interview,
+	Editorial: Design.Editorial,
+	Quiz: Design.Quiz,
+	Interactive: Design.Interactive,
+	PhotoEssay: Design.PhotoEssay,
+	PrintShop: Design.PrintShop,
+};
+
+const selectDesign = (initial: Design): Design =>
+	select('Design', designOptions, initial);
+
 // ----- Exports ----- //
 
-export { selectPillar };
+export { selectPillar, selectDesign };


### PR DESCRIPTION
## Why are you doing this?

On-going work to tidy up the renderer file. This time I'm pulling a couple of components out into their own files and creating stories for them.

## Changes

- Extracted `ul` and `li` from renderer into `List` and `ListItem`
- Added a storybook helper for selecting `Design`
- Added stories for `List` and `ListItem`
- Removed liveblog styling for `ListItem`
