### PR TITLE
LIVE-2566: Prepare for square ads

### DIFF
--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -15,6 +15,8 @@ import {
 	videoClient,
 } from '../native/nativeApi';
 
+const TEADS_ENABLED = true;
+
 type Slot = AdSlot | VideoSlot;
 
 function areRectsEqual(rectA: IRect, rectB: IRect): boolean {
@@ -78,12 +80,19 @@ function getAdSlots(): AdSlot[] {
 		return [];
 	}
 
-	return Array.from(advertSlots).map((adSlot) => {
+	return Array.from(advertSlots).map((adSlot, idx) => {
+		// To easily turn teads square ads on, we can use the TEADS_ENABLED boolean flag above
+		// Therefore we need to disable a rule for unnecessary conditions.
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- explained above.
+		const isSquare = TEADS_ENABLED && idx === 0;
+		if (isSquare) {
+			adSlot.classList.add('ad-slot-square');
+		}
 		const slotPosition = adSlot.getBoundingClientRect();
 		return new AdSlot({
 			rect: getRect(slotPosition),
 			targetingParams,
-			isSquare: false,
+			isSquare,
 		});
 	});
 }

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -81,9 +81,9 @@ function getAdSlots(): AdSlot[] {
 	}
 
 	return Array.from(advertSlots).map((adSlot, idx) => {
-		// To easily turn teads square ads on, we can use the TEADS_ENABLED boolean flag above
-		// Therefore we need to disable a rule for unnecessary conditions.
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- explained above.
+		/* eslint-disable @typescript-eslint/no-unnecessary-condition --
+		To easily turn teads square ads on, we can use the TEADS_ENABLED boolean flag above
+		Therefore we need to disable a rule for unnecessary conditions. */
 		const isSquare = TEADS_ENABLED && idx === 0;
 		if (isSquare) {
 			adSlot.classList.add('ad-slot-square');
@@ -94,6 +94,7 @@ function getAdSlots(): AdSlot[] {
 			targetingParams,
 			isSquare,
 		});
+		/* eslint-enable @typescript-eslint/no-unnecessary-condition */
 	});
 }
 

--- a/src/client/nativeCommunication.ts
+++ b/src/client/nativeCommunication.ts
@@ -15,7 +15,7 @@ import {
 	videoClient,
 } from '../native/nativeApi';
 
-const TEADS_ENABLED = true;
+const TEADS_ENABLED = false;
 
 type Slot = AdSlot | VideoSlot;
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -148,6 +148,14 @@ export const adStyles = (format: Format): SerializedStyles => {
 				padding-bottom: ${adHeight};
 			}
 
+			.ad-slot-square {
+				height: 344px;
+				width: 320px;
+				margin-left: auto;
+				margin-right: auto;
+				padding-bottom: 0;
+			}
+
 			.upgrade-banner {
 				padding: ${remSpace[3]};
 				background-color: ${brandAltBackground.primary};


### PR DESCRIPTION
## Why are you doing this?

This PR prepares for square ads format once enabled. Only for first ad in an article.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- prepare a boolean flag to turn on square ads
- `.ad-slot-square` styles.



## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/12860328/124645187-0aec2280-de8b-11eb-8bcb-2533ffe123a3.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/12860328/124645229-16d7e480-de8b-11eb-9681-467e4d62fd99.png" width="300px" /> |
