### PR TITLE
LIVE-2738-Trail-Override 

### DIFF
--- a/src/components/editions/standfirst/index.tsx
+++ b/src/components/editions/standfirst/index.tsx
@@ -126,13 +126,13 @@ interface Props {
 	shareIcon?: boolean;
 }
 
-const noLinks = true;
+const isEditions = true;
 
 const Standfirst: FC<Props> = ({ item, shareIcon }) => {
 	return maybeRender(item.standfirst, (standfirst) => (
 		<div css={getStyles(item)}>
 			<div css={textContainerStyles}>
-				{renderStandfirstText(standfirst, item, noLinks)}
+				{renderStandfirstText(standfirst, item, isEditions)}
 			</div>
 			{shareIcon && (
 				<span className="js-share-button" role="button">

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -289,39 +289,27 @@ const standfirstTextElement = (format: Format) => (
 	}
 };
 
-const noLinksStandfirstTextElement = (format: Format) => (
-	node: Node,
-	key: number,
-): ReactNode => {
-	const children = Array.from(node.childNodes).map(
-		standfirstTextElement(format),
-	);
-	switch (node.nodeName) {
-		case 'P':
-			return h('p', { key }, children);
-		case 'STRONG':
-			return h('strong', { key }, children);
-		default:
-			return null;
-	}
-};
-
 const text = (
 	doc: DocumentFragment,
 	format: Format,
 	supportsDarkMode = true,
 ): ReactNode[] =>
 	Array.from(doc.childNodes).map(textElement(format, supportsDarkMode));
+
+const editionsStandfirstFilter = (node: Node): boolean =>
+	!['UL', 'LI', 'A'].includes(node.nodeName);
+
 const standfirstText = (
 	doc: DocumentFragment,
 	format: Format,
-	noLinks?: boolean,
-): ReactNode[] =>
-	Array.from(doc.childNodes).map(
-		noLinks
-			? noLinksStandfirstTextElement(format)
-			: standfirstTextElement(format),
-	);
+	isEditions?: boolean,
+): ReactNode[] => {
+	const nodes = Array.from(doc.childNodes);
+	const filteredNodes = isEditions
+		? nodes.filter(editionsStandfirstFilter)
+		: nodes;
+	return filteredNodes.map(standfirstTextElement(format));
+};
 
 const Tweet = (props: {
 	content: NodeList;


### PR DESCRIPTION
## Why are you doing this?
Production `Standfirst` overrides weren't appearing on ER. The Editions `Standfirst` component doesn't use all of the nodes that Apps use and because of this it was accidentally filtering out the overrides, which can be text elements and are not currently accounted for.

This PR refactors the `Standfirst` render logic to explicitly filter out unwanted nodes if it's an Editions article before using the standard `Standfirst` render logic allowing text elements to flow correctly.  

Big thanks to @JamieB-gu for his help and influence!

## Changes

- Convert the `noLinkStandfirst` function to a filter for better readability and clearer intention
- Update param names
 
## Screenshots

| Before | After |
| --- | --- |
| <img src="" width="300px" /> | <img src="" width="300px" /> |
