### PR TITLE
LIVE-2065 - Set AssociatePublicIpAddress to false

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -305,7 +305,7 @@ Resources:
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: true
+      AssociatePublicIpAddress: false
       IamInstanceProfile: !Ref DistributionInstanceProfile
       ImageId: !Ref AMI
       InstanceType: !FindInMap [!Ref Stage, InstanceType, Value]


### PR DESCRIPTION
## Why are you doing this?
This PR sets removes the public IPv4 address from the EC2 instances. This change would resolve the relevant security issue in AWS security Hub.

Find more info in https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-9-remediation

Deployed and tested in code