### PR TITLE
Rich Link For Narrow Breakpoints

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -18631,7 +18631,7 @@ exports[`Storyshots Rich Link Default 1`] = `
   }
 }
 
-.emotion-1 .js-image img {
+.emotion-1 img {
   width: calc(100% + 1.5rem);
   margin: -0.75rem 0 0 -0.75rem;
 }
@@ -18697,7 +18697,7 @@ exports[`Storyshots Rich Link Default 1`] = `
     box-sizing: border-box;
   }
 
-  .emotion-1 .js-image {
+  .emotion-1 img {
     display: none;
   }
 }

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -18696,6 +18696,10 @@ exports[`Storyshots Rich Link Default 1`] = `
     width: 100%;
     box-sizing: border-box;
   }
+
+  .emotion-1 .js-image {
+    display: none;
+  }
 }
 
 @media (min-width: 1300px) {

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -18691,6 +18691,13 @@ exports[`Storyshots Rich Link Default 1`] = `
   }
 }
 
+@media (max-width: 23.4rem) {
+  .emotion-1 {
+    width: 100%;
+    box-sizing: border-box;
+  }
+}
+
 @media (min-width: 1300px) {
   .emotion-1 {
     margin-left: calc(

--- a/src/components/richLink.tsx
+++ b/src/components/richLink.tsx
@@ -139,6 +139,10 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 		@media (max-width: 23.4rem) {
 			width: 100%;
 			box-sizing: border-box;
+
+			.js-image {
+				display: none;
+			}
 		}
 		${from.wide} {
 			margin-left: calc(

--- a/src/components/richLink.tsx
+++ b/src/components/richLink.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css, jsx as styledH } from '@emotion/react';
 import { remSpace } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
@@ -136,6 +136,10 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 		margin: 0.375rem ${remSpace[4]} ${remSpace[3]} 0;
 
 		width: ${richLinkWidth};
+		${until.mobileMedium} {
+			width: 100%;
+			box-sizing: border-box;
+		}
 		${from.wide} {
 			margin-left: calc(
 				-${richLinkWidth} - ${remSpace[4]} - ${remSpace[6]}

--- a/src/components/richLink.tsx
+++ b/src/components/richLink.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css, jsx as styledH } from '@emotion/react';
 import { remSpace } from '@guardian/src-foundations';
-import { from, until } from '@guardian/src-foundations/mq';
+import { from } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
@@ -136,7 +136,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 		margin: 0.375rem ${remSpace[4]} ${remSpace[3]} 0;
 
 		width: ${richLinkWidth};
-		${until.mobileMedium} {
+		@media (max-width: 23.4rem) {
 			width: 100%;
 			box-sizing: border-box;
 		}

--- a/src/components/richLink.tsx
+++ b/src/components/richLink.tsx
@@ -89,7 +89,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 			${richLinkPillarStyles(lifestyleKicker, lifestyleInverted)}
 		}
 
-		.js-image img {
+		img {
 			width: calc(100% + ${remSpace[6]});
 			margin: -${remSpace[3]} 0 0 -${remSpace[3]};
 		}
@@ -140,7 +140,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 			width: 100%;
 			box-sizing: border-box;
 
-			.js-image {
+			img {
 				display: none;
 			}
 		}


### PR DESCRIPTION
## Why are you doing this?

Currently using the scaling slider to scale up articles results in the text around rich links becoming large and hard to read. We'd like to push rich links to full width beyond a certain scaling threshold to prevent this. One way to achieve this is to use a `rem`-based breakpoint, below which they become full-width.

## Changes

- Added a `rem`-based breakpoint for `mobileMedium`, below which rich links are full width

## Screenshots

| light mode | dark mode |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/12860328/125801460-f4243ab8-5e26-44e9-af33-847e7f6e7d82.png" width="300" /> | <img src="https://user-images.githubusercontent.com/12860328/125801553-5e6b3a58-3c4f-4498-a106-a485730f5135.png" width="300" /> |


