### PR TITLE
LIVE-2708: hydrate editions video component

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -14834,16 +14834,20 @@ exports[`Storyshots Editions/HeaderMedia Video 1`] = `
 }
 
 <div
-  className="emotion-0"
+  className="js-video-container"
 >
-  <iframe
-    allowFullScreen={true}
-    className="emotion-1"
-    frameBorder="0"
-    scrolling="no"
-    src="https://embed.theguardian.com/embed/atom/media/26401ff7-24d0-4ba5-8882-2c32c2b379f0#noadsaf"
-    title="Super Bowl LV: Tom Brady MVP as Buccaneers beat Chiefs 31-9 – video report"
-  />
+  <div
+    className="emotion-0"
+  >
+    <iframe
+      allowFullScreen={true}
+      className="emotion-1"
+      frameBorder="0"
+      scrolling="no"
+      src="https://embed.theguardian.com/embed/atom/media/26401ff7-24d0-4ba5-8882-2c32c2b379f0#noadsaf"
+      title="Super Bowl LV: Tom Brady MVP as Buccaneers beat Chiefs 31-9 – video report"
+    />
+  </div>
 </div>
 `;
 

--- a/src/client/editions.ts
+++ b/src/client/editions.ts
@@ -4,6 +4,7 @@ import {
 	pingEditionsNative,
 } from '@guardian/renditions';
 import ShareIcon from 'components/editions/shareIcon';
+import Video from 'components/editions/video';
 import { createElement as h } from 'react';
 import ReactDOM from 'react-dom';
 import interactives from './interactives';
@@ -60,3 +61,4 @@ adjustGalleryImages();
 interactives();
 
 ReactDOM.render(h(ShareIcon), document.querySelector('.js-share-button'));
+ReactDOM.render(h(Video), document.querySelector('.js-video-container'));

--- a/src/components/editions/headerMedia/index.tsx
+++ b/src/components/editions/headerMedia/index.tsx
@@ -199,7 +199,11 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 				video: { title, atomId },
 			} = media;
 
-			return <Video atomId={atomId} title={title} />;
+			return (
+				<div className="js-video-container">
+					<Video atomId={atomId} title={title} />
+				</div>
+			);
 		}
 	});
 };


### PR DESCRIPTION
## Why are you doing this?

We we're seeing the desired behaviour from the `useOnlineStatus` hook when templates were rendered.

## Changes

- Hydrate `Video` component

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/123988429-ecd07f00-d9bf-11eb-98e1-1a0a0f2387b3.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/123988543-04a80300-d9c0-11eb-8cba-862fbc3675d5.png" width="300px" /> |