### PR TITLE
LIVE-2788: use params to override theme

### DIFF
--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -5,7 +5,7 @@ import { CacheProvider } from '@emotion/react';
 import { extractCritical } from '@emotion/server';
 import type { EmotionCritical } from '@emotion/server/create-instance';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
-import type { Option } from '@guardian/types';
+import type { Option, Theme } from '@guardian/types';
 import { none, some } from '@guardian/types';
 import { getThirdPartyEmbeds } from 'capi';
 import type { ThirdPartyEmbeds } from 'capi';
@@ -106,9 +106,19 @@ const buildHtml = (
     </html>
 `;
 
-function render(imageSalt: string, request: RenderingRequest): Page {
+function render(
+	imageSalt: string,
+	request: RenderingRequest,
+	themeOverride?: Theme,
+): Page {
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
-	const body = renderBody(item);
+
+	const newItem = {
+		...item,
+		theme: themeOverride ?? item.theme,
+	};
+
+	const body = renderBody(newItem);
 	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
 
 	const head = renderHead(

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -6,7 +6,7 @@ import { extractCritical } from '@emotion/server';
 import type { EmotionCritical } from '@emotion/server/create-instance';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import type { Option, Theme } from '@guardian/types';
-import { none, some } from '@guardian/types';
+import { none, some, withDefault } from '@guardian/types';
 import { getThirdPartyEmbeds } from 'capi';
 import type { ThirdPartyEmbeds } from 'capi';
 import { atomCss, atomScript } from 'components/atoms/interactiveAtom';
@@ -109,13 +109,13 @@ const buildHtml = (
 function render(
 	imageSalt: string,
 	request: RenderingRequest,
-	themeOverride?: Theme,
+	themeOverride: Option<Theme>,
 ): Page {
 	const item = fromCapi({ docParser, salt: imageSalt })(request);
 
 	const newItem = {
 		...item,
-		theme: themeOverride ?? item.theme,
+		theme: withDefault(item.theme)(themeOverride),
 	};
 
 	const body = renderBody(newItem);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -244,18 +244,11 @@ async function serveArticlePost(
 	try {
 		const renderingRequest = await mapiDecoder(req.body);
 		const richLinkDetails = req.query.richlink === '';
-		const isEditions = req.query.editions === '';
-		const themeOverride = themeFromUnknown(req.query.theme);
 
 		if (richLinkDetails) {
 			void serveRichLinkDetails(renderingRequest, res);
 		} else {
-			void serveArticleSwitch(
-				renderingRequest,
-				res,
-				isEditions,
-				themeOverride,
-			);
+			void serveArticle(renderingRequest, res);
 		}
 	} catch (e) {
 		logger.error(`This error occurred`, e);


### PR DESCRIPTION
## Why are you doing this?

We need to override article theme styles based on which fronts container they live in. From the perspective of Editions Rendering this means we need to be able to pass a parameter containing the `theme` value from Editions backend, and use that to override the existing article theme value.

## Changes

- get `themeOverride` from query params
- pass value through to article `item` level


