### PR TITLE
LIVE-2708: simplify onlineStatusHook

### DIFF
--- a/src/components/editions/utils/useOnlineStatus.tsx
+++ b/src/components/editions/utils/useOnlineStatus.tsx
@@ -1,66 +1,22 @@
 import { useEffect, useState } from 'react';
 
-const PING_RESOURCE = '/ping.txt';
-const TIMEOUT_TIME_MS = 3000;
-const onlinePollingInterval = 10000;
-
-const timeout = (
-	time: number,
-	promise: Promise<Response>,
-): Promise<Response> => {
-	return new Promise(function (resolve, reject) {
-		setTimeout(() => {
-			reject(new Error('Request timed out.'));
-		}, time);
-		promise.then(resolve, reject);
-	});
-};
-
-const checkOnlineStatus = async (): Promise<boolean> => {
-	const controller = new AbortController();
-	const { signal } = controller;
-
-	// If the browser has no network connection return offline
-	if (!navigator.onLine) return navigator.onLine;
-
-	try {
-		await timeout(
-			TIMEOUT_TIME_MS,
-			fetch(PING_RESOURCE, {
-				method: 'GET',
-				signal,
-			}),
-		);
-		return true;
-	} catch (error) {
-		console.error(error);
-		controller.abort();
-	}
-	return false;
-};
-
 const useOnlineStatus = (): boolean => {
 	const [onlineStatus, setOnlineStatus] = useState<boolean>(true);
 
-	const checkStatus = async (): Promise<void> => {
-		const online = await checkOnlineStatus();
-		setOnlineStatus(online);
+	const setOnline = (): void => {
+		setOnlineStatus(true);
+	};
+	const setOffline = (): void => {
+		setOnlineStatus(false);
 	};
 
 	useEffect(() => {
-		window.addEventListener('offline', () => {
-			setOnlineStatus(false);
-		});
-
-		const id = setInterval((): void => {
-			void checkStatus();
-		}, onlinePollingInterval);
+		window.addEventListener('offline', setOffline);
+		window.addEventListener('online', setOnline);
 
 		return (): void => {
-			window.removeEventListener('offline', () => {
-				setOnlineStatus(false);
-			});
-			return clearInterval(id);
+			window.removeEventListener('offline', setOffline);
+			window.removeEventListener('online', setOnline);
 		};
 	}, []);
 


### PR DESCRIPTION
## Why are you doing this?

The previous incarnation of the `useOnlineStatus` hook was proving slow and ineffective. This version simplifies it.

## Changes

- simplify `useOnlineStatus` hook 



