### PR TITLE
Replace GT with GH as Editions doesn't support GT

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -438,12 +438,11 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 
 .emotion-9 {
   box-sizing: border-box;
-  font-family: GT Guardian Titlepiece,Georgia,serif;
-  font-size: 2.625rem;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
   line-height: 1.15;
   font-weight: 700;
   color: #BB3B80;
-  font-size: 1.0625rem;
   padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
 }
@@ -4766,12 +4765,11 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 
 .emotion-9 {
   box-sizing: border-box;
-  font-family: GT Guardian Titlepiece,Georgia,serif;
-  font-size: 2.625rem;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
   line-height: 1.15;
   font-weight: 700;
   color: #E05E00;
-  font-size: 1.0625rem;
   padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
 }
@@ -9258,12 +9256,11 @@ exports[`Storyshots Editions/Article Letter 1`] = `
 
 .emotion-9 {
   box-sizing: border-box;
-  font-family: GT Guardian Titlepiece,Georgia,serif;
-  font-size: 2.625rem;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
   line-height: 1.15;
   font-weight: 700;
   color: #E05E00;
-  font-size: 1.0625rem;
   padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
 }
@@ -10619,12 +10616,11 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 
 .emotion-30 {
   box-sizing: border-box;
-  font-family: GT Guardian Titlepiece,Georgia,serif;
-  font-size: 2.625rem;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
   line-height: 1.15;
   font-weight: 700;
   color: #0084C6;
-  font-size: 1.0625rem;
   padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
 }
@@ -16455,12 +16451,11 @@ exports[`Storyshots Editions/PullQuote Default 1`] = `
 exports[`Storyshots Editions/Series Default 1`] = `
 .emotion-0 {
   box-sizing: border-box;
-  font-family: GT Guardian Titlepiece,Georgia,serif;
-  font-size: 2.625rem;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
   line-height: 1.15;
   font-weight: 700;
   color: #C70000;
-  font-size: 1.0625rem;
   padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
 }
@@ -16481,12 +16476,11 @@ exports[`Storyshots Editions/Series Default 1`] = `
 exports[`Storyshots Editions/Series Immersive 1`] = `
 .emotion-0 {
   box-sizing: border-box;
-  font-family: GT Guardian Titlepiece,Georgia,serif;
-  font-size: 2.625rem;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
   line-height: 1.15;
   font-weight: 700;
   color: #C70000;
-  font-size: 1.0625rem;
   padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
   position: absolute;
@@ -16514,12 +16508,11 @@ exports[`Storyshots Editions/Series Immersive 1`] = `
 exports[`Storyshots Editions/Series Interview 1`] = `
 .emotion-0 {
   box-sizing: border-box;
-  font-family: GT Guardian Titlepiece,Georgia,serif;
-  font-size: 2.625rem;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
   line-height: 1.15;
   font-weight: 700;
   color: #A1845C;
-  font-size: 1.0625rem;
   padding: 0.25rem 0 0.75rem;
   box-sizing: border-box;
   position: absolute;

--- a/src/components/editions/series/index.tsx
+++ b/src/components/editions/series/index.tsx
@@ -4,7 +4,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { titlepiece } from '@guardian/src-foundations/typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { Design, Display } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
@@ -17,9 +17,8 @@ import { kickerPicker } from '../kickerPicker';
 
 const styles = (kicker: string): SerializedStyles => css`
 	box-sizing: border-box;
-	${titlepiece.small()}
+	${headline.xxxsmall({ fontWeight: 'bold' })}
 	color: ${kicker};
-	font-size: 1.0625rem;
 	padding: ${remSpace[1]} 0 ${remSpace[3]};
 	box-sizing: border-box;
 


### PR DESCRIPTION
## Why are you doing this?

Apps rendering doesn't currently support the `GT Guardian Titlepiece` font which was being used in the series/kicker component. This meant the font was falling back to Georgia instead. As a temporary fix, this PR replaces the `GT` with  `GH Guardian Headline`.  

Changing to this font also brings us inline with Source's font sizes (we were overriding these before to make GT smaller than Source wanted) but this is something for Design to decide if we want to stick with this longer term. 

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/125833596-7317e7b8-5047-4da2-a63e-639aff1c4f17.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/125833153-879918e6-05db-4897-b869-7c771fefba45.png" width="300px" /> |


