### PR TITLE
Minimum Supported iOS Version Is 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/server.ts",
   "browserslist": [
     "android >= 5",
-    "ios >= 11"
+    "ios >= 12"
   ],
   "scripts": {
     "postinstall": "is-ci || husky install",


### PR DESCRIPTION
## Why are you doing this?

The [`browserslist` field](https://github.com/browserslist/browserslist) in `package.json` is used by a number of build tools to determine which browsers to target with their build output. You specify a list of browsers here, and that list is used to determine which features, polyfills, workarounds etc. to include.

We support four apps in Apps-Rendering:

- iOS Live App
- Android Live App
- iOS Editions App
- Android Editions App

Our `browserslist` is determined by the oldest versions of iOS and Android supported by these apps. This PR updates our configuration to match the oldest versions currently supported.

## Changes

- Bump minimum iOS version from 11 to 12.
