### PR TITLE
LIVE-2836: update asset paths for fonts and js

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -195,6 +195,7 @@ async function serveEditionsArticle(
 	const { html, clientScript } = renderEditions(
 		imageSalt,
 		request,
+		res,
 		getAssetLocation,
 		themeOverride,
 	);
@@ -277,6 +278,7 @@ async function serveEditionsArticlePost(
 			content,
 		};
 		const themeOverride = themeFromUnknown(req.query.theme);
+
 		void serveEditionsArticle(renderingRequest, res, themeOverride);
 	} catch (e) {
 		logger.error('This error occurred', e);


### PR DESCRIPTION
## Why are you doing this?

Fonts and JS were loading incorrectly on `https://mobile.guardianapis.com/`.

## Changes

- add `EditionsEnv` enum


