### PR TITLE
LIVE 2857 & 2864:  Editorial template

### DIFF
--- a/src/components/body.tsx
+++ b/src/components/body.tsx
@@ -60,7 +60,11 @@ const Body: FC<Props> = ({ item, shouldHideAds }) => {
 		return <Interactive>{renderAllWithoutStyles(item, body)}</Interactive>;
 	}
 
-	if (item.design === Design.Comment || item.design === Design.Letter) {
+	if (
+		item.design === Design.Comment ||
+		item.design === Design.Letter ||
+		item.design === Design.Editorial
+	) {
 		return <Comment item={item}>{render(item, body)}</Comment>;
 	}
 

--- a/src/components/byline.tsx
+++ b/src/components/byline.tsx
@@ -87,10 +87,10 @@ const getStyles = (format: Format): SerializedStyles => {
 	}
 
 	switch (format.design) {
+		case Design.Editorial:
 		case Design.Letter:
 		case Design.Comment:
 			return commentStyles(kicker);
-
 		default:
 			return styles(kicker);
 	}
@@ -102,6 +102,8 @@ const getAnchorStyles = (format: Format): SerializedStyles => {
 		return labsAnchorStyles;
 	}
 	switch (format.design) {
+		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 			return commentAnchorStyles(kicker, inverted);
 

--- a/src/components/comment/article.tsx
+++ b/src/components/comment/article.tsx
@@ -21,7 +21,7 @@ import RelatedContent from 'components/shared/relatedContent';
 import Standfirst from 'components/standfirst';
 import Tags from 'components/tags';
 import HeaderMedia from 'headerMedia';
-import type { Comment as CommentItem, Letter } from 'item';
+import type { Comment as CommentItem, Editorial, Letter } from 'item';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,
@@ -68,7 +68,7 @@ const commentLineStylePosition = css`
 `;
 
 interface Props {
-	item: CommentItem | Letter;
+	item: CommentItem | Letter | Editorial;
 	children: ReactNode[];
 }
 

--- a/src/components/headerVideo.tsx
+++ b/src/components/headerVideo.tsx
@@ -23,6 +23,8 @@ const backgroundColour = (format: Format): string => {
 	switch (format.design) {
 		case Design.Media:
 			return neutral[20];
+		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 			return neutral[86];
 		default:

--- a/src/components/headline.tsx
+++ b/src/components/headline.tsx
@@ -127,6 +127,7 @@ const getStyles = (format: Format): SerializedStyles => {
 			);
 		case Design.Feature:
 			return css(styles(format), featureStyles, fontSizeRestriction);
+		case Design.Editorial:
 		case Design.Letter:
 		case Design.Comment:
 			return css(styles(format), commentStyles, fontSizeRestriction);

--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -24,6 +24,8 @@ const styles = (role: Role, format: Format): SerializedStyles => {
 		switch (format.design) {
 			case Design.Media:
 				return neutral[20];
+			case Design.Editorial:
+			case Design.Letter:
 			case Design.Comment:
 				return neutral[86];
 			default:

--- a/src/components/metadata.tsx
+++ b/src/components/metadata.tsx
@@ -62,7 +62,8 @@ const Metadata: FC<Props> = (props: Props) => {
 	if (
 		display === Display.Immersive ||
 		design === Design.Comment ||
-		design === Design.Letter
+		design === Design.Letter || 
+		design === Design.Editorial
 	) {
 		return <ShortMetadata {...props} />;
 	}

--- a/src/components/metadata.tsx
+++ b/src/components/metadata.tsx
@@ -62,7 +62,7 @@ const Metadata: FC<Props> = (props: Props) => {
 	if (
 		display === Display.Immersive ||
 		design === Design.Comment ||
-		design === Design.Letter || 
+		design === Design.Letter ||
 		design === Design.Editorial
 	) {
 		return <ShortMetadata {...props} />;

--- a/src/components/richLink.tsx
+++ b/src/components/richLink.tsx
@@ -9,7 +9,7 @@ import { Design, Pillar } from '@guardian/types';
 import type { Format } from '@guardian/types';
 import { createElement as h } from 'react';
 import type { ReactElement } from 'react';
-import { darkModeCss, darkModeStyles } from 'styles';
+import { backgroundColor, darkModeCss, darkModeStyles } from 'styles';
 import { getThemeStyles } from 'themeStyles';
 
 export const richLinkWidth = '8.75rem';
@@ -43,9 +43,6 @@ const richLinkPillarStyles = (kicker: string, inverted: string): string => {
 };
 
 const richLinkStyles = (format: Format): SerializedStyles => {
-	const backgroundColor =
-		format.design === Design.Comment ? neutral[86] : neutral[97];
-
 	const { kicker: newsKicker, inverted: newsInverted } = getThemeStyles(
 		Pillar.News,
 	);
@@ -64,7 +61,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 	} = getThemeStyles(Pillar.Lifestyle);
 
 	return css`
-		background: ${backgroundColor};
+		background: ${backgroundColor(format)};
 		padding: ${remSpace[3]} ${remSpace[3]} ${remSpace[2]};
 		border-top: solid 1px ${neutral[60]};
 		transition: all 0.2s ease;

--- a/src/components/richLink.tsx
+++ b/src/components/richLink.tsx
@@ -5,7 +5,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
-import { Design, Pillar } from '@guardian/types';
+import { Pillar } from '@guardian/types';
 import type { Format } from '@guardian/types';
 import { createElement as h } from 'react';
 import type { ReactElement } from 'react';

--- a/src/components/standfirst.tsx
+++ b/src/components/standfirst.tsx
@@ -92,6 +92,7 @@ const getStyles = (item: Item): SerializedStyles => {
 	switch (item.design) {
 		case Design.Review:
 		case Design.Feature:
+		case Design.Editorial:
 		case Design.Letter:
 		case Design.Comment:
 			return css(styles, thinHeadline);

--- a/src/components/tags.tsx
+++ b/src/components/tags.tsx
@@ -14,6 +14,8 @@ import { darkModeCss } from 'styles';
 
 const backgroundColour = (format: Format): string => {
 	switch (format.design) {
+		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 			return neutral[86];
 		case Design.LiveBlog:

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -65,7 +65,11 @@ const textHeadlinePrimaryInverse = (_: Format): Colour => neutral[86];
 const backgroundHeadlinePrimary = (format: Format): Colour => {
 	if (format.display === Display.Immersive) {
 		return neutral[7];
-	} else if (format.design === Design.Comment) {
+	} else if (
+		format.design === Design.Comment ||
+		format.design === Design.Letter ||
+		format.design === Design.Editorial
+	) {
 		return opinion[800];
 	} else if (format.design === Design.Media) {
 		return coreBackground.inverse;

--- a/src/item.ts
+++ b/src/item.ts
@@ -96,6 +96,11 @@ interface Letter extends Fields {
 	body: Body;
 }
 
+interface Editorial extends Fields {
+	design: Design.Editorial;
+	body: Body;
+}
+
 interface Interactive extends Fields {
 	design: Design.Interactive;
 	body: Body;
@@ -111,7 +116,11 @@ interface Obituary extends Fields {
 interface Standard extends Fields {
 	design: Exclude<
 		Design,
-		Design.LiveBlog | Design.Review | Design.Comment | Design.Letter
+		| Design.LiveBlog
+		| Design.Review
+		| Design.Comment
+		| Design.Letter
+		| Design.Editorial
 	>;
 	body: Body;
 }
@@ -124,7 +133,8 @@ type Item =
 	| Interactive
 	| MatchReport
 	| Letter
-	| Obituary;
+	| Obituary
+	| Editorial;
 
 // ----- Convenience Types ----- //
 
@@ -405,6 +415,7 @@ export {
 	MatchReport,
 	ResizedRelatedContent,
 	Letter,
+	Editorial,
 	fromCapi,
 	fromCapiLiveBlog,
 	getFormat,

--- a/src/item.ts
+++ b/src/item.ts
@@ -340,6 +340,11 @@ const fromCapi = (context: Context) => (request: RenderingRequest): Item => {
 			design: Design.Obituary,
 			...itemFieldsWithBody(context, request),
 		};
+	} else if (isGuardianView(tags)) {
+		return {
+			design: Design.Editorial,
+			...itemFieldsWithBody(context, request),
+		};
 	} else if (isComment(tags)) {
 		const item = itemFieldsWithBody(context, request);
 		return {
@@ -362,11 +367,6 @@ const fromCapi = (context: Context) => (request: RenderingRequest): Item => {
 	} else if (isRecipe(tags)) {
 		return {
 			design: Design.Recipe,
-			...itemFieldsWithBody(context, request),
-		};
-	} else if (isGuardianView(tags)) {
-		return {
-			design: Design.Editorial,
 			...itemFieldsWithBody(context, request),
 		};
 	} else if (isQuiz(tags)) {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -71,7 +71,7 @@ import RichLink from 'components/richLink';
 import { isElement, pipe } from 'lib';
 import { createElement as h } from 'react';
 import type { ReactElement, ReactNode } from 'react';
-import { darkModeCss } from 'styles';
+import { backgroundColor, darkModeCss } from 'styles';
 import {
 	getThemeStyles,
 	themeFromString,
@@ -536,9 +536,6 @@ const mediaAtomRenderer = (
 	isEditions: boolean,
 ): ReactNode => {
 	const { posterUrl, videoId, duration, caption } = element;
-
-	const backgroundColor = (format: Format): string =>
-		format.design === Design.Comment ? neutral[86] : neutral[97];
 
 	const styles = css`
 		width: 100%;

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -42,6 +42,8 @@ const scriptName = ({ design, display }: Format): Option<string> => {
 			return some('liveblog.js');
 		case Design.Interactive:
 			return display !== Display.Immersive ? some('article.js') : none;
+		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 		case Design.Feature:
 		case Design.Analysis:

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -104,7 +104,6 @@ export const onwardStyles: SerializedStyles = css`
 
 const adHeight = '258px';
 
-
 export const backgroundColor = (format: Format): string =>
 	format.design === Design.Comment ||
 	format.design === Design.Letter ||
@@ -113,7 +112,6 @@ export const backgroundColor = (format: Format): string =>
 		: neutral[97];
 
 export const adStyles = (format: Format): SerializedStyles => {
-
 	return css`
 		.ad-placeholder {
 			margin: ${remSpace[4]} 0;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -104,9 +104,15 @@ export const onwardStyles: SerializedStyles = css`
 
 const adHeight = '258px';
 
+
+export const backgroundColor = (format: Format): string =>
+	format.design === Design.Comment ||
+	format.design === Design.Letter ||
+	format.design === Design.Editorial
+		? neutral[86]
+		: neutral[97];
+
 export const adStyles = (format: Format): SerializedStyles => {
-	const backgroundColour =
-		format.design === Design.Comment ? neutral[86] : neutral[97];
 
 	return css`
 		.ad-placeholder {
@@ -117,7 +123,7 @@ export const adStyles = (format: Format): SerializedStyles => {
 			}
 
 			color: ${neutral[20]};
-			background: ${backgroundColour};
+			background: ${backgroundColor(format)};
 
 			${darkModeCss`
             background-color: ${neutral[20]};


### PR DESCRIPTION
## Why are you doing this?
Editorial articles were rendering incorrectly because they were being parsed as a Comment. Whilst this is ok for AR, as they share designs, ER visually distinguishes between Editorial and Comment.  

In investigating this, a bug was discovered whereby Letter and Editorial were not always styled the same as Comment (which they should be). This PR fixes this too. 

## Changes

- Move Editorial above Comment in parser to style Editorial differently in ER.
- Add Editorial and Letter where Comment styling is being applied in AR only. 

## Screenshots

## ER

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/127509437-07efde06-3930-41d8-b3f8-59854210b2f5.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/127509570-7f72b283-2f65-4fa3-a316-78e6ded9b6d6.png" width="300px" /> |

## AR
### Editorial

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/127487561-32bdb4fc-7abb-4676-8210-69dccbfb9790.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/127509151-60ca8041-2cb9-40fe-9080-a00406c5b279.png" width="300px" /> |

### Letter

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/127487425-1b18f60a-ad9f-4433-b0ca-7b366a378d18.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/127487438-6fccb952-678a-4fff-b842-3dc7f85e53b7.png" width="300px" /> |

