### PR TITLE
LIVE-2859 : Add Corrections and Clarifications Header

### DIFF
--- a/src/components/editions/header/index.tsx
+++ b/src/components/editions/header/index.tsx
@@ -12,7 +12,7 @@ import Lines from 'components/editions/lines';
 import Series from 'components/editions/series';
 import Standfirst from 'components/editions/standfirst';
 import type { Item } from 'item';
-import { isPicture } from 'item';
+import { isCorrection, isPicture } from 'item';
 import type { FC, ReactElement } from 'react';
 import {
 	articleMarginStyles,
@@ -252,6 +252,15 @@ const LetterHeader: FC<HeaderProps> = ({ item }) => (
 	</header>
 );
 
+const CorrectionsHeader: FC<HeaderProps> = ({ item }) => (
+	<header css={headerStyles}>
+		<HeaderMedia item={item} />
+		<Series item={item} />
+		<Headline item={item} />
+		<Standfirst item={item} />
+	</header>
+);
+
 const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 	// Display.Immersive needs to come before Design.Interview
 	if (item.display === Display.Immersive) {
@@ -274,6 +283,8 @@ const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 		) : (
 			<GalleryHeader item={item} />
 		);
+	} else if (isCorrection(item.tags)) {
+		return <CorrectionsHeader item={item} />;
 	} else {
 		return <StandardHeader item={item} />;
 	}

--- a/src/item.ts
+++ b/src/item.ts
@@ -289,6 +289,8 @@ const isLabs = hasTag('tone/advertisement-features');
 const isMatchReport = hasTag('tone/matchreports');
 const isPicture = hasTag('type/picture');
 
+const isCorrection = hasTag('theguardian/series/correctionsandclarifications');
+
 const fromCapiLiveBlog = (context: Context) => (
 	request: RenderingRequest,
 ): Liveblog => {
@@ -417,4 +419,5 @@ export {
 	isPicture,
 	isLetter,
 	isObituary,
+	isCorrection,
 };


### PR DESCRIPTION
## Why are you doing this?
Corrections and Clarifications need a different header without a byline on Editions. This PR checks for the Corrections and Clarifications tag and renders a specific header if true. 

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/127520242-1e07002b-90c1-4486-8e7c-942cb79d41ae.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/127520229-b096763c-dfa0-48c3-ab5f-c3693ffca9b5.png" width="300px" /> |
