### PR TITLE
LIVE-2875: hide share when no web url

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -502,6 +502,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -525,6 +526,7 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
 
 @media (min-width: 740px) {
   .emotion-12 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -1737,6 +1739,7 @@ exports[`Storyshots Editions/Article Cartoon 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -1760,6 +1763,7 @@ exports[`Storyshots Editions/Article Cartoon 1`] = `
 
 @media (min-width: 740px) {
   .emotion-13 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -2393,6 +2397,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
   padding-right: 6.5625rem;
@@ -2417,6 +2422,7 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 
 @media (min-width: 740px) {
   .emotion-12 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -3751,6 +3757,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -3774,6 +3781,7 @@ exports[`Storyshots Editions/Article Default 1`] = `
 
 @media (min-width: 740px) {
   .emotion-15 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -4922,6 +4930,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -4945,6 +4954,7 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
 
 @media (min-width: 740px) {
   .emotion-16 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -6081,6 +6091,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -6104,6 +6115,7 @@ exports[`Storyshots Editions/Article Feature 1`] = `
 
 @media (min-width: 740px) {
   .emotion-15 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -7275,6 +7287,7 @@ width:@media (min-width: 320px) {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -7298,6 +7311,7 @@ width:@media (min-width: 320px) {
 
 @media (min-width: 740px) {
   .emotion-17 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -8202,6 +8216,7 @@ width:@media (min-width: 320px) {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
   padding-left: 0.75rem;
@@ -8228,6 +8243,7 @@ width:@media (min-width: 320px) {
 
 @media (min-width: 740px) {
   .emotion-17 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -10773,6 +10789,7 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -10796,6 +10813,7 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 
 @media (min-width: 740px) {
   .emotion-37 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -11804,6 +11822,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -11827,6 +11846,7 @@ exports[`Storyshots Editions/Article Review 1`] = `
 
 @media (min-width: 740px) {
   .emotion-21 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -13044,6 +13064,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
   padding-bottom: 1.5rem;
@@ -13068,6 +13089,7 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
 
 @media (min-width: 740px) {
   .emotion-15 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -13923,6 +13945,7 @@ exports[`Storyshots Editions/Byline Analysis 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -13946,6 +13969,7 @@ exports[`Storyshots Editions/Byline Analysis 1`] = `
 
 @media (min-width: 740px) {
   .emotion-0 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -14036,6 +14060,7 @@ exports[`Storyshots Editions/Byline Comment 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
   padding-right: 6.5625rem;
@@ -14060,6 +14085,7 @@ exports[`Storyshots Editions/Byline Comment 1`] = `
 
 @media (min-width: 740px) {
   .emotion-0 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -14195,6 +14221,7 @@ exports[`Storyshots Editions/Byline Default 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -14218,6 +14245,7 @@ exports[`Storyshots Editions/Byline Default 1`] = `
 
 @media (min-width: 740px) {
   .emotion-0 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -14297,6 +14325,7 @@ exports[`Storyshots Editions/Byline Feature 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -14320,6 +14349,7 @@ exports[`Storyshots Editions/Byline Feature 1`] = `
 
 @media (min-width: 740px) {
   .emotion-0 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -14399,6 +14429,7 @@ exports[`Storyshots Editions/Byline Interview 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
   padding-left: 0.75rem;
@@ -14425,6 +14456,7 @@ exports[`Storyshots Editions/Byline Interview 1`] = `
 
 @media (min-width: 740px) {
   .emotion-0 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -14532,6 +14564,7 @@ exports[`Storyshots Editions/Byline Review 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
 }
@@ -14555,6 +14588,7 @@ exports[`Storyshots Editions/Byline Review 1`] = `
 
 @media (min-width: 740px) {
   .emotion-0 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -14634,6 +14668,7 @@ exports[`Storyshots Editions/Byline Showcase 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+  min-height: 3rem;
   padding-bottom: 1rem;
   margin: 0;
   padding-bottom: 1.5rem;
@@ -14658,6 +14693,7 @@ exports[`Storyshots Editions/Byline Showcase 1`] = `
 
 @media (min-width: 740px) {
   .emotion-0 {
+    min-height: 2.25rem;
     padding-bottom: 2.25rem;
   }
 }
@@ -16641,6 +16677,13 @@ exports[`Storyshots Editions/Standfirst Analysis 1`] = `
   flex-direction: column;
 }
 
+.emotion-2 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
   className="emotion-0"
 >
@@ -16651,6 +16694,30 @@ exports[`Storyshots Editions/Standfirst Analysis 1`] = `
       The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
     </p>
   </div>
+  <span
+    className="js-share-button"
+    role="button"
+  >
+    <button
+      className="emotion-2"
+      onClick={[Function]}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="15"
+          cy="15"
+          r="14.5"
+        />
+        <path
+          d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+        />
+      </svg>
+    </button>
+  </span>
 </div>
 `;
 
@@ -16733,6 +16800,13 @@ exports[`Storyshots Editions/Standfirst Comment 1`] = `
   flex-direction: column;
 }
 
+.emotion-2 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
   className="emotion-0"
 >
@@ -16743,6 +16817,30 @@ exports[`Storyshots Editions/Standfirst Comment 1`] = `
       The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
     </p>
   </div>
+  <span
+    className="js-share-button"
+    role="button"
+  >
+    <button
+      className="emotion-2"
+      onClick={[Function]}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="15"
+          cy="15"
+          r="14.5"
+        />
+        <path
+          d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+        />
+      </svg>
+    </button>
+  </span>
 </div>
 `;
 
@@ -16813,6 +16911,13 @@ exports[`Storyshots Editions/Standfirst Default 1`] = `
   flex-direction: column;
 }
 
+.emotion-2 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
   className="emotion-0"
 >
@@ -16823,6 +16928,30 @@ exports[`Storyshots Editions/Standfirst Default 1`] = `
       The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
     </p>
   </div>
+  <span
+    className="js-share-button"
+    role="button"
+  >
+    <button
+      className="emotion-2"
+      onClick={[Function]}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="15"
+          cy="15"
+          r="14.5"
+        />
+        <path
+          d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+        />
+      </svg>
+    </button>
+  </span>
 </div>
 `;
 
@@ -16907,6 +17036,13 @@ exports[`Storyshots Editions/Standfirst Media 1`] = `
   flex-direction: column;
 }
 
+.emotion-2 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
   style={
     Object {
@@ -16924,6 +17060,30 @@ exports[`Storyshots Editions/Standfirst Media 1`] = `
         The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
       </p>
     </div>
+    <span
+      className="js-share-button"
+      role="button"
+    >
+      <button
+        className="emotion-2"
+        onClick={[Function]}
+      >
+        <svg
+          fill="none"
+          viewBox="0 0 30 30"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="15"
+            cy="15"
+            r="14.5"
+          />
+          <path
+            d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+          />
+        </svg>
+      </button>
+    </span>
   </div>
 </div>
 `;
@@ -17007,6 +17167,13 @@ exports[`Storyshots Editions/Standfirst Showcase 1`] = `
   flex-direction: column;
 }
 
+.emotion-2 {
+  background: none;
+  border: none;
+  padding: 0;
+  height: 2.5rem;
+}
+
 <div
   className="emotion-0"
 >
@@ -17017,6 +17184,30 @@ exports[`Storyshots Editions/Standfirst Showcase 1`] = `
       The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
     </p>
   </div>
+  <span
+    className="js-share-button"
+    role="button"
+  >
+    <button
+      className="emotion-2"
+      onClick={[Function]}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="15"
+          cy="15"
+          r="14.5"
+        />
+        <path
+          d="M14.2727 8.83636V15.1818H15.7273V8.83636L18.3273 10.8182L18.9818 10.1818L15.2545 6.45455H14.7455L11.0364 10.1818L11.6727 10.8182L14.2727 8.83636ZM21.5455 13.7273V19.5455H8.45455V13.7273L7.72727 13H7V20.2545L7.70909 21H22.2545L23 20.2545V13H22.2727L21.5455 13.7273Z"
+        />
+      </svg>
+    </button>
+  </span>
 </div>
 `;
 

--- a/src/components/editions/article/article.stories.tsx
+++ b/src/components/editions/article/article.stories.tsx
@@ -30,6 +30,12 @@ const isImmersive = (): { display: Display } => {
 	};
 };
 
+const hasShareIcon = (): { webUrl: string } => {
+	return {
+		webUrl: boolean('ShareIcon', true) ? 'www.guardian.com' : '',
+	};
+};
+
 const getTag = (id: string, webTitle: string): Tag => ({
 	id,
 	type: 6,
@@ -47,6 +53,7 @@ const Default = (): ReactElement => (
 		item={{
 			...article,
 			...isImmersive(),
+			...hasShareIcon(),
 			theme: selectPillar(Pillar.News),
 		}}
 	/>
@@ -57,6 +64,8 @@ const Analysis = (): ReactElement => (
 		item={{
 			...analysis,
 			...isImmersive(),
+			...hasShareIcon(),
+
 			tags: [getTag('tone/analysis', 'View from the Guardian ')],
 			theme: selectPillar(Pillar.Lifestyle),
 		}}
@@ -69,6 +78,8 @@ const Editorial = (): ReactElement => (
 			...editorial,
 			tags: [getTag('tone/editorials', 'View from the Guardian ')],
 			...isImmersive(),
+			...hasShareIcon(),
+
 			theme: selectPillar(Pillar.Opinion),
 		}}
 	/>
@@ -79,6 +90,8 @@ const Feature = (): ReactElement => (
 		item={{
 			...feature,
 			...isImmersive(),
+			...hasShareIcon(),
+
 			theme: selectPillar(Pillar.Sport),
 		}}
 	/>
@@ -88,6 +101,8 @@ const Review = (): ReactElement => (
 	<Article
 		item={{
 			...review,
+			...hasShareIcon(),
+
 			theme: selectPillar(Pillar.Culture),
 		}}
 	/>
@@ -97,6 +112,8 @@ const Showcase = (): ReactElement => (
 	<Article
 		item={{
 			...article,
+			...hasShareIcon(),
+
 			display: Display.Showcase,
 			theme: selectPillar(Pillar.News),
 		}}
@@ -107,6 +124,8 @@ const Interview = (): ReactElement => (
 	<Article
 		item={{
 			...interview,
+			...hasShareIcon(),
+
 			...isImmersive(),
 			theme: selectPillar(Pillar.Sport),
 		}}
@@ -117,6 +136,8 @@ const Comment = (): ReactElement => (
 	<Article
 		item={{
 			...comment,
+			...hasShareIcon(),
+
 			...isImmersive(),
 			theme: selectPillar(Pillar.News),
 		}}
@@ -127,6 +148,7 @@ const Letter = (): ReactElement => (
 	<Article
 		item={{
 			...letter,
+			...hasShareIcon(),
 			tags: [getTag('tone/letters', 'Letters ')],
 			theme: selectPillar(Pillar.Opinion),
 		}}
@@ -136,6 +158,7 @@ const MatchReport = (): ReactElement => (
 	<Article
 		item={{
 			...matchReport,
+			...hasShareIcon(),
 			tags: [getTag('tone/sport', 'Sport ')],
 			theme: selectPillar(Pillar.Sport),
 		}}
@@ -146,6 +169,7 @@ const Cartoon = (): ReactElement => (
 	<Article
 		item={{
 			...cartoon,
+			...hasShareIcon(),
 			tags: [getTag('type/picture', 'cartoon')],
 		}}
 	/>
@@ -155,6 +179,7 @@ const Gallery = (): ReactElement => (
 	<Article
 		item={{
 			...media,
+			...hasShareIcon(),
 			theme: selectPillar(Pillar.News),
 		}}
 	/>

--- a/src/components/editions/byline/byline.stories.tsx
+++ b/src/components/editions/byline/byline.stories.tsx
@@ -72,12 +72,19 @@ const isImmersive = (): { display: Display } => {
 	};
 };
 
+const hasShareIcon = (): { webUrl: string } => {
+	return {
+		webUrl: boolean('ShareIcon', true) ? 'www.guardian.com' : '',
+	};
+};
+
 // ----- Stories ----- //
 
 const Default = (): ReactElement => (
 	<Byline
 		item={{
 			...article,
+			...hasShareIcon(),
 			display: Display.Standard,
 			bylineHtml: mockBylineHtml(),
 			theme: selectPillar(Pillar.News),
@@ -90,6 +97,7 @@ const Analysis = (): ReactElement => (
 		item={{
 			...analysis,
 			...isImmersive(),
+			...hasShareIcon(),
 			bylineHtml: mockBylineHtml(),
 			theme: selectPillar(Pillar.News),
 		}}
@@ -101,6 +109,7 @@ const Feature = (): ReactElement => (
 		item={{
 			...feature,
 			...isImmersive(),
+			...hasShareIcon(),
 			bylineHtml: mockBylineHtml(),
 			theme: selectPillar(Pillar.News),
 		}}
@@ -111,6 +120,7 @@ const Review = (): ReactElement => (
 	<Byline
 		item={{
 			...review,
+			...hasShareIcon(),
 			bylineHtml: mockBylineHtml(),
 			theme: selectPillar(Pillar.News),
 		}}
@@ -122,6 +132,7 @@ const Showcase = (): ReactElement => (
 		item={{
 			...article,
 			display: Display.Showcase,
+			...hasShareIcon(),
 			bylineHtml: mockBylineHtml(),
 			theme: selectPillar(Pillar.News),
 		}}
@@ -133,6 +144,7 @@ const Interview = (): ReactElement => (
 		item={{
 			...interview,
 			...isImmersive(),
+			...hasShareIcon(),
 			bylineHtml: mockBylineHtml(),
 			theme: selectPillar(Pillar.News),
 		}}

--- a/src/components/editions/byline/index.tsx
+++ b/src/components/editions/byline/index.tsx
@@ -106,11 +106,13 @@ const styles = (iconColor: string): SerializedStyles => {
 				fill: ${iconColor};
 			}
 		}
+		min-height: ${remSpace[12]};
 
 		padding-bottom: ${remSpace[4]};
 		margin: 0;
 
 		${from.tablet} {
+			min-height: ${remSpace[9]};
 			padding-bottom: ${remSpace[9]};
 		}
 	`;
@@ -242,7 +244,7 @@ const Byline: FC<Props> = ({ item }) => {
 			<address>{renderText(byline, format)}</address>
 			{hasShareIcon(format) && (
 				<span className="js-share-button" role="button">
-					<ShareIcon />
+					<ShareIcon item={item} />
 				</span>
 			)}
 			{hasAvatar(item) && (

--- a/src/components/editions/shareIcon/index.tsx
+++ b/src/components/editions/shareIcon/index.tsx
@@ -5,8 +5,10 @@ import {
 	pingEditionsNative,
 	Platform,
 } from '@guardian/renditions';
+import { Item } from 'item';
 import type { FC, ReactElement } from 'react';
 import { useEffect, useState } from 'react';
+import { useArticlePath } from './useArticlePath';
 
 const usePlatform = (defaultPlatform: Platform): Platform => {
 	const [platform, setPlatform] = useState(defaultPlatform);
@@ -52,12 +54,19 @@ const buttonStyles = css`
 	height: 2.5rem;
 `;
 
-const ShareIcon: FC = () => {
+interface Props {
+	item: Item;
+}
+
+const ShareIcon: FC<Props> = ({ item }) => {
 	const platform = usePlatform(Platform.IOS);
 	useEffect(() => {
 		pingEditionsNative({ kind: MessageKind.PlatformQuery });
 	}, []);
-	return (
+
+	const articlePath = item ? useArticlePath(item.webUrl) : null;
+
+	return articlePath ? (
 		<button
 			css={buttonStyles}
 			onClick={(): void =>
@@ -70,7 +79,7 @@ const ShareIcon: FC = () => {
 				<AndroidShareIcon />
 			)}
 		</button>
-	);
+	) : null;
 };
 
 export default ShareIcon;

--- a/src/components/editions/shareIcon/useArticlePath.tsx
+++ b/src/components/editions/shareIcon/useArticlePath.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+const isSuccessOrRedirect = (status: number) => [302, 200].includes(status);
+
+export const useArticlePath = (webUrl: string) => {
+	const [articlePath, setArticlePath] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (webUrl) {
+			const checkPathExists = async (articlePath: string) => {
+				const dotComResult = await fetch(`${articlePath}`, {
+					method: 'HEAD',
+				}).catch(() => null);
+				console.log(dotComResult);
+				return dotComResult && isSuccessOrRedirect(dotComResult.status)
+					? setArticlePath(articlePath)
+					: setArticlePath(null);
+			};
+			checkPathExists(webUrl);
+		}
+	}, [webUrl]);
+
+	return { articlePath };
+};

--- a/src/components/editions/standfirst/index.tsx
+++ b/src/components/editions/standfirst/index.tsx
@@ -136,7 +136,7 @@ const Standfirst: FC<Props> = ({ item, shareIcon }) => {
 			</div>
 			{shareIcon && (
 				<span className="js-share-button" role="button">
-					<ShareIcon />
+					<ShareIcon item={item} />
 				</span>
 			)}
 		</div>

--- a/src/components/editions/standfirst/standfirst.stories.tsx
+++ b/src/components/editions/standfirst/standfirst.stories.tsx
@@ -2,7 +2,7 @@
 import { neutral } from '@guardian/src-foundations/palette';
 import { Display, Pillar, toOption } from '@guardian/types';
 import type { Option } from '@guardian/types';
-import { withKnobs } from '@storybook/addon-knobs';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
 import { analysis, article, comment, media } from 'fixtures/item';
 import { pipe } from 'lib';
@@ -21,13 +21,21 @@ const standfirst: Option<DocumentFragment> = pipe(
 	toOption,
 );
 
+const hasShareIcon = (): { webUrl: string } => {
+	return {
+		webUrl: boolean('ShareIcon', true) ? 'www.guardian.com' : '',
+	};
+};
+
 // ----- Stories ----- //
 
 const Default = (): ReactElement => (
 	<Standfirst
+		shareIcon
 		item={{
 			...article,
 			standfirst,
+			...hasShareIcon(),
 			theme: selectPillar(Pillar.News),
 		}}
 	/>
@@ -35,9 +43,11 @@ const Default = (): ReactElement => (
 
 const Showcase = (): ReactElement => (
 	<Standfirst
+		shareIcon
 		item={{
 			...article,
 			standfirst,
+			...hasShareIcon(),
 			display: Display.Showcase,
 			theme: selectPillar(Pillar.News),
 		}}
@@ -46,9 +56,11 @@ const Showcase = (): ReactElement => (
 
 const Comment = (): ReactElement => (
 	<Standfirst
+		shareIcon
 		item={{
 			...comment,
 			standfirst,
+			...hasShareIcon(),
 			theme: selectPillar(Pillar.News),
 		}}
 	/>
@@ -56,9 +68,11 @@ const Comment = (): ReactElement => (
 
 const Analysis = (): ReactElement => (
 	<Standfirst
+		shareIcon
 		item={{
 			...analysis,
 			standfirst,
+			...hasShareIcon(),
 			theme: selectPillar(Pillar.News),
 		}}
 	/>
@@ -71,9 +85,11 @@ const Media = (): ReactElement => (
 		}}
 	>
 		<Standfirst
+			shareIcon
 			item={{
 				...media,
 				standfirst,
+				...hasShareIcon(),
 				theme: selectPillar(Pillar.News),
 			}}
 		/>

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -272,6 +272,7 @@ const fields = {
 	relatedContent: none,
 	footballContent: none,
 	logo: none,
+	webUrl: '',
 };
 
 const article: Item = {

--- a/src/item.ts
+++ b/src/item.ts
@@ -62,6 +62,7 @@ interface Fields extends Format {
 	commentCount: Option<number>;
 	relatedContent: Option<ResizedRelatedContent>;
 	logo: Option<Logo>;
+	webUrl: string;
 }
 
 interface MatchReport extends Fields {
@@ -180,7 +181,7 @@ const itemFields = (
 	request: RenderingRequest,
 ): ItemFields => {
 	const { content, branding, commentCount, relatedContent } = request;
-
+	console.log(content.webTitle);
 	return {
 		theme: themeFromString(content.pillarId),
 		display: getDisplay(content),
@@ -218,6 +219,7 @@ const itemFields = (
 			})),
 		),
 		logo: paidContentLogo(content.tags),
+		webUrl: content.webUrl,
 	};
 };
 


### PR DESCRIPTION
## Why are you doing this?

We have repeated user feedback from users trying to share articles and the button doing nothing. This PR copies the logic from Mallard so a share icon will not be rendered when there is not weburl present.

Needs testing.

## Changes

- add `shareIcon` checkbox to relevant stories
- add `showShareIcon` logic to `standfirst` and `byeline`
- add min-height to byeline to fix height when icon is not there

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/127832442-716dd20d-eb57-41fc-9c29-cdb8b8834af7.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/127832499-50d5ad22-7652-4ad1-bdd5-2e7bcf4a1e5d.png" width="300px" /> |

