### PR TITLE
LIVE-2860 :  Pinch and Zoom

### DIFF
--- a/src/components/meta.tsx
+++ b/src/components/meta.tsx
@@ -7,18 +7,26 @@ import type { FC } from 'react';
 interface Props {
 	title: string;
 	cspString: string;
+	isEditions?: boolean;
 }
 
-const Meta: FC<Props> = ({ title, cspString }) => (
+const Meta: FC<Props> = ({ title, cspString, isEditions = false }) => (
 	<>
 		<meta charSet="utf-8" />
 		<title>{title}</title>
 		<meta id="twitter-theme" name="twitter:widgets:theme" content="light" />
 		<meta name="twitter:dnt" content="on" />
-		<meta
-			name="viewport"
-			content="initial-scale=1, maximum-scale=1, user-scalable=no"
-		/>
+		{isEditions ? (
+			<meta
+				name="viewport"
+				content="initial-scale=1, maximum-scale=2, user-scalable=1"
+			/>
+		) : (
+			<meta
+				name="viewport"
+				content="initial-scale=1, maximum-scale=1, user-scalable=no"
+			/>
+		)}
 		<meta name="description" content={title} />
 		<meta httpEquiv="Content-Security-Policy" content={cspString} />
 	</>

--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -108,7 +108,11 @@ function renderHead(
 		inlineStyles,
 		isEditions,
 	);
-	const meta = h(Meta, { title: request.content.webTitle, cspString });
+	const meta = h(Meta, {
+		title: request.content.webTitle,
+		cspString,
+		isEditions: true,
+	});
 
 	return `
         ${renderToString(meta)}


### PR DESCRIPTION
## Why are you doing this?
Users on Editions want to be able to pinch and zoom on articles. This was previously disabled for all articles. This PR adds a metatag to allow zooming on editions articles only. 
