### PR TITLE
LIVE-2892: remove headline padding when no avatar

### DIFF
--- a/src/components/editions/headline/index.tsx
+++ b/src/components/editions/headline/index.tsx
@@ -12,10 +12,11 @@ import { border, neutral } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { SvgQuote } from '@guardian/src-icons';
 import type { Format } from '@guardian/types';
-import { Design, Display } from '@guardian/types';
+import { Design, Display, OptionKind } from '@guardian/types';
 import { editionsHeadlineTextColour } from 'editorialStyles';
 import type { Item } from 'item';
 import { getFormat } from 'item';
+import { pipe } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import Series from '../series';
@@ -37,9 +38,9 @@ const analysisStyles = (kickerColor: string): SerializedStyles => css`
 	padding-bottom: 0;
 `;
 
-const commentStyles = css`
+const commentStyles = (hasImage: boolean): SerializedStyles => css`
 	padding-bottom: 0;
-	padding-right: 6rem;
+	padding-right: ${hasImage ? '6rem' : 0};
 `;
 
 const galleryStyles = css`
@@ -179,6 +180,7 @@ const getDecorativeStyles = (item: Item): JSX.Element | string => {
 const getHeadlineStyles = (
 	format: Format,
 	kickerColor: string,
+	hasImage: boolean,
 ): SerializedStyles => {
 	const sharedStyles = getSharedStyles(format);
 
@@ -195,7 +197,7 @@ const getHeadlineStyles = (
 		return css(
 			sharedStyles,
 			getFontStyles('regular', 'light'),
-			commentStyles,
+			commentStyles(hasImage),
 		);
 	}
 
@@ -243,6 +245,13 @@ const Headline: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
 
+	const [contributor] = item.contributors;
+
+	const hasImage = pipe(
+		contributor.image,
+		(image) => image.kind === OptionKind.Some,
+	);
+
 	return (
 		<div css={headlineWrapperStyles}>
 			{hasSeriesKicker(format) && (
@@ -250,7 +259,7 @@ const Headline: FC<Props> = ({ item }) => {
 					<Series item={item} />
 				</div>
 			)}
-			<h1 css={getHeadlineStyles(format, kickerColor)}>
+			<h1 css={getHeadlineStyles(format, kickerColor, hasImage)}>
 				{getDecorativeStyles(item)}
 			</h1>
 		</div>


### PR DESCRIPTION
## Why are you doing this?

Styles were wrong on comment articles.

## Changes

- add check for avatar image to headline component


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/128216445-2c292c26-8f4a-4651-aeb1-c2e37b12bc15.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/128216505-78aab53e-2cfe-4f2c-af11-f97439ef9213.png" width="300px" /> |
