### PR TITLE
LIVE-2859 : Add Corrections and Clarifications Design 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6185,9 +6185,9 @@
       }
     },
     "@guardian/types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-7.0.0.tgz",
-      "integrity": "sha512-mS12S8DhXajFMqtgSuFktA/6dCvpJO3EuT00g7sA5FUglzfUFVHAPhvrX8qlUUZK4oaEHrPf/XkLQBGVrNLzoQ=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-axy50QarWbinGJ1jz0I2Npk4U/OTSGu39PRZuFYNlFNbZrIP2CoG+DI5Ruq7ydrLxhBqXGiS2EjAGMAA3BdlCQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@guardian/src-svgs": "^2.8.2",
     "@guardian/src-text-area": "^3.3.0",
     "@guardian/src-text-input": "^3.3.0",
-    "@guardian/types": "^7.0.0",
+    "@guardian/types": "^8.0.0",
     "@types/jsdom": "^16.2.12",
     "@types/uuid": "^8.3.0",
     "@types/webpack-node-externals": "^2.5.0",

--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -3441,6 +3441,1044 @@ exports[`Storyshots Editions/Article Comment 1`] = `
 </main>
 `;
 
+exports[`Storyshots Editions/Article Correction 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
+.emotion-1 {
+  min-height: 100%;
+  background-color: inherit;
+}
+
+.emotion-2 {
+  background-color: #FFFFFF;
+}
+
+.emotion-3 {
+  border-bottom: 1px solid #DCDCDC;
+}
+
+@media (min-width: 740px) {
+  .emotion-3 {
+    width: 526px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-3 {
+    width: 545px;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-3 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-3 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-3 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-4 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+@media (min-width: 740px) {
+  .emotion-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  position: relative;
+}
+
+@media (min-width: 980px) {
+  .emotion-5 {
+    width: 750px;
+  }
+}
+
+.emotion-6 {
+  width: 100vw;
+  height: calc(100vw * 0.6);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+  display: block;
+  width: 100%;
+}
+
+@media (min-width: 1300px) {
+  .emotion-6 {
+    width: 620px;
+    height: calc(620px * 0.6);
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-6 {
+    width: calc(100vw - 3.75rem);
+    height: calc((100vw - 3.75rem) * 0.6);
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-6 {
+    width: 750px;
+    height: 450px;
+  }
+}
+
+.emotion-7 {
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.emotion-7 summary {
+  display: block;
+  pointer-events: auto;
+  text-align: center;
+  background-color: #C70000;
+  width: 34px;
+  height: 34px;
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  border-radius: 100%;
+  outline: none;
+}
+
+.emotion-7 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-7 details[open] {
+  min-height: 44px;
+  max-height: 999px;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  padding: 0.75rem;
+  overflow: hidden;
+  padding-right: 3rem;
+  z-index: 1;
+  color: #FFFFFF;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  box-sizing: border-box;
+}
+
+@media (min-width: 740px) {
+  .emotion-7 {
+    width: calc(100vw - 3.75rem);
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-7 {
+    width: 750px;
+  }
+}
+
+.emotion-8 {
+  line-height: 32px;
+  font-size: 0;
+}
+
+.emotion-8 svg {
+  width: 75%;
+  height: 75%;
+  margin: 12.5%;
+}
+
+.emotion-8 path {
+  fill: #FFF4F2;
+}
+
+.emotion-9 {
+  box-sizing: border-box;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #C70000;
+  padding: 0.25rem 0 0.75rem;
+  box-sizing: border-box;
+}
+
+@media (min-width: 740px) {
+  .emotion-9 {
+    padding-bottom: 0.75rem;
+  }
+}
+
+.emotion-10 {
+  position: relative;
+}
+
+.emotion-11 {
+  color: #121212;
+  box-sizing: border-box;
+  border-top: 1px solid #DCDCDC;
+  padding-bottom: 1rem;
+  padding-right: 0.75rem;
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  font-weight: 500;
+}
+
+@media (min-width: 375px) {
+  .emotion-11 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-11 {
+    font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+    font-size: 2.125rem;
+    line-height: 1.15;
+    font-weight: 500;
+  }
+}
+
+.emotion-12 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 400;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  color: #121212;
+}
+
+@media (min-width: 740px) {
+  .emotion-12 {
+    width: 526px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-12 {
+    width: 545px;
+  }
+}
+
+.emotion-12 p,
+.emotion-12 ul {
+  padding-top: 0.25rem;
+  margin: 0;
+}
+
+.emotion-12 address {
+  font-style: normal;
+}
+
+.emotion-12 svg {
+  -webkit-flex: 0 0 1.875rem;
+  -ms-flex: 0 0 1.875rem;
+  flex: 0 0 1.875rem;
+  margin-top: 0.375rem;
+  padding-left: 0.5rem;
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.emotion-12 svg circle {
+  stroke: #C70000;
+}
+
+.emotion-12 svg path {
+  fill: #C70000;
+}
+
+.emotion-13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+@media (min-width: 740px) {
+  .emotion-14 {
+    width: 526px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-14 {
+    width: 545px;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-14 {
+    padding-right: 0.75rem;
+    border-right: 1px solid #DCDCDC;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-14 {
+    margin-left: 24px;
+  }
+}
+
+@media (min-width: 980px) {
+  .emotion-14 {
+    margin-left: 144px;
+  }
+}
+
+.emotion-15 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.emotion-15 iframe {
+  width: 100%;
+  border: none;
+}
+
+.emotion-15 figcaption {
+  background: #FFFFFF;
+  padding-bottom: 0.75rem;
+}
+
+@media (min-width: 740px) {
+  .emotion-15 {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .emotion-15 p {
+    margin: 0;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}
+
+@media (min-width: 740px) {
+  .emotion-15 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.emotion-16 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  margin: 0 0 0.75rem;
+}
+
+.emotion-17 {
+  margin: 1rem 0;
+  width: 100%;
+}
+
+@media (min-width: 660px) {
+  .emotion-17 {
+    width: 620px;
+  }
+}
+
+.emotion-18 {
+  width: 100%;
+  height: calc(100% * 1.25);
+  background-color: #F6F6F6;
+  color: #999999;
+  display: block;
+}
+
+@media (min-width: 660px) {
+  .emotion-18 {
+    width: 620px;
+    height: calc(620px * 1.25);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .emotion-18 {
+    background-color: #333333;
+  }
+}
+
+.emotion-21 {
+  display: block;
+  position: relative;
+}
+
+.emotion-22 {
+  margin: 16px 0 36px;
+  background: #EDEDED;
+  color: #121212;
+  padding: 0 5px 6px;
+  border-image: repeating-linear-gradient(
+              to bottom,
+              #DCDCDC,
+              #DCDCDC 1px,
+              transparent 1px,
+              transparent 4px
+          ) 13;
+  border-top: 13px solid black;
+  position: relative;
+}
+
+.emotion-22 summary {
+  list-style: none;
+  margin: 0 0 16px;
+}
+
+.emotion-22 summary::-webkit-details-marker {
+  display: none;
+}
+
+.emotion-22 summary:focus {
+  outline: none;
+}
+
+.emotion-23 {
+  display: block;
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: #C70000;
+}
+
+.emotion-24 {
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 500;
+  margin: 0;
+  line-height: 22px;
+}
+
+.emotion-25 {
+  background: #121212;
+  color: #FFFFFF;
+  height: 2rem;
+  position: absolute;
+  bottom: 0;
+  -webkit-transform: translate(0, 50%);
+  -moz-transform: translate(0, 50%);
+  -ms-transform: translate(0, 50%);
+  transform: translate(0, 50%);
+  padding: 0 15px 0 7px;
+  border-radius: 100em;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 0;
+  margin: 0;
+}
+
+.emotion-25:hover {
+  background: #C70000;
+}
+
+.emotion-26 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-27 {
+  margin-right: 12px;
+  margin-bottom: 6px;
+  width: 33px;
+  fill: white;
+  height: 28px;
+}
+
+.emotion-28 {
+  font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif;
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-28 p {
+  margin-bottom: 0.5rem;
+}
+
+.emotion-28 ol {
+  list-style: decimal;
+  list-style-position: inside;
+  margin-bottom: 1rem;
+}
+
+.emotion-28 ul {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.emotion-28 ul li {
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.emotion-28 ul li:before {
+  display: inline-block;
+  content: '';
+  border-radius: 0.375rem;
+  height: 0.75rem;
+  width: 0.75rem;
+  margin-right: 0.5rem;
+  background-color: #DCDCDC;
+  margin-left: -1.25rem;
+}
+
+.emotion-28 b {
+  font-weight: 700;
+}
+
+.emotion-28 i {
+  font-style: italic;
+}
+
+.emotion-28 a {
+  color: #AB0613;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.0625rem solid #DCDCDC;
+  -webkit-transition: border-color 0.15s ease-out;
+  transition: border-color 0.15s ease-out;
+}
+
+.emotion-28 a:hover {
+  border-bottom: solid 0.0625rem #C70000;
+}
+
+.emotion-29 {
+  font-size: 13px;
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+}
+
+.emotion-30 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.emotion-31 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+
+.emotion-31:hover {
+  background: #C70000;
+}
+
+.emotion-31:focus {
+  border: none;
+}
+
+.emotion-32 {
+  width: 16px;
+  height: 16px;
+}
+
+.emotion-33 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  background: black;
+  color: white;
+  border-style: hidden;
+  border-radius: 100%;
+  margin: 0 0 0 5px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+}
+
+.emotion-33:hover {
+  background: #C70000;
+}
+
+.emotion-33:focus {
+  border: none;
+}
+
+.emotion-35 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  font-weight: 400;
+  height: 28px;
+}
+
+.emotion-38 {
+  width: 10.875rem;
+  position: relative;
+  box-sizing: border-box;
+  padding: 0 0.5rem 1.5rem 0.5rem;
+  margin: 0.375rem 1rem calc(1rem + 1.5rem) 0;
+  color: #C70000;
+  border: 1px solid #C70000;
+  border-top: 0.75rem solid #C70000;
+  border-bottom: none;
+  float: left;
+  clear: left;
+}
+
+@media (min-width: 980px) {
+  .emotion-38 {
+    float: right;
+    clear: right;
+    margin-right: calc(-10.875rem - 2.5rem);
+  }
+}
+
+.emotion-38:before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #C70000;
+  border-top: none;
+  border-radius: 0 0 100% 0;
+}
+
+.emotion-38:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(1.5rem + 1px);
+  width: calc(100% - 1.5rem);
+  height: 1px;
+  border-top: 1px solid #C70000;
+}
+
+.emotion-39 {
+  margin: 0;
+}
+
+.emotion-40 {
+  margin: 0;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.emotion-40 svg {
+  margin-bottom: -0.6rem;
+  height: 2rem;
+  margin-left: -0.3rem;
+  fill: #C70000;
+}
+
+.emotion-41 {
+  font-style: normal;
+  font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
+  font-size: 1.25rem;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
+<main
+  className="emotion-0"
+>
+  <article
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+    >
+      <section
+        className="emotion-3"
+      >
+        <header
+          className="emotion-4"
+        >
+          <figure
+            aria-labelledby="header-image-caption"
+            className="emotion-5"
+          >
+            <picture>
+              <source
+                media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="(min-width: 1300px) 620px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w"
+              />
+              <source
+                sizes="(min-width: 1300px) 620px, 100vw"
+                srcSet="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w"
+              />
+              <img
+                alt="image"
+                className="js-launch-slideshow js-main-image emotion-6"
+                data-ratio={0.6}
+                src="https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f"
+              />
+            </picture>
+            <figcaption
+              className="emotion-7"
+            >
+              <details>
+                <summary>
+                  <span
+                    className="emotion-8"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M25.9999 9.99999V20.9749L24.5249 22.5249H5.49999L4 21.0499V9.99999L5.49999 8.49999H10.475L12.975 6H17L19.4999 8.49999H24.5249L25.9999 9.99999ZM15 19.75C17.5 19.75 19.5249 17.75 19.5249 15.275C19.5249 12.775 17.5 10.775 15 10.775C12.5 10.775 10.5 12.775 10.5 15.275C10.5 17.75 12.5 19.75 15 19.75Z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                    Click to see figure caption
+                  </span>
+                </summary>
+                <span
+                  id="header-image-caption"
+                >
+                  ‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.
+                   
+                  Photograph: Philip Keith/The Guardian
+                </span>
+              </details>
+            </figcaption>
+          </figure>
+          <nav
+            className="emotion-9"
+          >
+            Corrections and Clarifications 
+          </nav>
+          <div
+            className="emotion-10"
+          >
+            <h1
+              className="emotion-11"
+            >
+              Reclaimed lakes and giant airports: how Mexico City might have looked
+            </h1>
+          </div>
+          <div
+            className="emotion-12"
+          >
+            <div
+              className="emotion-13"
+            >
+              <p>
+                The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects
+              </p>
+            </div>
+          </div>
+        </header>
+      </section>
+    </div>
+    <div
+      className="emotion-14"
+    >
+      <section
+        className="emotion-15"
+      >
+        <p
+          className="emotion-16"
+        />
+        <figure
+          className="emotion-17"
+        >
+          <picture>
+            <source
+              media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w"
+            />
+            <source
+              sizes="(min-width: 660px) 620px, 100%"
+              srcSet="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w"
+            />
+            <img
+              alt="Jane Giddins outside her home in Newton St Loe"
+              className="js-launch-slideshow emotion-18"
+              data-caption="Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles."
+              data-credit="Photograph: Sam Frost/The Guardian"
+              data-ratio={1.25}
+              src="https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d"
+            />
+          </picture>
+        </figure>
+        <p
+          className="emotion-16"
+        />
+        <p
+          className="emotion-16"
+        />
+        <div
+          className="emotion-21"
+          data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+          data-atom-type="guide"
+        >
+          <details
+            className="emotion-22"
+            data-atom-id="575888ee-9973-4256-9a96-bad4b9c65d81"
+            data-snippet-type="guide"
+          >
+            <summary
+              onClick={[Function]}
+            >
+              <span
+                className="emotion-23"
+              >
+                Quick Guide
+              </span>
+              <h4
+                className="emotion-24"
+              >
+                What is Queen's consent?
+              </h4>
+              <span
+                className="emotion-25"
+              >
+                <span
+                  className="emotion-26"
+                >
+                  <span
+                    className="emotion-27"
+                  >
+                    <svg
+                      viewBox="0 0 30 30"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M13.8 16.2l.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45z"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  Show
+                </span>
+              </span>
+            </summary>
+            <div>
+              <div
+                className="emotion-28"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+                  }
+                }
+              />
+            </div>
+            <footer
+              className="emotion-29"
+            >
+              <div
+                hidden={false}
+              >
+                <div
+                  className="emotion-30"
+                >
+                  <div>
+                    Was this helpful?
+                  </div>
+                  <button
+                    className="emotion-31"
+                    data-testid="like"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="emotion-32"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    className="emotion-33"
+                    data-testid="dislike"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      className="emotion-32"
+                      viewBox="0 0 40 40"
+                    >
+                      <path
+                        d="M33.78 22.437l-4.228 13.98L27.93 37.5 5.062 34.14V15.503l7.8-1.517L24.354 2.5h1.624L28.9 5.426l-4.548 8.67h.107l10.477 1.31"
+                        fill="#FFF"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="emotion-35"
+                data-testid="feedback"
+                hidden={true}
+              >
+                Thank you for your feedback.
+              </div>
+            </footer>
+          </details>
+        </div>
+        <p
+          className="emotion-16"
+        />
+        <p
+          className="emotion-16"
+        />
+        <aside
+          className="emotion-38"
+        >
+          <blockquote
+            className="emotion-39"
+          >
+            <p
+              className="emotion-40"
+            >
+              <svg
+                viewBox="0 0 30 30"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              Why should the crown be allowed to carry on with a feudal system just because they want to?
+            </p>
+            <cite
+              className="emotion-41"
+            >
+              Jane Giddins
+            </cite>
+          </blockquote>
+        </aside>
+        <p
+          className="emotion-16"
+        />
+        <p
+          className="emotion-16"
+        />
+      </section>
+    </div>
+  </article>
+</main>
+`;
+
 exports[`Storyshots Editions/Article Default 1`] = `
 .emotion-0 {
   height: 100%;

--- a/src/components/body.tsx
+++ b/src/components/body.tsx
@@ -87,7 +87,8 @@ const Body: FC<Props> = ({ item, shouldHideAds }) => {
 		item.design === Design.Interactive ||
 		item.design === Design.Quiz ||
 		item.design === Design.MatchReport ||
-		item.design === Design.Obituary
+		item.design === Design.Obituary ||
+		item.design === Design.Correction
 	) {
 		return <Standard item={item}>{render(item, body)}</Standard>;
 	}

--- a/src/components/editions/article/article.stories.tsx
+++ b/src/components/editions/article/article.stories.tsx
@@ -8,6 +8,7 @@ import {
 	article,
 	cartoon,
 	comment,
+	correction,
 	editorial,
 	feature,
 	interview,
@@ -154,6 +155,22 @@ const Letter = (): ReactElement => (
 		}}
 	/>
 );
+
+const Correction = (): ReactElement => (
+	<Article
+		item={{
+			...correction,
+			tags: [
+				getTag(
+					'theguardian/series/correctionsandclarifications',
+					'Corrections and Clarifications ',
+				),
+			],
+			theme: selectPillar(Pillar.News),
+		}}
+	/>
+);
+
 const MatchReport = (): ReactElement => (
 	<Article
 		item={{
@@ -218,6 +235,7 @@ export {
 	Editorial,
 	Gallery,
 	Letter,
+	Correction,
 	MatchReport,
 	Cartoon,
 };

--- a/src/components/editions/article/index.tsx
+++ b/src/components/editions/article/index.tsx
@@ -166,7 +166,8 @@ const Article: FC<Props> = ({ item }) => {
 		item.design === Design.Quiz ||
 		item.design === Design.Recipe ||
 		item.design === Design.MatchReport ||
-		item.design === Design.Obituary
+		item.design === Design.Obituary ||
+		item.design === Design.Correction
 	) {
 		return (
 			<main css={mainStyles}>

--- a/src/components/editions/header/index.tsx
+++ b/src/components/editions/header/index.tsx
@@ -252,6 +252,15 @@ const LetterHeader: FC<HeaderProps> = ({ item }) => (
 	</header>
 );
 
+const CorrectionsHeader: FC<HeaderProps> = ({ item }) => (
+	<header css={headerStyles}>
+		<HeaderMedia item={item} />
+		<Series item={item} />
+		<Headline item={item} />
+		<Standfirst item={item} />
+	</header>
+);
+
 const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 	// Display.Immersive needs to come before Design.Interview
 	if (item.display === Display.Immersive) {
@@ -268,6 +277,8 @@ const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
 		return <ShowcaseHeader item={item} />;
 	} else if (item.design === Design.Analysis) {
 		return <AnalysisHeader item={item} />;
+	} else if (item.design === Design.Correction) {
+		return <CorrectionsHeader item={item} />;
 	} else if (item.design === Design.Media) {
 		return isPicture(item.tags) ? (
 			<PictureHeader item={item} />

--- a/src/fixtures/item.ts
+++ b/src/fixtures/item.ts
@@ -341,6 +341,10 @@ const matchReport: Item = {
 	body: galleryBody,
 };
 
+const correction: Item = {
+	design: Design.Correction,
+	...fields,
+};
 // ----- Exports ----- //
 
 export {
@@ -356,4 +360,5 @@ export {
 	letter,
 	matchReport,
 	cartoon,
+	correction,
 };

--- a/src/item.ts
+++ b/src/item.ts
@@ -112,6 +112,11 @@ interface Obituary extends Fields {
 	body: Body;
 }
 
+interface Correction extends Fields {
+	design: Design.Correction;
+	body: Body;
+}
+
 // Catch-all for other Designs for now. As coverage of Designs increases,
 // this will likely be split out into each Design type.
 interface Standard extends Fields {
@@ -135,7 +140,8 @@ type Item =
 	| MatchReport
 	| Letter
 	| Obituary
-	| Editorial;
+	| Editorial
+	| Correction;
 
 // ----- Convenience Types ----- //
 
@@ -298,6 +304,9 @@ const isQuiz = hasTag('tone/quizzes');
 const isLabs = hasTag('tone/advertisement-features');
 
 const isMatchReport = hasTag('tone/matchreports');
+
+const isCorrection = hasTag('theguardian/series/correctionsandclarifications');
+
 const isPicture = hasTag('type/picture');
 
 const fromCapiLiveBlog = (context: Context) => (
@@ -339,6 +348,11 @@ const fromCapi = (context: Context) => (request: RenderingRequest): Item => {
 	} else if (isAnalysis(tags)) {
 		return {
 			design: Design.Analysis,
+			...itemFieldsWithBody(context, request),
+		};
+	} else if (isCorrection(tags)) {
+		return {
+			design: Design.Correction,
 			...itemFieldsWithBody(context, request),
 		};
 	} else if (isLetter(tags)) {


### PR DESCRIPTION
## Why are you doing this?

Following a [discussion](https://github.com/guardian/types/pull/164) about how to parse the Corrections and Clarifications article, it was added as a new design type. 

This PR adds the correction type and renders it on Editions and Live and replaces [1417](https://github.com/guardian/apps-rendering/pull/1417)
## Changes

- Bump @guardian/types to 8.0.0
- Add Design.Correction
- Add Design.Correction header to Editions without lines or byline components. 
- Render Design.Correction as standard article on Live Apps.
- Add Design.Correction to Storybook 

## Screenshots

| Before | After |
### ER
| <img src="https://user-images.githubusercontent.com/20416599/127520242-1e07002b-90c1-4486-8e7c-942cb79d41ae.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/127520229-b096763c-dfa0-48c3-ab5f-c3693ffca9b5.png" width="300px" /> |
