### PR TITLE
Fix AR Client Script

### DIFF
--- a/src/server/editionsPage.tsx
+++ b/src/server/editionsPage.tsx
@@ -49,6 +49,9 @@ const docParser = JSDOM.fragment.bind(null);
 
 // ----- Functions ----- //
 
+const stage = Stage === 'CODE' ? 'code' : 'prod';
+const s3Path = `https://editions-published-${stage}.s3.eu-west-1.amazonaws.com`;
+
 const getEditionsEnv = (isPreview: boolean, path?: string): EditionsEnv => {
 	if (isPreview) {
 		return EditionsEnv.Preview;
@@ -66,7 +69,7 @@ const getFonts = (env: EditionsEnv): string => {
 		case EditionsEnv.Prod:
 			return prodFonts;
 		case EditionsEnv.Preview:
-			return previewFonts;
+			return previewFonts(s3Path);
 		default:
 			return devFonts;
 	}
@@ -180,9 +183,6 @@ function render(
 
 	const devScript = map(getAssetLocation)(some('editions.js'));
 	const prodScript = some('assets/js/editions.js');
-
-	const stage = Stage === 'CODE' ? 'code' : 'prod';
-	const s3Path = `https://editions-published-${stage}.s3.eu-west-1.amazonaws.com`;
 	const previewScript = some(`${s3Path}/assets/js/editions.js`);
 
 	const getClientScript = (env: EditionsEnv): Option<string> => {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -11,7 +11,6 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 import type { Format, Option } from '@guardian/types';
 import { Design, map, none, some, withDefault } from '@guardian/types';
 import { pipe } from 'lib';
-import { Stage } from 'server/appIdentity';
 
 export const sidePadding = css`
 	padding-left: ${remSpace[3]};
@@ -468,10 +467,7 @@ export const editionsPageFonts = `
 	)}
 `;
 
-const stage = Stage === 'CODE' ? 'code' : 'prod';
-const s3Path = `https://editions-published-${stage}.s3.eu-west-1.amazonaws.com`;
-
-export const editionsPreviewFonts = `
+export const editionsPreviewFonts = (s3Path: string): string => `
     ${fontFace(
 		'Guardian Text Egyptian Web',
 		some(400),


### PR DESCRIPTION
## Why are you doing this?

Fixed a runtime error in the AR client script.

## Changes

- Stopped importing `appIdentity` into `styles` module
- Editions preview fonts now take s3 path as an argument
