### PR TITLE
Correctly `await` Promises In Express

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -295,8 +295,8 @@ async function serveArticleGet(
 		const isEditions = req.query.editions === '';
 		const capiContent = await askCapiFor(articleId);
 
-		either(
-			(errorStatus: number) => {
+		await either(
+			async (errorStatus: number) => {
 				res.sendStatus(errorStatus);
 			},
 			async ([content, relatedContent]: [Content, RelatedContent]) => {
@@ -317,9 +317,9 @@ async function serveArticleGet(
 				const themeOverride = themeFromUnknown(req.query.theme);
 
 				if (richLinkDetails) {
-					void serveRichLinkDetails(mockedRenderingRequest, res);
+					await serveRichLinkDetails(mockedRenderingRequest, res);
 				} else {
-					void serveArticleSwitch(
+					await serveArticleSwitch(
 						mockedRenderingRequest,
 						res,
 						isEditions,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -250,9 +250,9 @@ async function serveArticlePost(
 		const themeOverride = themeFromUnknown(req.query.theme);
 
 		if (richLinkDetails) {
-			void serveRichLinkDetails(renderingRequest, res);
+			await serveRichLinkDetails(renderingRequest, res);
 		} else {
-			void serveArticleSwitch(
+			await serveArticleSwitch(
 				renderingRequest,
 				res,
 				isEditions,
@@ -279,7 +279,7 @@ async function serveEditionsArticlePost(
 		};
 		const themeOverride = themeFromUnknown(req.query.theme);
 
-		void serveEditionsArticle(renderingRequest, res, themeOverride);
+		await serveEditionsArticle(renderingRequest, res, themeOverride);
 	} catch (e) {
 		logger.error('This error occurred', e);
 		next(e);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -296,8 +296,9 @@ async function serveArticleGet(
 		const capiContent = await askCapiFor(articleId);
 
 		await either(
-			async (errorStatus: number) => {
+			(errorStatus: number) => {
 				res.sendStatus(errorStatus);
+				return Promise.resolve();
 			},
 			async ([content, relatedContent]: [Content, RelatedContent]) => {
 				const footballContent = await getFootballContent(content);


### PR DESCRIPTION
## Why are you doing this?

### TL;DR

We weren't handling `Promise` rejection correctly, which caused requests to hang on error.

### In Full

We had a recent bug in Editions, which we traced back to a hanging request in the group of requests the Editions backend makes to AR. I believe this issue would also have an impact on the live apps, although perhaps with less severe consequences.

As seen in the temporary fix in #1436, it was triggered by a crash in the rendering code. However, that should have resulted in a rapid 500 response rather than a hanging request.

I believe what happened was that the crash caused a `Promise` to be rejected, and we weren't handling that rejection. As a result, the code path that catches errors and sends an Express response was not hit, and so the request stayed open indefinitely.

I suspect we didn't realise this because our `server` file contains some `async`/`await` code mixed in with some `Promise` code, and this caused some confusion about how exactly errors were being caught. When using `async`/`await`, any `Promise`s have to be explicitly `await`ed for them to trigger an exception that can be understood by the `try...catch` block. Allowing them to run normally doesn't work, and results in `Promise` rejections going unhandled. At the moment, in Express 4, you have to explicitly handle all `Promise` rejections, either by catching and writing a response or by passing errors to the `next` function. It looks like [in Express 5](https://expressjs.com/en/guide/error-handling.html) returning rejected `Promise`s from the handler function will be handled automatically 🤞.

**Note:** I think a few other improvements could be made to mitigate future problems like this:
1. We should tidy up our `server` code, it's not easy to understand.
2. The Editions backend could handle request timeouts more gracefully, so they don't take down the entire build.
3. We should set a timeout on the AR Express server, so it doesn't tie up failed connections indefinitely.

## Changes

- Explicitly `await` `Promise`s in our `server` file so that responses are sent correctly on error
