### PR TITLE
Docs For `oneOf`

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -718,7 +718,7 @@ const andThen = <A, B>(f: (a: A) => Parser<B>) => (pa: Parser<A>): Parser<B> =>
  * const resultB = parse(parser)(jsonB); // Ok<number>, 42
  * 
  * const jsonC: unknown = JSON.parse('null');
- * const resultC = parse(parser)(jsonC); // Err<string>, "null is not a valid number"
+ * const resultC = parse(parser)(jsonC); // Err<string>, "null is not a valid number. null is not a valid string"
  * 
  * const jsonD: unknown = JSON.parse('"foo"');
  * const resultD = parse(parser)(jsonD); // Err<string>, "'foo' is not a valid number. NaN is not a valid number"

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -693,6 +693,36 @@ const map8 = <A, B, C, D, E, F, G, H, I>(
 const andThen = <A, B>(f: (a: A) => Parser<B>) => (pa: Parser<A>): Parser<B> =>
 	parser((a) => resultAndThen<string, A, B>((x) => f(x).run(a))(pa.run(a)));
 
+/**
+ * Handles situations where there are multiple valid ways that the input data
+ * can be structured. This will accept a list of parsers to try one after
+ * another until a) one of them succeeds, or b) the end of the list is reached
+ * with none successful. If none are successful then all the error messages
+ * will be concatenated into a final error.
+ * 
+ * @param parsers A list of parsers to try one after another
+ * @returns {Parser<A>} A new parser for type `A`
+ * @example
+ * const stringAsNumberParser: Parser<number> = pipe(
+ *   stringParser,
+ *   map(parseFloat),
+ *   andThen(numberParser),
+ * );
+ * 
+ * const parser = oneOf([numberParser, stringAsNumberParser]); // Parser<number>
+ * 
+ * const jsonA: unknown = JSON.parse('42');
+ * const resultA = parse(parser)(jsonA); // Ok<number>, 42
+ * 
+ * const jsonB: unknown = JSON.parse('"42"');
+ * const resultB = parse(parser)(jsonB); // Ok<number>, 42
+ * 
+ * const jsonC: unknown = JSON.parse('null');
+ * const resultC = parse(parser)(jsonC); // Err<string>, "null is not a valid number"
+ * 
+ * const jsonD: unknown = JSON.parse('"foo"');
+ * const resultD = parse(parser)(jsonD); // Err<string>, "'foo' is not a valid number. NaN is not a valid number"
+ */
 const oneOf = <A>(parsers: Array<Parser<A>>): Parser<A> =>
 	parser((a) => {
 		const f = (

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -723,7 +723,7 @@ const andThen = <A, B>(f: (a: A) => Parser<B>) => (pa: Parser<A>): Parser<B> =>
  *
  * const jsonD: unknown = JSON.parse('"foo"');
  * // Err<string>, "'foo' is not a valid number. NaN is not a valid number"
- * const resultD = parse(parser)(jsonD); 
+ * const resultD = parse(parser)(jsonD);
  */
 const oneOf = <A>(parsers: Array<Parser<A>>): Parser<A> =>
 	parser((a) => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -699,7 +699,7 @@ const andThen = <A, B>(f: (a: A) => Parser<B>) => (pa: Parser<A>): Parser<B> =>
  * another until a) one of them succeeds, or b) the end of the list is reached
  * with none successful. If none are successful then all the error messages
  * will be concatenated into a final error.
- * 
+ *
  * @param parsers A list of parsers to try one after another
  * @returns {Parser<A>} A new parser for type `A`
  * @example
@@ -708,20 +708,22 @@ const andThen = <A, B>(f: (a: A) => Parser<B>) => (pa: Parser<A>): Parser<B> =>
  *   map(parseFloat),
  *   andThen(numberParser),
  * );
- * 
+ *
  * const parser = oneOf([numberParser, stringAsNumberParser]); // Parser<number>
- * 
+ *
  * const jsonA: unknown = JSON.parse('42');
  * const resultA = parse(parser)(jsonA); // Ok<number>, 42
- * 
+ *
  * const jsonB: unknown = JSON.parse('"42"');
  * const resultB = parse(parser)(jsonB); // Ok<number>, 42
- * 
+ *
  * const jsonC: unknown = JSON.parse('null');
- * const resultC = parse(parser)(jsonC); // Err<string>, "null is not a valid number. null is not a valid string"
- * 
+ * // Err<string>, "null is not a valid number. null is not a valid string"
+ * const resultC = parse(parser)(jsonC);
+ *
  * const jsonD: unknown = JSON.parse('"foo"');
- * const resultD = parse(parser)(jsonD); // Err<string>, "'foo' is not a valid number. NaN is not a valid number"
+ * // Err<string>, "'foo' is not a valid number. NaN is not a valid number"
+ * const resultD = parse(parser)(jsonD); 
  */
 const oneOf = <A>(parsers: Array<Parser<A>>): Parser<A> =>
 	parser((a) => {


### PR DESCRIPTION
## Why are you doing this?

There were some docs missing for the `oneOf` function introduced in #1384. This adds those docs.

## Changes

- Added docs for the oneOf parser function
