### PR TITLE
Support For`<sub>` And `<sup>` Tags

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -187,6 +187,10 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 			return h('li', { key }, children);
 		case 'MARK':
 			return styledH('mark', { key }, children);
+		case 'SUB':
+			return h('sub', { key }, children);
+		case 'SUP':
+			return h('sup', { key }, children);
 		default:
 			return null;
 	}
@@ -242,6 +246,10 @@ const textElement = (format: Format, supportsDarkMode = true) => (
 			return h(ListItem, { format, children });
 		case 'MARK':
 			return styledH('mark', { key }, children);
+		case 'SUB':
+			return h('sub', { key }, children);
+		case 'SUP':
+			return h('sup', { key }, children);
 		default:
 			return null;
 	}


### PR DESCRIPTION
## Why are you doing this?

Added support for subscript and superscript tags in body text. This will fix them on the Apps and Editions.

## Changes

- Added checks for `SUB` and `SUP` in text renderer functions

## Screenshots

Taken from [this piece](https://www.theguardian.com/science/across-the-universe/2013/sep/04/equation-alien-life-universe).

| Before | After |
| --- | --- |
| ![sub-sup-before](https://user-images.githubusercontent.com/53781962/129036353-97c97d6c-960a-4a68-8c1f-dee9d7b1350f.jpg) | ![sub-sup-after](https://user-images.githubusercontent.com/53781962/129036401-75ed1427-5e18-44f6-9afc-08c36328ef83.jpg) |
