### PR TITLE
Add ingress security group rule for loadbalancer

### DIFF
--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -65,6 +65,12 @@ Parameters:
   DomainName:
     Type: String
     Description: The DomainName of the ALB, should contain the trailing dot stuff.zone.example.com.
+  EditionsPreviewLambdaSecurityGroupId:
+    Type: String
+    Description: A security group id for editions preview lambda to access AR
+  EditionsPublishedLambdaSecurityGroupId:
+    Type: String
+    Description: A security group id for editions published lambda to access AR    
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -112,10 +118,15 @@ Resources:
           IpProtocol: tcp
           ToPort: 3040
       SecurityGroupIngress:
-        - CidrIp: 0.0.0.0/0
-          FromPort: '443'
+        - FromPort: '443'
           IpProtocol: tcp
           ToPort: '443'
+          SourceSecurityGroupId: !Ref EditionsPreviewLambdaSecurityGroupId
+      SecurityGroupIngress:
+        - FromPort: '443'
+          IpProtocol: tcp
+          ToPort: '443'
+          SourceSecurityGroupId: !Ref EditionsPublishedLambdaSecurityGroupId      
       VpcId: !ImportValue MobileAppsApiVPC-VpcId
 
   Listener:

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -65,12 +65,12 @@ Parameters:
   DomainName:
     Type: String
     Description: The DomainName of the ALB, should contain the trailing dot stuff.zone.example.com.
-  EditionsPreviewLambdaSecurityGroupId:
+  EditionsBackendPreviewLambdaSecurityGroupId:
     Type: String
-    Description: A security group id for editions preview lambda to access AR
-  EditionsPublishedLambdaSecurityGroupId:
+    Description: A security group id for editions backend preview lambda to access AR
+  EditionsBackendPublishedLambdaSecurityGroupId:
     Type: String
-    Description: A security group id for editions published lambda to access AR    
+    Description: A security group id for editions backend published lambda to access AR    
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -121,12 +121,12 @@ Resources:
         - FromPort: '443'
           IpProtocol: tcp
           ToPort: '443'
-          SourceSecurityGroupId: !Ref EditionsPreviewLambdaSecurityGroupId
+          SourceSecurityGroupId: !Ref EditionsBackendPreviewLambdaSecurityGroupId
       SecurityGroupIngress:
         - FromPort: '443'
           IpProtocol: tcp
           ToPort: '443'
-          SourceSecurityGroupId: !Ref EditionsPublishedLambdaSecurityGroupId      
+          SourceSecurityGroupId: !Ref EditionsBackendPublishedLambdaSecurityGroupId      
       VpcId: !ImportValue MobileAppsApiVPC-VpcId
 
   Listener:

--- a/config/cloudformation.yaml
+++ b/config/cloudformation.yaml
@@ -111,6 +111,11 @@ Resources:
           FromPort: 3040
           IpProtocol: tcp
           ToPort: 3040
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          FromPort: '443'
+          IpProtocol: tcp
+          ToPort: '443'
       VpcId: !ImportValue MobileAppsApiVPC-VpcId
 
   Listener:


### PR DESCRIPTION
## Why are you doing this?
This PRs updates AR loadbalancer security group to allow inbound traffic from the lambda within the same VPC.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- update cloudformation loadbalancer security rule
