### PR TITLE
Add CI bash script for TeamCity Build

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -4,7 +4,7 @@ source ~/.nvm/nvm.sh
 nvm install
 nvm use
 
-npm config set unsafe-perm true && npm ci
+npm ci
 npm run test
 npm run build:client:prod
 npm run build:server:prod

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source ~/.nvm/nvm.sh
+nvm install
+nvm use
+
+npm config set unsafe-perm true && npm ci
+npm run test
+npm run build:client:prod
+npm run build:server:prod
+npm run copy-manifest
+npm run copy-fonts
+npm run upload


### PR DESCRIPTION
## Why are you doing this?
This PR creates a Bash script in under scripts directory that would be used by teamcity step to built the app.

Currently teamcity has been setup so that it can work both when the script exists and when the script doesn't exist. So there will be no disruption for the existing PRs builds.

It has been tested in both scenarios.
When the script doesn't exists teamcity ignores the new step and run the original step

**First step:**
![image](https://user-images.githubusercontent.com/15894063/129172005-c40cfc62-1648-4928-82f8-ab089547e39a.png)

**Second step:**
![image](https://user-images.githubusercontent.com/15894063/129172298-bfb8ff38-951d-49ee-84cf-f1a037c6e31b.png)


When the script exists teamcity ignores the original step and runs the new step using the bash script

**first step:**
![image](https://user-images.githubusercontent.com/15894063/129172174-8a659b59-068c-4244-865c-d60e93f49a74.png)

**second step:**
![image](https://user-images.githubusercontent.com/15894063/129172236-bc26e55d-6020-43b7-8bb3-2bfbf1916402.png)

