### PR TITLE
Remove Paragraph From `Bullet` Component

### DIFF
--- a/src/components/bullet.tsx
+++ b/src/components/bullet.tsx
@@ -2,8 +2,6 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { remSpace } from '@guardian/src-foundations';
-import { body } from '@guardian/src-foundations/typography';
 import type { Format } from '@guardian/types';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
@@ -16,14 +14,7 @@ interface Props {
 	text: string;
 }
 
-const styles = css`
-	${body.medium({ lineHeight: 'loose' })}
-	display: inline;
-	overflow-wrap: break-word;
-	margin: 0 0 ${remSpace[3]};
-`;
-
-const bulletStyles = (format: Format): SerializedStyles => {
+const styles = (format: Format): SerializedStyles => {
 	const { kicker, inverted } = getThemeStyles(format.theme);
 
 	return css`
@@ -46,10 +37,10 @@ const bulletStyles = (format: Format): SerializedStyles => {
 };
 
 const Bullet: FC<Props> = ({ format, text }) => (
-	<p css={styles}>
-		<span css={bulletStyles(format)}>•</span>
+	<>
+		<span css={styles(format)}>•</span>
 		{text.replace(/•/g, '')}
-	</p>
+	</>
 );
 
 // ----- Exports ----- //


### PR DESCRIPTION
## Why are you doing this?

The `Bullet` component assumed too much about its context. It included a `p` tag, which caused problems when the component was nested inside _another_ paragraph. Paragraphs are [not allowed](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p) inside other paragraphs, so the browser was not able to render this combination correctly. See screenshots below for the result.

## Changes

- Removed paragraph from `Bullet` component

## Screenshots

| Article | Before | After |
| --- | --- | --- |
| [Article](https://www.theguardian.com/news/2021/jul/28/corrections-and-clarifications) (Editions-Rendering) | ![bullet-before](https://user-images.githubusercontent.com/53781962/129185182-21ba9cf8-82a6-425d-a28b-ad7dd19d2cf2.jpg) | ![bullet-after](https://user-images.githubusercontent.com/53781962/129185191-585e1ba4-450a-46e9-a98b-5bc8784ff92d.jpg) |
| [Article](https://www.theguardian.com/us-news/2020/jan/21/why-havent-you-shut-down-the-border-inside-trumps-white-house) (Apps-Rendering) | ![bullet-alt-before](https://user-images.githubusercontent.com/53781962/129185892-bb9f65c1-68e0-444b-b2a9-8e55e397dd5f.jpg) | ![bullet-alt-after](https://user-images.githubusercontent.com/53781962/129185883-ca0c7a12-1f23-4917-9af5-e78ea13599dc.jpg) |

**Note:** The second example is more subtle, but there _is_ a difference in font size if you look closely.
