### PR TITLE
LIVE-2906: hide byline

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -755,6 +755,11 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
+
+  .emotion-21 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
+  }
 }
 
 @media (min-width: 740px) {
@@ -1982,6 +1987,11 @@ exports[`Storyshots Editions/Article Cartoon 1`] = `
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
+
+  .emotion-22 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
+  }
 }
 
 @media (min-width: 740px) {
@@ -2664,6 +2674,11 @@ exports[`Storyshots Editions/Article Comment 1`] = `
     margin: 0;
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
+  }
+
+  .emotion-23 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
   }
 }
 
@@ -3780,6 +3795,11 @@ exports[`Storyshots Editions/Article Correction 1`] = `
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
+
+  .emotion-15 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
+  }
 }
 
 @media (min-width: 740px) {
@@ -4893,6 +4913,11 @@ exports[`Storyshots Editions/Article Default 1`] = `
     margin: 0;
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
+  }
+
+  .emotion-20 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
   }
 }
 
@@ -6067,6 +6092,11 @@ exports[`Storyshots Editions/Article Editorial 1`] = `
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
+
+  .emotion-21 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
+  }
 }
 
 @media (min-width: 740px) {
@@ -7227,6 +7257,11 @@ exports[`Storyshots Editions/Article Feature 1`] = `
     margin: 0;
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
+  }
+
+  .emotion-20 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
   }
 }
 
@@ -8458,6 +8493,11 @@ width:@media (min-width: 320px) {
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
+
+  .emotion-22 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
+  }
 }
 
 @media (min-width: 740px) {
@@ -8719,7 +8759,7 @@ width:@media (min-width: 320px) {
           <div
             className="editions-gallery-caption emotion-25"
           >
-            <h2
+            <h3
               className="emotion-26"
             >
               <svg
@@ -8732,7 +8772,7 @@ width:@media (min-width: 320px) {
                 />
               </svg>
               Washington DC, US
-            </h2>
+            </h3>
             <p
               className="emotion-28"
             >
@@ -8763,7 +8803,7 @@ width:@media (min-width: 320px) {
           <div
             className="editions-gallery-caption emotion-25"
           >
-            <h2
+            <h3
               className="emotion-26"
             >
               <svg
@@ -8776,7 +8816,7 @@ width:@media (min-width: 320px) {
                 />
               </svg>
               Prayagraj, India
-            </h2>
+            </h3>
             <p
               className="emotion-28"
             >
@@ -8807,7 +8847,7 @@ width:@media (min-width: 320px) {
           <div
             className="editions-gallery-caption emotion-25"
           >
-            <h2
+            <h3
               className="emotion-26"
             >
               <svg
@@ -8820,7 +8860,7 @@ width:@media (min-width: 320px) {
                 />
               </svg>
               Hua Hin, Thailand
-            </h2>
+            </h3>
             <p
               className="emotion-28"
             >
@@ -8851,7 +8891,7 @@ width:@media (min-width: 320px) {
           <div
             className="editions-gallery-caption emotion-25"
           >
-            <h2
+            <h3
               className="emotion-26"
             >
               <svg
@@ -8864,7 +8904,7 @@ width:@media (min-width: 320px) {
                 />
               </svg>
               Mulhouse, France
-            </h2>
+            </h3>
             <p
               className="emotion-28"
             >
@@ -9383,6 +9423,11 @@ width:@media (min-width: 320px) {
     margin: 0;
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
+  }
+
+  .emotion-22 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
   }
 }
 
@@ -10525,6 +10570,11 @@ exports[`Storyshots Editions/Article Letter 1`] = `
     margin: 0;
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
+  }
+
+  .emotion-18 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
   }
 }
 
@@ -11926,6 +11976,11 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
+
+  .emotion-42 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
+  }
 }
 
 @media (min-width: 740px) {
@@ -12958,6 +13013,11 @@ exports[`Storyshots Editions/Article Review 1`] = `
     margin: 0;
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
+  }
+
+  .emotion-26 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
   }
 }
 
@@ -14201,6 +14261,11 @@ exports[`Storyshots Editions/Article Showcase 1`] = `
     margin: 0;
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
+  }
+
+  .emotion-20 h2 {
+    margin: 0;
+    padding: 1rem 0 0.25rem 0;
   }
 }
 

--- a/src/components/editions/article/index.tsx
+++ b/src/components/editions/article/index.tsx
@@ -5,8 +5,8 @@ import { css } from '@emotion/react';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { background, border, neutral } from '@guardian/src-foundations/palette';
-import type { Format } from '@guardian/types';
-import { Design, Display, partition } from '@guardian/types';
+import type { Format, Option } from '@guardian/types';
+import { Design, Display, OptionKind, partition } from '@guardian/types';
 import type { Item } from 'item';
 import { isPicture } from 'item';
 import type { FC } from 'react';
@@ -44,15 +44,22 @@ const articleStyles = css`
 	${articleMarginStyles}
 `;
 
-const headerStyles = css`
-	${articleWidthStyles}
-	border-bottom: 1px solid ${border.secondary};
+const hasChildNodes = (field: Option<DocumentFragment>): boolean =>
+	field.kind === OptionKind.Some && field.value.hasChildNodes();
+
+const headerStyles = (item: Item): SerializedStyles => {
+	const hasByline = hasChildNodes(item.bylineHtml);
+
+	return css`
+		${articleWidthStyles}
+		${hasByline && `border-bottom: 1px solid ${border.secondary};`}
 
 	${from.tablet} {
-		padding-right: ${remSpace[3]};
-		border-right: 1px solid ${border.secondary};
-	}
-`;
+			padding-right: ${remSpace[3]};
+			border-right: 1px solid ${border.secondary};
+		}
+	`;
+};
 
 const bodyStyles = css`
 	padding-top: ${remSpace[3]};
@@ -75,6 +82,11 @@ const bodyStyles = css`
 			margin: 0;
 			padding-top: ${remSpace[3]};
 			padding-bottom: ${remSpace[3]};
+		}
+
+		h2 {
+			margin: 0;
+			padding: ${remSpace[4]} 0 ${remSpace[1]} 0;
 		}
 	}
 
@@ -141,7 +153,7 @@ const itemStyles = (item: Item): SerializedStyles => {
 	}
 };
 
-const getSectionStyles = (item: Format): SerializedStyles[] => {
+const getSectionStyles = (item: Item): SerializedStyles[] => {
 	if (
 		item.design === Design.Interview ||
 		item.design === Design.Media ||
@@ -149,7 +161,7 @@ const getSectionStyles = (item: Format): SerializedStyles[] => {
 	) {
 		return [];
 	}
-	return [headerStyles, articleStyles];
+	return [headerStyles(item), articleStyles];
 };
 
 const Article: FC<Props> = ({ item }) => {

--- a/src/components/editions/galleryImage/index.tsx
+++ b/src/components/editions/galleryImage/index.tsx
@@ -108,10 +108,10 @@ const CaptionLocation: FC<{ location: string; triangleColor: string }> = ({
 		}
 	`;
 	return (
-		<h2 css={styles}>
+		<h3 css={styles}>
 			<Triangle color={triangleColor} />
 			{location}
-		</h2>
+		</h3>
 	);
 };
 

--- a/src/item.ts
+++ b/src/item.ts
@@ -11,11 +11,14 @@ import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
 import type { Format, Option } from '@guardian/types';
 import {
+	andThen,
 	Design,
 	Display,
 	fromNullable,
 	map,
+	none,
 	Pillar,
+	some,
 	Special,
 } from '@guardian/types';
 import type { Body } from 'bodyElement';
@@ -192,6 +195,9 @@ function getDisplay(content: Content): Display {
 	return Display.Standard;
 }
 
+const nonEmptyString = (s: string): Option<string> =>
+	s !== '' ? some(s) : none;
+
 const itemFields = (
 	context: Context,
 	request: RenderingRequest,
@@ -210,6 +216,7 @@ const itemFields = (
 		bylineHtml: pipe(
 			content.fields?.bylineHtml,
 			fromNullable,
+			andThen(nonEmptyString),
 			map(context.docParser),
 		),
 		publishDate: maybeCapiDate(content.webPublicationDate),


### PR DESCRIPTION
## Why are you doing this?

Now we're hiding the shareIcon when article share is not available we were getting UI bugs as if there was no byline copy. In the old Editions app we simply hid the byline component, this PR implements both the non-rendering of byline components and the hiding of the header border bottom if there is no byline.

It also fixes a minor bug where use of `h2` text was breaking the border-right on the article body.

## Changes

- hide byline component if byline is not present 
- hide header border bottom if byline  is not present
- swap margin for padding on editions body `h2` tag (production use this in draft articles sometimes :( ).

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/129582475-3e84e083-c11c-4d29-990a-cb5c0de1ab94.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/129582550-067def34-436c-45b6-a7c5-3021ba09ed3c.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/77005274/129582662-39e23048-c46a-4184-a5f2-67de523f922b.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/129582684-1e7e37c6-1c0c-4061-a3ea-5d8618ca6fa5.png" width="300px"  /> |





