### PR TITLE
LIVE-2954: add kicker to gallery

### DIFF
--- a/src/components/editions/header/index.tsx
+++ b/src/components/editions/header/index.tsx
@@ -204,6 +204,7 @@ const GalleryHeader: FC<HeaderProps> = ({ item }) => (
 	<header css={galleryHeaderStyles}>
 		<HeaderMedia item={item} />
 		<div css={galleryInnerHeaderStyles}>
+			<Series item={item} />
 			<Headline item={item} />
 			<div css={galleryHeaderBorderStyles}>
 				<Standfirst item={item} />


### PR DESCRIPTION
## Why are you doing this?

Editions Galleries were missing a series kicker.

## Changes

- add kicker

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/130074801-2b586e31-5461-4bd1-aaff-ae2b6f4fd596.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/130074889-c7bc9911-ed75-43d4-9add-e9e61c64b83c.png" width="300px" /> |
