### PR TITLE
LIVE-2961: hide quote marks on editions

### DIFF
--- a/src/components/anchor.tsx
+++ b/src/components/anchor.tsx
@@ -17,12 +17,12 @@ interface Props {
 	children?: ReactNode;
 	format: Format;
 	className?: SerializedStyles;
-	supportsDarkMode?: boolean;
+	isEditions?: boolean;
 }
 
-const styles = (supportsDarkMode: boolean): SerializedStyles => css`
+const styles = (isEditions: boolean): SerializedStyles => css`
 	text-decoration: none;
-	${supportsDarkMode &&
+	${!isEditions &&
 	darkModeCss`
         color: ${neutral[86]};
         border-color: ${neutral[46]};
@@ -60,9 +60,9 @@ const Anchor: FC<Props> = ({
 	children,
 	href,
 	className,
-	supportsDarkMode = true,
+	isEditions = false,
 }: Props) => (
-	<a css={[styles(supportsDarkMode), colour(format), className]} href={href}>
+	<a css={[styles(isEditions), colour(format), className]} href={href}>
 		{children}
 	</a>
 );

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -196,13 +196,13 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 	}
 };
 
-const textElement = (format: Format, supportsDarkMode = true) => (
+const textElement = (format: Format, isEditions = false) => (
 	node: Node,
 	key: number,
 ): ReactNode => {
 	const text = node.textContent ?? '';
 	const children = Array.from(node.childNodes).map(
-		textElement(format, supportsDarkMode),
+		textElement(format, isEditions),
 	);
 	switch (node.nodeName) {
 		case 'P':
@@ -218,7 +218,7 @@ const textElement = (format: Format, supportsDarkMode = true) => (
 					href: withDefault('')(getHref(node)),
 					format,
 					key,
-					supportsDarkMode,
+					isEditions,
 				},
 				transform(text, format),
 			);
@@ -231,7 +231,7 @@ const textElement = (format: Format, supportsDarkMode = true) => (
 						children,
 				  );
 		case 'BLOCKQUOTE':
-			return supportsDarkMode
+			return !isEditions
 				? h(Blockquote, { key, format }, children)
 				: h('blockquote', { key }, children);
 		case 'STRONG':
@@ -302,9 +302,9 @@ const standfirstTextElement = (format: Format) => (
 const text = (
 	doc: DocumentFragment,
 	format: Format,
-	supportsDarkMode = true,
+	isEditions = false,
 ): ReactNode[] =>
-	Array.from(doc.childNodes).map(textElement(format, supportsDarkMode));
+	Array.from(doc.childNodes).map(textElement(format, isEditions));
 
 const editionsStandfirstFilter = (node: Node): boolean =>
 	!['UL', 'LI', 'A'].includes(node.nodeName);
@@ -430,11 +430,11 @@ const textRenderer = (
 	format: Format,
 	excludeStyles: boolean,
 	element: Text,
-	supportsDarkMode?: boolean,
+	isEditions?: boolean,
 ): ReactNode => {
 	return excludeStyles
 		? Array.from(element.doc.childNodes).map(plainTextElement)
-		: text(element.doc, format, supportsDarkMode);
+		: text(element.doc, format, isEditions);
 };
 
 const guideAtomRenderer = (
@@ -721,7 +721,7 @@ const renderEditions = (format: Format, excludeStyles = false) => (
 ): ReactNode => {
 	switch (element.kind) {
 		case ElementKind.Text:
-			return textRenderer(format, excludeStyles, element, false);
+			return textRenderer(format, excludeStyles, element, true);
 
 		case ElementKind.Image:
 			return format.design === Design.Media

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -231,7 +231,9 @@ const textElement = (format: Format, supportsDarkMode = true) => (
 						children,
 				  );
 		case 'BLOCKQUOTE':
-			return h(Blockquote, { key, format }, children);
+			return supportsDarkMode
+				? h(Blockquote, { key, format }, children)
+				: h('blockquote', { key }, children);
 		case 'STRONG':
 			return h('strong', { key }, children);
 		case 'B':

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -231,9 +231,9 @@ const textElement = (format: Format, isEditions = false) => (
 						children,
 				  );
 		case 'BLOCKQUOTE':
-			return !isEditions
-				? h(Blockquote, { key, format }, children)
-				: h('blockquote', { key }, children);
+			return isEditions
+				? h('blockquote', { key }, children)
+				: h(Blockquote, { key, format }, children);
 		case 'STRONG':
 			return h('strong', { key }, children);
 		case 'B':


### PR DESCRIPTION
## Why are you doing this?

Sometimes Editorial use block quotes for poetry.  We should double check we don't need these anywhere else in the body in Editions.

## Changes

- Don't render `Blockquote` component on Editions

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/130213544-74200caa-5ef5-48ce-b62e-f7d695df1ecf.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/130213586-71ca61f7-544f-4a6e-9ac8-7bc2e3174529.png" width="300px" /> |
