### PR TITLE
Migration Preparation - Storybook type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34769,6 +34769,7 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -34787,6 +34788,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -34819,6 +34821,7 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -34831,6 +34834,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -34886,6 +34890,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -34895,6 +34900,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -34906,6 +34912,7 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -34955,6 +34962,7 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/src/components/editions/starRating/starRating.stories.tsx
+++ b/src/components/editions/starRating/starRating.stories.tsx
@@ -7,7 +7,7 @@ import StarRating from '.';
 
 // ----- Setup ----- //
 
-const starRating: Record<number, number> = [0, 1, 2, 3, 4, 5];
+const starRating = { 0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5 };
 
 // ----- Stories ----- //
 

--- a/src/components/headline.stories.tsx
+++ b/src/components/headline.stories.tsx
@@ -9,7 +9,7 @@ import Headline from './headline';
 
 // ----- Setup ----- //
 
-const starRating: Record<number, number> = [0, 1, 2, 3, 4, 5];
+const starRating = { 0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5 };
 
 // ----- Stories ----- //
 

--- a/src/components/starRating.stories.tsx
+++ b/src/components/starRating.stories.tsx
@@ -7,7 +7,7 @@ import StarRating from './starRating';
 
 // ----- Setup ----- //
 
-const starRating: Record<number, number> = [0, 1, 2, 3, 4, 5];
+const starRating = { 0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5 };
 
 // ----- Stories ----- //
 


### PR DESCRIPTION
## Why are you doing this?

Type errors on storybook post-repo-migration will be thrown as errors during build time, so to ensure that the build completes, we should solve the type errors now

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- Update type for `radio` which is used for star rating stories

