### PR TITLE
Revert "LIVE-2976: fix styling"

### DIFF
--- a/src/__snapshots__/storyshots.test.ts.snap
+++ b/src/__snapshots__/storyshots.test.ts.snap
@@ -456,22 +456,11 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
   font-size: 1.5rem;
   line-height: 1.35;
   font-weight: 300;
-  background-image: repeating-linear-gradient(
-  		to bottom,
-  		transparent,
-  		transparent 46px,
-  		#DCDCDC
-  	);
-  line-height: 3rem;
-  -webkit-background-size: 1rem 3rem;
-  background-size: 1rem 3rem;
-  -webkit-background-position: top left;
-  background-position: top left;
-  -webkit-background-clip: content-box;
-  background-clip: content-box;
-  background-origin: content-box;
-  padding-bottom: 0.5rem;
-  padding-right: 0;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: from-font;
+  text-decoration-color: #BB3B80;
+  padding-bottom: 0;
 }
 
 @media (min-width: 375px) {
@@ -489,18 +478,6 @@ exports[`Storyshots Editions/Article Analysis 1`] = `
     font-size: 2.125rem;
     line-height: 1.35;
     font-weight: 300;
-  }
-}
-
-@media (min-width: 320px) {
-  .emotion-11 {
-    line-height: 3rem;
-  }
-}
-
-@media (min-width: 740px) {
-  .emotion-11 {
-    line-height: 3rem;
   }
 }
 
@@ -16933,22 +16910,11 @@ exports[`Storyshots Editions/Headline Analysis 1`] = `
   font-size: 1.5rem;
   line-height: 1.35;
   font-weight: 300;
-  background-image: repeating-linear-gradient(
-  		to bottom,
-  		transparent,
-  		transparent 46px,
-  		#DCDCDC
-  	);
-  line-height: 3rem;
-  -webkit-background-size: 1rem 3rem;
-  background-size: 1rem 3rem;
-  -webkit-background-position: top left;
-  background-position: top left;
-  -webkit-background-clip: content-box;
-  background-clip: content-box;
-  background-origin: content-box;
-  padding-bottom: 0.5rem;
-  padding-right: 0;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: from-font;
+  text-decoration-color: #C70000;
+  padding-bottom: 0;
 }
 
 @media (min-width: 375px) {
@@ -16966,18 +16932,6 @@ exports[`Storyshots Editions/Headline Analysis 1`] = `
     font-size: 2.125rem;
     line-height: 1.35;
     font-weight: 300;
-  }
-}
-
-@media (min-width: 320px) {
-  .emotion-1 {
-    line-height: 3rem;
-  }
-}
-
-@media (min-width: 740px) {
-  .emotion-1 {
-    line-height: 3rem;
   }
 }
 

--- a/src/components/editions/headline/index.tsx
+++ b/src/components/editions/headline/index.tsx
@@ -31,28 +31,11 @@ const tablet = tabletContentWidth + 12;
 
 // ----- Template Format Specific Styles ----- //
 
-const analysisStyles = css`
-	background-image: repeating-linear-gradient(
-		to bottom,
-		transparent,
-		transparent 46px,
-		${neutral[86]}
-	);
-	line-height: ${remSpace[12]};
-	background-size: ${remSpace[4]} ${remSpace[12]};
-	background-position: top left;
-	background-clip: content-box;
-	background-origin: content-box;
-	padding-bottom: ${remSpace[2]};
-	padding-right: 0;
-
-	${from.mobile} {
-		line-height: ${remSpace[12]};
-	}
-
-	${from.tablet} {
-		line-height: ${remSpace[12]};
-	}
+const analysisStyles = (kickerColor: string): SerializedStyles => css`
+	text-decoration: underline;
+	text-decoration-thickness: from-font;
+	text-decoration-color: ${kickerColor};
+	padding-bottom: 0;
 `;
 
 const commentStyles = (hasImage: boolean): SerializedStyles => css`
@@ -196,6 +179,7 @@ const getDecorativeStyles = (item: Item): JSX.Element | string => {
 
 const getHeadlineStyles = (
 	format: Format,
+	kickerColor: string,
 	hasImage: boolean,
 ): SerializedStyles => {
 	const sharedStyles = getSharedStyles(format);
@@ -239,7 +223,7 @@ const getHeadlineStyles = (
 			return css(
 				sharedStyles,
 				getFontStyles('regular', 'light'),
-				analysisStyles,
+				analysisStyles(kickerColor),
 			);
 		case Design.Media:
 			return css(sharedStyles, galleryStyles);
@@ -259,6 +243,7 @@ interface Props {
 
 const Headline: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
+	const { kicker: kickerColor } = getThemeStyles(format.theme);
 	const contributor = index(0)(item.contributors);
 
 	const hasImage =
@@ -272,7 +257,7 @@ const Headline: FC<Props> = ({ item }) => {
 					<Series item={item} />
 				</div>
 			)}
-			<h1 css={getHeadlineStyles(format, hasImage)}>
+			<h1 css={getHeadlineStyles(format, kickerColor, hasImage)}>
 				{getDecorativeStyles(item)}
 			</h1>
 		</div>


### PR DESCRIPTION
Reverts guardian/apps-rendering#1462 as the designs don't work with font scaling.