### PR TITLE
Put `(modern)` In The Footer

### DIFF
--- a/src/components/footerContent.tsx
+++ b/src/components/footerContent.tsx
@@ -44,7 +44,7 @@ const FooterContent: FC<Props> = ({ isCcpa }) => {
 	return (
 		<div id="js-footer">
 			&#169; {currentYear} Guardian News and Media Limited or its
-			affiliated companies. All rights reserved.
+			affiliated companies. All rights reserved. (modern)
 			<br />
 			<PrivacySettings isCcpa={isCcpa} />
 			<a


### PR DESCRIPTION
## Why are you doing this?

To make it easy to tell if a piece is AR or not in the production app. This idea is copied from DCR: https://github.com/guardian/dotcom-rendering/pull/1891.

## Changes

- Put the word `(modern)` in the footer

## Screenshots

To follow.

| Before | After |
| --- | --- |
| <img src="" width="300px" /> | <img src="" width="300px" /> |
