### PR TITLE
update readme to inform repo is archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## apps-rendering
 
+**This repository has been archived** and is not active any more since the content has been moved to the mono repo https://github.com/guardian/dotcom-rendering 
+
 ### Install
 
 1. Clone the repo


### PR DESCRIPTION
## Why are you doing this?
This PR updates readme to announce that this repo is not active any more and it's content has been moved to a mono repo https://github.com/guardian/dotcom-rendering